### PR TITLE
Add comprehensive BLAS benchmarks

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -20,6 +20,11 @@ endif()
 # Define test executables
 set(BENCHMARK_TARGETS
     geqrf_benchmark
+    gemm_benchmark
+    gemv_benchmark
+    spmm_benchmark
+    trsm_benchmark
+    ormqr_benchmark
 )
 
 # Create test executables

--- a/benchmarks/bench_utils.hh
+++ b/benchmarks/bench_utils.hh
@@ -1,0 +1,36 @@
+#pragma once
+#include <benchmark/benchmark.h>
+
+namespace bench_utils {
+
+inline void SquareSizes(benchmark::internal::Benchmark* b) {
+    for (int s : {64, 128, 256, 512, 1024}) {
+        b->Args({s, s});
+    }
+}
+
+inline void SquareBatchSizes(benchmark::internal::Benchmark* b) {
+    for (int s : {64, 128, 256}) {
+        b->Args({s, s, 10});
+    }
+    for (int s : {64, 128, 256, 512, 1024}) {
+        b->Args({s, s, 100});
+    }
+}
+
+inline void CubeSizes(benchmark::internal::Benchmark* b) {
+    for (int s : {64, 128, 256, 512, 1024}) {
+        b->Args({s, s, s});
+    }
+}
+
+inline void CubeBatchSizes(benchmark::internal::Benchmark* b) {
+    for (int s : {64, 128, 256}) {
+        b->Args({s, s, s, 10});
+    }
+    for (int s : {64, 128, 256, 512, 1024}) {
+        b->Args({s, s, s, 100});
+    }
+}
+
+} // namespace bench_utils

--- a/benchmarks/gemm_benchmark.cc
+++ b/benchmarks/gemm_benchmark.cc
@@ -1,0 +1,73 @@
+#include <benchmark/benchmark.h>
+#include <blas/linalg.hh>
+#include "bench_utils.hh"
+
+using namespace batchlas;
+
+// Single GEMM benchmark
+template <typename T, Backend B>
+static void BM_GEMM_Single(benchmark::State& state) {
+    const int m = state.range(0);
+    const int n = state.range(1);
+    const int k = state.range(2);
+
+    auto A = Matrix<T>::Random(m, k, false);
+    auto Bm = Matrix<T>::Random(k, n, false);
+    auto C = Matrix<T>::Random(m, n, false);
+
+    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto C_copy = C;
+        state.ResumeTiming();
+        gemm<B>(queue, A.view(), Bm.view(), C_copy.view(), T(1), T(0),
+                Transpose::NoTrans, Transpose::NoTrans);
+        queue.wait();
+        benchmark::DoNotOptimize(C_copy.data());
+    }
+
+    state.counters["FLOPS"] = benchmark::Counter(2.0 * m * n * k,
+                                                   benchmark::Counter::kIsRate);
+}
+
+// Batched GEMM benchmark
+template <typename T, Backend B>
+static void BM_GEMM_Batched(benchmark::State& state) {
+    const int m = state.range(0);
+    const int n = state.range(1);
+    const int k = state.range(2);
+    const int batch = state.range(3);
+
+    auto A = Matrix<T>::Random(m, k, false, batch);
+    auto Bm = Matrix<T>::Random(k, n, false, batch);
+    auto C = Matrix<T>::Random(m, n, false, batch);
+
+    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto C_copy = C;
+        state.ResumeTiming();
+        gemm<B>(queue, A.view(), Bm.view(), C_copy.view(), T(1), T(0),
+                Transpose::NoTrans, Transpose::NoTrans);
+        queue.wait();
+        benchmark::DoNotOptimize(C_copy.data());
+    }
+
+    state.counters["FLOPS"] = benchmark::Counter(
+        static_cast<double>(batch) * 2.0 * m * n * k, benchmark::Counter::kIsRate);
+    state.counters["BatchSize"] = batch;
+}
+
+BENCHMARK_TEMPLATE(BM_GEMM_Single, float, Backend::NETLIB)->Apply(bench_utils::CubeSizes);
+BENCHMARK_TEMPLATE(BM_GEMM_Single, double, Backend::NETLIB)->Apply(bench_utils::CubeSizes);
+BENCHMARK_TEMPLATE(BM_GEMM_Single, float, Backend::CUDA)->Apply(bench_utils::CubeSizes);
+BENCHMARK_TEMPLATE(BM_GEMM_Single, double, Backend::CUDA)->Apply(bench_utils::CubeSizes);
+
+BENCHMARK_TEMPLATE(BM_GEMM_Batched, float, Backend::NETLIB)->Apply(bench_utils::CubeBatchSizes);
+BENCHMARK_TEMPLATE(BM_GEMM_Batched, double, Backend::NETLIB)->Apply(bench_utils::CubeBatchSizes);
+BENCHMARK_TEMPLATE(BM_GEMM_Batched, float, Backend::CUDA)->Apply(bench_utils::CubeBatchSizes);
+BENCHMARK_TEMPLATE(BM_GEMM_Batched, double, Backend::CUDA)->Apply(bench_utils::CubeBatchSizes);
+
+BENCHMARK_MAIN();

