### PR TITLE
Add matrix inversion extension

### DIFF
--- a/include/blas/extensions.hh
+++ b/include/blas/extensions.hh
@@ -206,4 +206,40 @@ namespace batchlas {
         JobType jobz = JobType::NoEigenVectors,
         const MatrixView<T, MatrixFormat::Dense>& V = MatrixView<T, MatrixFormat::Dense>(),
         const LanczosParams<T>& params = LanczosParams<T>());
+    /**
+     * @brief Computes the explicit inverse of a dense matrix
+     *
+     * @param ctx Execution context/device queue
+     * @param A Input matrix to invert
+     * @param Ainv Output matrix storing the inverse
+     * @param workspace Pre-allocated workspace buffer
+     * @return Event Event to track operation completion
+     */
+    template <Backend B, typename T>
+    Event inv(Queue& ctx,
+        const MatrixView<T, MatrixFormat::Dense>& A,
+        const MatrixView<T, MatrixFormat::Dense>& Ainv,
+        Span<std::byte> workspace);
+
+    /**
+     * @brief Get required workspace size for matrix inversion
+     *
+     * @param ctx Execution context/device queue
+     * @param A Matrix to invert
+     * @return size_t Required workspace size in bytes
+     */
+    template <Backend B, typename T>
+    size_t inv_buffer_size(Queue& ctx,
+        const MatrixView<T, MatrixFormat::Dense>& A);
+
+    /**
+     * @brief Convenience overload allocating output matrix internally
+     *
+     * @param ctx Execution context/device queue
+     * @param A Matrix to invert
+     * @return Matrix<T, MatrixFormat::Dense> Inverted matrix
+     */
+    template <Backend B, typename T>
+    Matrix<T, MatrixFormat::Dense> inv(Queue& ctx,
+        const MatrixView<T, MatrixFormat::Dense>& A);
 }

--- a/src/extensions/CMakeLists.txt
+++ b/src/extensions/CMakeLists.txt
@@ -1,7 +1,9 @@
 set(EXTENSIONS_SOURCES
     ortho_matrixview.cc
     syevx_matrixview.cc
+    inv_matrixview.cc
     lanczos_matrixview.cc
 )
 
 target_sources(batchlas PRIVATE ${EXTENSIONS_SOURCES})
+

--- a/src/extensions/inv_matrixview.cc
+++ b/src/extensions/inv_matrixview.cc
@@ -1,0 +1,56 @@
+#include "../linalg-impl.hh"
+#include <util/sycl-vector.hh>
+#include <util/sycl-span.hh>
+#include "../queue.hh"
+#include <util/mempool.hh>
+
+namespace batchlas {
+
+    template <Backend B, typename T>
+    Event inv(Queue& ctx,
+              const MatrixView<T, MatrixFormat::Dense>& A,
+              const MatrixView<T, MatrixFormat::Dense>& Ainv,
+              Span<std::byte> workspace) {
+        BumpAllocator pool(workspace);
+        auto Acopy = MatrixView<T, MatrixFormat::Dense>::deep_copy(
+            A,
+            pool.allocate<T>(ctx, A.data().size()).data(),
+            pool.allocate<T*>(ctx, A.batch_size()).data());
+        auto pivots = pool.allocate<int64_t>(ctx, A.rows()*A.batch_size());
+        auto getri_ws = pool.allocate<std::byte>(ctx, getri_buffer_size<B>(ctx, Acopy));
+        getrf<B>(ctx, Acopy, pivots);
+        getri<B>(ctx, Acopy, Ainv, pivots, getri_ws);
+        return ctx.get_event();
+    }
+
+    template <Backend B, typename T>
+    size_t inv_buffer_size(Queue& ctx,
+                           const MatrixView<T, MatrixFormat::Dense>& A) {
+        return  BumpAllocator::allocation_size<T>(ctx, A.data().size()) +
+                BumpAllocator::allocation_size<T*>(ctx, A.batch_size()) +
+                BumpAllocator::allocation_size<int64_t>(ctx, A.rows()*A.batch_size()) +
+                BumpAllocator::allocation_size<std::byte>(ctx, getri_buffer_size<B>(ctx, A));
+    }
+
+    template <Backend B, typename T>
+    Matrix<T, MatrixFormat::Dense> inv(Queue& ctx,
+                                       const MatrixView<T, MatrixFormat::Dense>& A) {
+        Matrix<T, MatrixFormat::Dense> Aout(A.rows(), A.cols(), A.batch_size());
+        UnifiedVector<std::byte> workspace(inv_buffer_size<B>(ctx, A));
+        inv<B>(ctx, A, Aout.view(), workspace);
+        return Aout;
+    }
+
+#define INV_INSTANTIATE(fp) \
+    template Event inv<Backend::CUDA, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&, const MatrixView<fp, MatrixFormat::Dense>&, Span<std::byte>); \
+    template size_t inv_buffer_size<Backend::CUDA, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&); \
+    template Matrix<fp, MatrixFormat::Dense> inv<Backend::CUDA, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&);
+
+    INV_INSTANTIATE(float)
+    INV_INSTANTIATE(double)
+    INV_INSTANTIATE(std::complex<float>)
+    INV_INSTANTIATE(std::complex<double>)
+
+#undef INV_INSTANTIATE
+
+}

--- a/src/extra/cond.cc
+++ b/src/extra/cond.cc
@@ -1,5 +1,6 @@
 #include <blas/extra.hh>
 #include <blas/functions.hh>
+#include <blas/extensions.hh>
 #include <util/mempool.hh>
 #include "../queue.hh"
 namespace batchlas
