### PR TITLE
Enhance custom benchmark utility

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -27,7 +27,7 @@ set(BENCHMARK_TARGETS
     ormqr_benchmark
 )
 
-set(SIMPLE_BENCH_TARGETS
+set(MINI_BENCH_TARGETS
     gemm_custom
 )
 
@@ -48,7 +48,7 @@ foreach(test ${BENCHMARK_TARGETS})
     add_test(NAME ${test} COMMAND ${test})
 endforeach()
 
-foreach(test ${SIMPLE_BENCH_TARGETS})
+foreach(test ${MINI_BENCH_TARGETS})
     add_executable(${test} ${test}.cc)
     target_link_libraries(${test} PRIVATE
         batchlas

--- a/benchmarks/gemm_custom.cc
+++ b/benchmarks/gemm_custom.cc
@@ -1,11 +1,11 @@
 #include <blas/linalg.hh>
-#include <util/simple_benchmark.hh>
+#include <util/minibench.hh>
 
 using namespace batchlas;
 
-SIMPLE_BENCHMARK(gemm_custom);
+MINI_BENCHMARK(gemm_custom);
 
-static void gemm_custom(simple_bench::State& state) {
+static void gemm_custom(minibench::State& state) {
     state.PauseTiming();
     size_t m = state.range(0);
     size_t n = state.range(1);
@@ -33,4 +33,4 @@ static auto* bench_cfg = BENCHMARK_gemm_custom
     ->Args({128, 128, 128, 1280}) ->Args({256, 256, 256, 1280})
     ->Args({512, 512, 512, 1280}) ->Args({1024, 1024, 1024, 1280});
 
-SIMPLE_BENCHMARK_MAIN();
+MINI_BENCHMARK_MAIN();


### PR DESCRIPTION
## Summary
- rename `simple_benchmark` to `minibench`
- add colour output and fixed precision to benchmark table
- introduce helper functions for argument ranges
- update gemm_custom benchmark and CMakeLists to use new API
- print benchmark rows immediately instead of waiting for completion

## Testing
- `cmake ..` *(fails: LAPACKE library not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ace8169748325a6cbc8cba268cbfa