--- a/benchmarks/gemv_benchmark.cc
+++ b/benchmarks/gemv_benchmark.cc
@@ -1,0 +1,73 @@
+#include <benchmark/benchmark.h>
+#include <blas/linalg.hh>
+#include "bench_utils.hh"
+
+using namespace batchlas;
+
+// Single GEMV benchmark
+template <typename T, Backend B>
+static void BM_GEMV_Single(benchmark::State& state) {
+    const int m = state.range(0);
+    const int n = state.range(1);
+
+    auto A = Matrix<T>::Random(m, n, false);
+    UnifiedVector<T> x(n);
+    UnifiedVector<T> y(m);
+
+    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto y_copy = y;
+        state.ResumeTiming();
+        gemv<B>(queue, A.view(), VectorView<T>(x.data(), n, 1),
+                 VectorView<T>(y_copy.data(), m, 1), T(1), T(0),
+                 Transpose::NoTrans);
+        queue.wait();
+        benchmark::DoNotOptimize(y_copy.data());
+    }
+
+    state.counters["FLOPS"] = benchmark::Counter(2.0 * m * n,
+                                                   benchmark::Counter::kIsRate);
+}
+
+// Batched GEMV benchmark
+template <typename T, Backend B>
+static void BM_GEMV_Batched(benchmark::State& state) {
+    const int m = state.range(0);
+    const int n = state.range(1);
+    const int batch = state.range(2);
+
+    auto A = Matrix<T>::Random(m, n, false, batch);
+    UnifiedVector<T> x(n * batch);
+    UnifiedVector<T> y(m * batch);
+
+    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto y_copy = y;
+        state.ResumeTiming();
+        gemv<B>(queue, A.view(), VectorView<T>(x.data(), n, 1, n, batch),
+                 VectorView<T>(y_copy.data(), m, 1, m, batch), T(1), T(0),
+                 Transpose::NoTrans);
+        queue.wait();
+        benchmark::DoNotOptimize(y_copy.data());
+    }
+
+    state.counters["FLOPS"] = benchmark::Counter(
+        static_cast<double>(batch) * 2.0 * m * n, benchmark::Counter::kIsRate);
+    state.counters["BatchSize"] = batch;
+}
+
+BENCHMARK_TEMPLATE(BM_GEMV_Single, float, Backend::NETLIB)->Apply(bench_utils::SquareSizes);
+BENCHMARK_TEMPLATE(BM_GEMV_Single, double, Backend::NETLIB)->Apply(bench_utils::SquareSizes);
+BENCHMARK_TEMPLATE(BM_GEMV_Single, float, Backend::CUDA)->Apply(bench_utils::SquareSizes);
+BENCHMARK_TEMPLATE(BM_GEMV_Single, double, Backend::CUDA)->Apply(bench_utils::SquareSizes);
+
+BENCHMARK_TEMPLATE(BM_GEMV_Batched, float, Backend::NETLIB)->Apply(bench_utils::SquareBatchSizes);
+BENCHMARK_TEMPLATE(BM_GEMV_Batched, double, Backend::NETLIB)->Apply(bench_utils::SquareBatchSizes);
+BENCHMARK_TEMPLATE(BM_GEMV_Batched, float, Backend::CUDA)->Apply(bench_utils::SquareBatchSizes);
+BENCHMARK_TEMPLATE(BM_GEMV_Batched, double, Backend::CUDA)->Apply(bench_utils::SquareBatchSizes);
+
+BENCHMARK_MAIN();

--- a/benchmarks/geqrf_benchmark.cc
+++ b/benchmarks/geqrf_benchmark.cc
@@ -1,5 +1,6 @@
 #include <benchmark/benchmark.h>
 #include <blas/linalg.hh>