@@ -11,20 +12,15 @@ namespace batchlas
                     const Span<T> conds,
                     const Span<std::byte> workspace){
                         auto pool = BumpAllocator(workspace);
-                        auto pivots = pool.allocate<int64_t>(ctx, A.batch_size()*A.rows());
-                        auto Acopy = MatrixView<T, MatrixFormat::Dense>::deep_copy(A, pool.allocate<T>(ctx, A.data().size()).data(),
-                                                                                    pool.allocate<T*>(ctx, A.batch_size()).data());
-
                         auto Ainv = MatrixView<T, MatrixFormat::Dense>(pool.allocate<T>(ctx, A.data().size()).data(),
-                                                                        A.rows(), A.cols(), A.ld(), A.stride(), A.batch_size(),
-                                                                        pool.allocate<T*>(ctx, A.batch_size()).data());
-                                                                        
-                        auto getri_workspace = pool.allocate<std::byte>(ctx, getri_buffer_size<B>(ctx, Acopy));
+                                                                     A.rows(), A.cols(), A.ld(), A.stride(), A.batch_size(),
+                                                                     pool.allocate<T*>(ctx, A.batch_size()).data());
+
+                        auto inv_workspace = pool.allocate<std::byte>(ctx, inv_buffer_size<B>(ctx, A));
                         auto A_norms = pool.allocate<T>(ctx, A.batch_size());
                         auto A_inv_norms = pool.allocate<T>(ctx, A.batch_size());
-                        
-                        getrf<B>(ctx, Acopy, pivots);
-                        getri<B>(ctx, Acopy, Ainv, pivots, workspace);
+
+                        inv<B>(ctx, A, Ainv, inv_workspace);
                         
                         norm<B>(ctx, Ainv, norm_type, A_inv_norms);
                         norm<B>(ctx, A, norm_type, A_norms);
@@ -50,11 +46,10 @@ namespace batchlas
                             const MatrixView<T, MF> &A,
                             const NormType norm_type)
     {
-        return  BumpAllocator::allocation_size<std::byte>(ctx, getri_buffer_size<B>(ctx, A)) +
+        return  BumpAllocator::allocation_size<std::byte>(ctx, inv_buffer_size<B>(ctx, A)) +
                 BumpAllocator::allocation_size<T>(ctx, A.batch_size()) * 2 + // For norms
-                BumpAllocator::allocation_size<T>(ctx, A.data().size()) * 2 + // For Ainv and Acopy
-                BumpAllocator::allocation_size<int64_t>(ctx, A.batch_size() * A.rows()) + // For pivots
-                BumpAllocator::allocation_size<T*>(ctx, A.batch_size()) * 2 + // For data_ptrs
+                BumpAllocator::allocation_size<T>(ctx, A.data().size()) + // For Ainv
+                BumpAllocator::allocation_size<T*>(ctx, A.batch_size()) + // For data_ptrs
                 BumpAllocator::allocation_size<T>(ctx, A.batch_size()); // For conds
     }
 
@@ -71,3 +66,4 @@ namespace batchlas
     }
 
 } // namespace batchlas
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ set(TEST_TARGETS
     matrix_view_tests
     trsm_operations_tests
     ortho_tests
+    inverse_tests
     norm_tests
 )
 
@@ -49,3 +50,4 @@ foreach(test ${TEST_TARGETS})
     # Add to CTest
     add_test(NAME ${test} COMMAND ${test})
 endforeach()
+

--- a/tests/inverse_tests.cc
+++ b/tests/inverse_tests.cc
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include <blas/linalg.hh>
+#include <util/sycl-device-queue.hh>
+#include <util/sycl-vector.hh>
+
+using namespace batchlas;
+
+TEST(InverseTest, InverseIdentityCheck) {
+    auto ctx = std::make_shared<Queue>(Device::default_device());
+
+    Matrix<float, MatrixFormat::Dense> A(2,2,1);
+    auto Adata = A.data();
+    Adata[0] = 4.0f; Adata[1] = 2.0f; // column 0
+    Adata[2] = 7.0f; Adata[3] = 6.0f; // column 1
+
+    Matrix<float, MatrixFormat::Dense> Ainverse(2,2,1);
+    UnifiedVector<std::byte> ws(inv_buffer_size<Backend::CUDA>(*ctx, A.view()));
+    inv<Backend::CUDA>(*ctx, A.view(), Ainverse.view(), ws);
+    ctx->wait();
+
+    Matrix<float, MatrixFormat::Dense> result(2,2,1);
+    gemm<Backend::CUDA>(*ctx, A.view(), Ainverse.view(), result.view(), 1.0f, 0.0f,
+                        Transpose::NoTrans, Transpose::NoTrans);
+    ctx->wait();
+
+    auto r = result.data();
+    EXPECT_NEAR(r[0], 1.0f, 1e-3f);
+    EXPECT_NEAR(r[1], 0.0f, 1e-3f);
+    EXPECT_NEAR(r[2], 0.0f, 1e-3f);
+    EXPECT_NEAR(r[3], 1.0f, 1e-3f);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- extend API with `inv` driver function to compute matrix inverse
- implement inversion driver using `getrf` and `getri`
- register the new extension source file
- provide unit test ensuring `A * inv(A)` yields identity
- use the new `inv` primitive in condition number routine
- fix missing newline at end of several files

## Testing
- `cmake .. -DBATCHLAS_BUILD_TESTS=ON` *(fails: backend_config.h.in does not exist; LAPACKE not found)*

------
https://chatgpt.com/codex/tasks/task_e_684196a6c0a08325946fbe3f53327ca0