### PR TITLE
Improve simple benchmarking utilities

### DIFF
--- a/include/util/simple_benchmark.hh
+++ b/include/util/simple_benchmark.hh
@@ -6,6 +6,9 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <fstream>
+#include <sstream>
+#include <iomanip>
 
 namespace simple_bench {
 
@@ -29,6 +32,37 @@ struct Metric {
     double value = 0.0;
     bool rate = false;  // divide by time if true
 };
+
+// Helper to parse a single integer or a range/list specification of the form
+// "start:end:num" or "v1,v2,v3". Returned values are rounded to int.
+inline std::vector<int> parse_range_or_list(const std::string& str) {
+    std::vector<int> vals;
+    if (str.find(':') != std::string::npos) {
+        std::vector<std::string> parts;
+        std::stringstream ss(str);
+        std::string item;
+        while (std::getline(ss, item, ':')) parts.push_back(item);
+        if (parts.size() >= 2) {
+            double start = std::stod(parts[0]);
+            double end   = std::stod(parts[1]);
+            size_t num   = parts.size() >= 3 ? std::stoul(parts[2]) : 5;
+            if (num < 2) num = 2;
+            for (size_t i = 0; i < num; ++i) {
+                double v = start + (end - start) * static_cast<double>(i) / (num - 1);
+                vals.push_back(static_cast<int>(std::lround(v)));
+            }
+        }
+    } else if (str.find(',') != std::string::npos) {
+        std::stringstream ss(str);
+        std::string item;
+        while (std::getline(ss, item, ',')) {
+            if (!item.empty()) vals.push_back(std::stoi(item));
+        }
+    } else if (!str.empty()) {
+        vals.push_back(std::stoi(str));
+    }
+    return vals;
+}
 
 using MetricsFunc = std::function<void(Result&)>;
 
@@ -185,47 +219,122 @@ inline Result run_benchmark(const Benchmark& b,
     return res;
 }
 
-inline void print_result(const Result& r) {
-    std::cout << r.name;
-    if (!r.args.empty()) {
-        std::cout << " [";
-        for (size_t i = 0; i < r.args.size(); ++i) {
-            if (i) std::cout << ",";
-            std::cout << r.args[i];
-        }
-        std::cout << "]";
-    }
-    std::cout << "\n";
-    std::cout << "Iterations: " << r.iterations
-              << "  Avg(ms): " << r.avg_ms
-              << "  StdDev(ms): " << r.stddev_ms << "\n";
-    for (const auto& kv : r.metrics) {
-        std::cout << "  " << kv.first << ": " << kv.second << "\n";
-    }
-}
-
-inline int RunRegisteredBenchmarks(const Config& cfg = {}) {
-    for (const auto& b : registry()) {
-        if (b.args_list.empty()) {
-            auto r = run_benchmark(b, {}, cfg);
-            print_result(r);
-        } else {
-            for (const auto& a : b.args_list) {
-                auto r = run_benchmark(b, a, cfg);
-                print_result(r);
+inline void print_table(const std::vector<Result>& results) {
+    if (results.empty()) return;
+    size_t max_args = 0;
+    std::vector<std::string> metric_names;
+    std::unordered_map<std::string, bool> metric_seen;
+    for (const auto& r : results) {
+        max_args = std::max(max_args, r.args.size());
+        for (const auto& kv : r.metrics) {
+            if (!metric_seen[kv.first]) {
+                metric_names.push_back(kv.first);
+                metric_seen[kv.first] = true;
             }
         }
     }
+
+    std::cout << std::left << std::setw(16) << "Name";
+    for (size_t i = 0; i < max_args; ++i) {
+        std::cout << std::setw(8) << ("Arg" + std::to_string(i));
+    }
+    std::cout << std::setw(12) << "Iter"
+              << std::setw(12) << "Avg(ms)"
+              << std::setw(12) << "Std(ms)";
+    for (const auto& m : metric_names) {
+        std::cout << std::setw(12) << m;
+    }
+    std::cout << '\n';
+
+    for (const auto& r : results) {
+        std::cout << std::left << std::setw(16) << r.name;
+        for (size_t i = 0; i < max_args; ++i) {
+            if (i < r.args.size())
+                std::cout << std::setw(8) << r.args[i];
+            else
+                std::cout << std::setw(8) << "";
+        }
+        std::cout << std::setw(12) << r.iterations
+                  << std::setw(12) << r.avg_ms
+                  << std::setw(12) << r.stddev_ms;
+        for (const auto& m : metric_names) {
+            auto it = r.metrics.find(m);
+            if (it != r.metrics.end())
+                std::cout << std::setw(12) << it->second;
+            else
+                std::cout << std::setw(12) << "";
+        }
+        std::cout << '\n';
+    }
+}
+
+inline void write_csv(const std::string& path, const std::vector<Result>& results) {
+    std::ofstream f(path);
+    if (!f.is_open()) {
+        std::cerr << "Failed to open CSV file: " << path << '\n';
+        return;
+    }
+    size_t max_args = 0;
+    std::vector<std::string> metric_names;
+    std::unordered_map<std::string, bool> metric_seen;
+    for (const auto& r : results) {
+        max_args = std::max(max_args, r.args.size());
+        for (const auto& kv : r.metrics) {
+            if (!metric_seen[kv.first]) {
+                metric_names.push_back(kv.first);
+                metric_seen[kv.first] = true;
+            }
+        }
+    }
+    f << "name";
+    for (size_t i = 0; i < max_args; ++i) f << ",arg" << i;
+    f << ",iterations,avg_ms,stddev_ms";
+    for (const auto& m : metric_names) f << ',' << m;
+    f << '\n';
+    for (const auto& r : results) {
+        f << r.name;
+        for (size_t i = 0; i < max_args; ++i) {
+            if (i < r.args.size()) f << ',' << r.args[i];
+            else f << ',';
+        }
+        f << ',' << r.iterations
+          << ',' << r.avg_ms
+          << ',' << r.stddev_ms;
+        for (const auto& m : metric_names) {
+            auto it = r.metrics.find(m);
+            if (it != r.metrics.end()) f << ',' << it->second; else f << ',';
+        }
+        f << '\n';
+    }
+}
+
+inline int RunRegisteredBenchmarks(const Config& cfg = {},
+                                   const std::string& csv_path = "") {
+    std::vector<Result> results;
+    for (const auto& b : registry()) {
+        if (b.args_list.empty()) {
+            results.push_back(run_benchmark(b, {}, cfg));
+        } else {
+            for (const auto& a : b.args_list) {
+                results.push_back(run_benchmark(b, a, cfg));
+            }
+        }
+    }
+
+    print_table(results);
+    if (!csv_path.empty()) write_csv(csv_path, results);
     return 0;
 }
 
 struct CliOptions {
     Config cfg;
-    std::vector<int> args;
+    std::vector<std::vector<int>> args_list;
+    std::string csv_file;
 };
 
 inline CliOptions ParseCommandLine(int argc, char** argv) {
     CliOptions opt;
+    std::vector<std::vector<int>> arg_values;
     for (int i = 1; i < argc; ++i) {
         std::string s(argv[i]);
         if (s.rfind("--warmup=", 0) == 0) {
@@ -236,21 +345,50 @@ inline CliOptions ParseCommandLine(int argc, char** argv) {
             opt.cfg.max_iters = std::stoul(s.substr(12));
         } else if (s.rfind("--min_time=", 0) == 0) {
             opt.cfg.min_time_ms = std::stod(s.substr(11));
+        } else if (s.rfind("--csv=", 0) == 0) {
+            opt.csv_file = s.substr(6);
+        } else if (s == "--help" || s == "-h") {
+            std::cout << "Usage: benchmark [options] [ARGS...]\n";
+            std::cout << "Options:\n";
+            std::cout << "  --warmup=N       warmup iterations (default 2)\n";
+            std::cout << "  --min_iters=N    minimum measured iterations\n";
+            std::cout << "  --max_iters=N    maximum measured iterations\n";
+            std::cout << "  --min_time=MS    minimum total measurement time\n";
+            std::cout << "  --csv=FILE       write results to CSV file\n";
+            std::cout << "  ARGS can be integers, comma lists or start:end:num ranges\n";
+            exit(0);
         } else {
-            opt.args.push_back(std::stoi(s));
+            arg_values.push_back(parse_range_or_list(s));
         }
     }
+
+    if (!arg_values.empty()) {
+        std::vector<std::vector<int>> combos{{}};
+        for (const auto& vals : arg_values) {
+            std::vector<std::vector<int>> next;
+            for (const auto& c : combos) {
+                for (int v : vals) {
+                    auto tmp = c;
+                    tmp.push_back(v);
+                    next.push_back(std::move(tmp));
+                }
+            }
+            combos = std::move(next);
+        }
+        opt.args_list = std::move(combos);
+    }
+
     return opt;
 }
 
 inline int SimpleBenchMain(int argc, char** argv) {
     auto opts = ParseCommandLine(argc, argv);
     for (auto& b : registry()) {
-        if (!opts.args.empty() && b.args_list.empty()) {
-            b.args_list.push_back(opts.args);
+        if (!opts.args_list.empty() && b.args_list.empty()) {
+            b.args_list = opts.args_list;
         }
     }
-    return RunRegisteredBenchmarks(opts.cfg);
+    return RunRegisteredBenchmarks(opts.cfg, opts.csv_file);
 }
 
 #define SIMPLE_BENCHMARK_MAIN()                        \


### PR DESCRIPTION
## Summary
- revert mistaken syevx benchmark changes
- extend simple_benchmark utility with range parsing and CSV output
- format benchmark results in columns

## Testing
- `python -m py_compile scripts/run_syevx_benchmark.py`


------
https://chatgpt.com/codex/tasks/task_e_684aca10c9b08325958f5e7fabc60f6c