+#include "bench_utils.hh"
 #include <vector>
 #include <random>
 #include <memory>
@@ -77,17 +78,25 @@ static void BM_GEQRF_Batched(benchmark::State& state) {
 }
 
 // Register single matrix benchmarks
-BENCHMARK_TEMPLATE(BM_GEQRF_Single, float, batchlas::Backend::NETLIB)->Args({64, 64})->Args({128, 128})->Args({256, 256})->Args({512, 512})->Args({1024, 1024});
-BENCHMARK_TEMPLATE(BM_GEQRF_Single, double, batchlas::Backend::NETLIB)->Args({64, 64})->Args({128, 128})->Args({256, 256})->Args({512, 512})->Args({1024, 1024});
+BENCHMARK_TEMPLATE(BM_GEQRF_Single, float, batchlas::Backend::NETLIB)
+    ->Apply(bench_utils::SquareSizes);
+BENCHMARK_TEMPLATE(BM_GEQRF_Single, double, batchlas::Backend::NETLIB)
+    ->Apply(bench_utils::SquareSizes);
 
-BENCHMARK_TEMPLATE(BM_GEQRF_Single, float, batchlas::Backend::CUDA)->Args({64, 64})->Args({128, 128})->Args({256, 256})->Args({512, 512})->Args({1024, 1024});
-BENCHMARK_TEMPLATE(BM_GEQRF_Single, double, batchlas::Backend::CUDA)->Args({64, 64})->Args({128, 128})->Args({256, 256})->Args({512, 512})->Args({1024, 1024});
+BENCHMARK_TEMPLATE(BM_GEQRF_Single, float, batchlas::Backend::CUDA)
+    ->Apply(bench_utils::SquareSizes);
+BENCHMARK_TEMPLATE(BM_GEQRF_Single, double, batchlas::Backend::CUDA)
+    ->Apply(bench_utils::SquareSizes);
 
 // Register batched matrix benchmarks
-BENCHMARK_TEMPLATE(BM_GEQRF_Batched, float, batchlas::Backend::NETLIB)->Args({64, 64, 10})->Args({128, 128, 10})->Args({256, 256, 10})->Args({64, 64, 100})->Args({128, 128, 100});
-BENCHMARK_TEMPLATE(BM_GEQRF_Batched, double, batchlas::Backend::NETLIB)->Args({64, 64, 10})->Args({128, 128, 10})->Args({256, 256, 10})->Args({64, 64, 100})->Args({128, 128, 100});
+BENCHMARK_TEMPLATE(BM_GEQRF_Batched, float, batchlas::Backend::NETLIB)
+    ->Apply(bench_utils::SquareBatchSizes);
+BENCHMARK_TEMPLATE(BM_GEQRF_Batched, double, batchlas::Backend::NETLIB)
+    ->Apply(bench_utils::SquareBatchSizes);
 
-BENCHMARK_TEMPLATE(BM_GEQRF_Batched, float, batchlas::Backend::CUDA)->Args({64, 64, 10})->Args({128, 128, 10})->Args({256, 256, 10})->Args({64, 64, 100})->Args({128, 128, 100})->Args({256, 256, 100})->Args({512, 512, 100})->Args({1024, 1024, 100});
-BENCHMARK_TEMPLATE(BM_GEQRF_Batched, double, batchlas::Backend::CUDA)->Args({64, 64, 10})->Args({128, 128, 10})->Args({256, 256, 10})->Args({64, 64, 100})->Args({128, 128, 100});
+BENCHMARK_TEMPLATE(BM_GEQRF_Batched, float, batchlas::Backend::CUDA)
+    ->Apply(bench_utils::SquareBatchSizes);
+BENCHMARK_TEMPLATE(BM_GEQRF_Batched, double, batchlas::Backend::CUDA)
+    ->Apply(bench_utils::SquareBatchSizes);
 
 BENCHMARK_MAIN();

--- a/benchmarks/ormqr_benchmark.cc
+++ b/benchmarks/ormqr_benchmark.cc
@@ -1,0 +1,84 @@
+#include <benchmark/benchmark.h>
+#include <blas/linalg.hh>
+#include "bench_utils.hh"
+
+using namespace batchlas;
+
+// Single ORMQR benchmark
+template <typename T, Backend B>
+static void BM_ORMQR_Single(benchmark::State& state) {
+    const int m = state.range(0);
+
+    auto A = Matrix<T>::Random(m, m, false);
+    UnifiedVector<T> tau(m);
+    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
+    size_t geqrf_ws = geqrf_buffer_size<B>(queue, A.view(), tau.to_span());
+    UnifiedVector<std::byte> ws_geqrf(geqrf_ws);
+    geqrf<B>(queue, A.view(), tau.to_span(), ws_geqrf.to_span());
+    queue.wait();
+
+    auto Q = Matrix<T>::Identity(m);
+    size_t orm_ws = ormqr_buffer_size<B>(queue, A.view(), Q.view(), Side::Left,
+                                         Transpose::NoTrans, tau.to_span());
+    UnifiedVector<std::byte> ws(orm_ws);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto Q_copy = Q;
+        state.ResumeTiming();
+        ormqr<B>(queue, A.view(), Q_copy.view(), Side::Left, Transpose::NoTrans,
+                 tau.to_span(), ws.to_span());
+        queue.wait();
+        benchmark::DoNotOptimize(Q_copy.data());
+    }
+
+    state.counters["FLOPS"] = benchmark::Counter(
+        4.0 * m * m * m, benchmark::Counter::kIsRate);
+}
+
+// Batched ORMQR benchmark
+template <typename T, Backend B>
+static void BM_ORMQR_Batched(benchmark::State& state) {
+    const int m = state.range(0);
+    const int batch = state.range(1);
+
+    auto A = Matrix<T>::Random(m, m, false, batch);
+    UnifiedVector<T> tau(m * batch);
+    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
+    size_t geqrf_ws = geqrf_buffer_size<B>(queue, A.view(), tau.to_span());
+    UnifiedVector<std::byte> ws_geqrf(geqrf_ws);
+    geqrf<B>(queue, A.view(), tau.to_span(), ws_geqrf.to_span());
+    queue.wait();
+
+    auto Q = Matrix<T>::Identity(m, batch);
+    size_t orm_ws = ormqr_buffer_size<B>(queue, A.view(), Q.view(), Side::Left,
+                                         Transpose::NoTrans, tau.to_span());
+    UnifiedVector<std::byte> ws(orm_ws);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto Q_copy = Q;
+        state.ResumeTiming();
+        ormqr<B>(queue, A.view(), Q_copy.view(), Side::Left, Transpose::NoTrans,
+                 tau.to_span(), ws.to_span());
+        queue.wait();
+        benchmark::DoNotOptimize(Q_copy.data());
+    }
+
+    state.counters["FLOPS"] = benchmark::Counter(
+        static_cast<double>(batch) * 4.0 * m * m * m,
+        benchmark::Counter::kIsRate);
+    state.counters["BatchSize"] = batch;
+}
+
+BENCHMARK_TEMPLATE(BM_ORMQR_Single, float, Backend::NETLIB)->Apply(bench_utils::SquareSizes);
+BENCHMARK_TEMPLATE(BM_ORMQR_Single, double, Backend::NETLIB)->Apply(bench_utils::SquareSizes);
+BENCHMARK_TEMPLATE(BM_ORMQR_Single, float, Backend::CUDA)->Apply(bench_utils::SquareSizes);
+BENCHMARK_TEMPLATE(BM_ORMQR_Single, double, Backend::CUDA)->Apply(bench_utils::SquareSizes);
+
+BENCHMARK_TEMPLATE(BM_ORMQR_Batched, float, Backend::NETLIB)->Apply(bench_utils::SquareBatchSizes);
+BENCHMARK_TEMPLATE(BM_ORMQR_Batched, double, Backend::NETLIB)->Apply(bench_utils::SquareBatchSizes);
+BENCHMARK_TEMPLATE(BM_ORMQR_Batched, float, Backend::CUDA)->Apply(bench_utils::SquareBatchSizes);
+BENCHMARK_TEMPLATE(BM_ORMQR_Batched, double, Backend::CUDA)->Apply(bench_utils::SquareBatchSizes);
+
+BENCHMARK_MAIN();

--- a/benchmarks/spmm_benchmark.cc
+++ b/benchmarks/spmm_benchmark.cc
@@ -1,0 +1,85 @@
+#include <benchmark/benchmark.h>
+#include <blas/linalg.hh>
+#include "bench_utils.hh"
+
+using namespace batchlas;
+
+// Single SPMM benchmark (CSR * Dense)
+template <typename T, Backend B>
+static void BM_SPMM_Single(benchmark::State& state) {
+    const int m = state.range(0);
+    const int k = state.range(1);
+    const int n = state.range(2);
+
+    // Create random dense matrix and convert to CSR for sparsity
+    auto A_dense = Matrix<T>::Random(m, k, false);
+    auto A = A_dense.convert_to<MatrixFormat::CSR>();
+    auto Bm = Matrix<T>::Random(k, n, false);
+    auto C = Matrix<T>::Random(m, n, false);
+
+    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
+    size_t ws_size = spmm_buffer_size<B>(queue, A.view(), Bm.view(), C.view(),
+                                        T(1), T(0), Transpose::NoTrans,
+                                        Transpose::NoTrans);
+    UnifiedVector<std::byte> workspace(ws_size);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto C_copy = C;
+        state.ResumeTiming();
+        spmm<B>(queue, A.view(), Bm.view(), C_copy.view(), T(1), T(0),
+                Transpose::NoTrans, Transpose::NoTrans, workspace.to_span());
+        queue.wait();
+        benchmark::DoNotOptimize(C_copy.data());
+    }
+
+    state.counters["FLOPS"] = benchmark::Counter(
+        2.0 * A.nnz() * n, benchmark::Counter::kIsRate);
+}
+
+// Batched SPMM benchmark
+template <typename T, Backend B>
+static void BM_SPMM_Batched(benchmark::State& state) {
+    const int m = state.range(0);
+    const int k = state.range(1);
+    const int n = state.range(2);
+    const int batch = state.range(3);
+
+    auto A_dense = Matrix<T>::Random(m, k, false, batch);
+    auto A = A_dense.convert_to<MatrixFormat::CSR>();
+    auto Bm = Matrix<T>::Random(k, n, false, batch);
+    auto C = Matrix<T>::Random(m, n, false, batch);
+
+    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
+    size_t ws_size = spmm_buffer_size<B>(queue, A.view(), Bm.view(), C.view(),
+                                        T(1), T(0), Transpose::NoTrans,
+                                        Transpose::NoTrans);
+    UnifiedVector<std::byte> workspace(ws_size);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto C_copy = C;
+        state.ResumeTiming();
+        spmm<B>(queue, A.view(), Bm.view(), C_copy.view(), T(1), T(0),
+                Transpose::NoTrans, Transpose::NoTrans, workspace.to_span());
+        queue.wait();
+        benchmark::DoNotOptimize(C_copy.data());
+    }
+
+    state.counters["FLOPS"] = benchmark::Counter(
+        static_cast<double>(batch) * 2.0 * A.nnz() * n,
+        benchmark::Counter::kIsRate);
+    state.counters["BatchSize"] = batch;
+}
+
+BENCHMARK_TEMPLATE(BM_SPMM_Single, float, Backend::NETLIB)->Apply(bench_utils::CubeSizes);
+BENCHMARK_TEMPLATE(BM_SPMM_Single, double, Backend::NETLIB)->Apply(bench_utils::CubeSizes);
+BENCHMARK_TEMPLATE(BM_SPMM_Single, float, Backend::CUDA)->Apply(bench_utils::CubeSizes);
+BENCHMARK_TEMPLATE(BM_SPMM_Single, double, Backend::CUDA)->Apply(bench_utils::CubeSizes);
+
+BENCHMARK_TEMPLATE(BM_SPMM_Batched, float, Backend::NETLIB)->Apply(bench_utils::CubeBatchSizes);
+BENCHMARK_TEMPLATE(BM_SPMM_Batched, double, Backend::NETLIB)->Apply(bench_utils::CubeBatchSizes);
+BENCHMARK_TEMPLATE(BM_SPMM_Batched, float, Backend::CUDA)->Apply(bench_utils::CubeBatchSizes);
+BENCHMARK_TEMPLATE(BM_SPMM_Batched, double, Backend::CUDA)->Apply(bench_utils::CubeBatchSizes);
+
+BENCHMARK_MAIN();

--- a/benchmarks/spmm_benchmark.cc
+++ b/benchmarks/spmm_benchmark.cc
@@ -13,7 +13,7 @@ static void BM_SPMM_Single(benchmark::State& state) {
 
     // Create random dense matrix and convert to CSR for sparsity
     auto A_dense = Matrix<T>::Random(m, k, false);
-    auto A = A_dense.convert_to<MatrixFormat::CSR>();
+    auto A = A_dense.template convert_to<MatrixFormat::CSR>();
     auto Bm = Matrix<T>::Random(k, n, false);
     auto C = Matrix<T>::Random(m, n, false);
 
@@ -46,7 +46,7 @@ static void BM_SPMM_Batched(benchmark::State& state) {
     const int batch = state.range(3);
 
     auto A_dense = Matrix<T>::Random(m, k, false, batch);
-    auto A = A_dense.convert_to<MatrixFormat::CSR>();
+    auto A = A_dense.template convert_to<MatrixFormat::CSR>();
     auto Bm = Matrix<T>::Random(k, n, false, batch);
     auto C = Matrix<T>::Random(m, n, false, batch);
 

--- a/benchmarks/trsm_benchmark.cc
+++ b/benchmarks/trsm_benchmark.cc
@@ -1,0 +1,67 @@
+#include <benchmark/benchmark.h>
+#include <blas/linalg.hh>
+#include "bench_utils.hh"
+
+using namespace batchlas;
+
+// Single TRSM benchmark
+template <typename T, Backend B>
+static void BM_TRSM_Single(benchmark::State& state) {
+    const int n = state.range(0);
+
+    auto A = Matrix<T>::Triangular(n, Uplo::Lower, T(1), T(0.5));
+    auto Bm = Matrix<T>::Random(n, n, false);
+
+    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto B_copy = Bm;
+        state.ResumeTiming();
+        trsm<B>(queue, A.view(), B_copy.view(), Side::Left, Uplo::Lower,
+                Transpose::NoTrans, Diag::NonUnit, T(1));
+        queue.wait();
+        benchmark::DoNotOptimize(B_copy.data());
+    }
+
+    state.counters["FLOPS"] = benchmark::Counter(1.0 * n * n,
+                                                   benchmark::Counter::kIsRate);
+}
+
+// Batched TRSM benchmark
+template <typename T, Backend B>
+static void BM_TRSM_Batched(benchmark::State& state) {
+    const int n = state.range(0);
+    const int batch = state.range(1);
+
+    auto A = Matrix<T>::Triangular(n, Uplo::Lower, T(1), T(0.5), batch);
+    auto Bm = Matrix<T>::Random(n, n, false, batch);
+
+    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto B_copy = Bm;
+        state.ResumeTiming();
+        trsm<B>(queue, A.view(), B_copy.view(), Side::Left, Uplo::Lower,
+                Transpose::NoTrans, Diag::NonUnit, T(1));
+        queue.wait();
+        benchmark::DoNotOptimize(B_copy.data());
+    }
+
+    state.counters["FLOPS"] = benchmark::Counter(
+        static_cast<double>(batch) * n * n, benchmark::Counter::kIsRate);
+    state.counters["BatchSize"] = batch;
+}
+
+BENCHMARK_TEMPLATE(BM_TRSM_Single, float, Backend::NETLIB)->Apply(bench_utils::SquareSizes);
+BENCHMARK_TEMPLATE(BM_TRSM_Single, double, Backend::NETLIB)->Apply(bench_utils::SquareSizes);
+BENCHMARK_TEMPLATE(BM_TRSM_Single, float, Backend::CUDA)->Apply(bench_utils::SquareSizes);
+BENCHMARK_TEMPLATE(BM_TRSM_Single, double, Backend::CUDA)->Apply(bench_utils::SquareSizes);
+
+BENCHMARK_TEMPLATE(BM_TRSM_Batched, float, Backend::NETLIB)->Apply(bench_utils::SquareBatchSizes);
+BENCHMARK_TEMPLATE(BM_TRSM_Batched, double, Backend::NETLIB)->Apply(bench_utils::SquareBatchSizes);
+BENCHMARK_TEMPLATE(BM_TRSM_Batched, float, Backend::CUDA)->Apply(bench_utils::SquareBatchSizes);
+BENCHMARK_TEMPLATE(BM_TRSM_Batched, double, Backend::CUDA)->Apply(bench_utils::SquareBatchSizes);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
## Summary
- add helper utilities for Google Benchmark argument ranges
- clean up GEQRF benchmark range specification
- add new benchmarks for GEMM, GEMV, SPMM, TRSM and ORMQR
- register new benchmark executables in CMake

## Testing
- `cmake ..` *(fails: LAPACKE library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496ed5ea1883258ffcd82b5c30a97b