### PR TITLE
Remove google benchmark and use minibench

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,23 +1,3 @@
-# Find a testing framework (like GTest)
-find_package(GTest QUIET)
-find_package(benchmark QUIET)
-if(NOT GTest_FOUND)
-    # Include FetchContent for downloading dependencies
-    include(FetchContent)
-    
-    # Fetch GoogleTest
-    FetchContent_Declare(
-        googletest
-        GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG release-1.12.1
-    )
-    
-    # Configure GoogleTest to build shared libraries
-    set(BUILD_SHARED_LIBS ON CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(googletest)
-endif()
-
-# Define test executables
 set(BENCHMARK_TARGETS
     geqrf_benchmark
     gemm_benchmark
@@ -25,34 +5,12 @@ set(BENCHMARK_TARGETS
     spmm_benchmark
     trsm_benchmark
     ormqr_benchmark
-)
-
-set(MINI_BENCH_TARGETS
     gemm_custom
 )
 
-# Create test executables
 foreach(test ${BENCHMARK_TARGETS})
-    # Add executable
     add_executable(${test} ${test}.cc)
-    
-    # Link dependencies
-    target_link_libraries(${test} PRIVATE 
-        batchlas
-        GTest::gtest 
-        GTest::gtest_main
-        benchmark::benchmark
-    )
-    
-    # Add to CTest
-    add_test(NAME ${test} COMMAND ${test})
-endforeach()
-
-foreach(test ${MINI_BENCH_TARGETS})
-    add_executable(${test} ${test}.cc)
-    target_link_libraries(${test} PRIVATE
-        batchlas
-    )
+    target_link_libraries(${test} PRIVATE batchlas)
     add_test(NAME ${test} COMMAND ${test})
 endforeach()
 

--- a/benchmarks/bench_utils.hh
+++ b/benchmarks/bench_utils.hh
@@ -1,15 +1,18 @@
 #pragma once
-#include <benchmark/benchmark.h>
+#include <util/minibench.hh>
 
 namespace bench_utils {
 
-inline void SquareSizes(benchmark::internal::Benchmark* b) {
+inline void SquareSizes(minibench::Benchmark* b) {
     for (int s : {64, 128, 256, 512, 1024, 2048, 4096, 8192}) {
         b->Args({s, s});
     }
 }
 
-inline void SquareBatchSizes(benchmark::internal::Benchmark* b) {
+inline void SquareBatchSizes(minibench::Benchmark* b) {
+    for (int s : {64, 128, 256}) {
+        b->Args({s, s, 1});
+    }
     for (int s : {64, 128, 256}) {
         b->Args({s, s, 10});
     }
@@ -21,13 +24,16 @@ inline void SquareBatchSizes(benchmark::internal::Benchmark* b) {
     }
 }
 
-inline void CubeSizes(benchmark::internal::Benchmark* b) {
+inline void CubeSizes(minibench::Benchmark* b) {
     for (int s : {64, 128, 256, 512, 1024, 2048, 4096, 8192}) {
         b->Args({s, s, s});
     }
 }
 
-inline void CubeBatchSizes(benchmark::internal::Benchmark* b) {
+inline void CubeBatchSizes(minibench::Benchmark* b) {
+    for (int s : {64, 128, 256}) {
+        b->Args({s, s, s, 1});
+    }
     for (int s : {64, 128, 256}) {
         b->Args({s, s, s, 10});
     }

--- a/benchmarks/bench_utils.hh
+++ b/benchmarks/bench_utils.hh
@@ -3,46 +3,5 @@
 
 namespace bench_utils {
 
-inline void SquareSizes(minibench::Benchmark* b) {
-    for (int s : {64, 128, 256, 512, 1024, 2048, 4096, 8192}) {
-        b->Args({s, s});
-    }
-}
-
-inline void SquareBatchSizes(minibench::Benchmark* b) {
-    for (int s : {64, 128, 256}) {
-        b->Args({s, s, 1});
-    }
-    for (int s : {64, 128, 256}) {
-        b->Args({s, s, 10});
-    }
-    for (int s : {64, 128, 256, 512}) {
-        b->Args({s, s, 100});
-    }
-    for (int s : {64, 128, 256, 512, 1024}) {
-        b->Args({s, s, 1000});
-    }
-}
-
-inline void CubeSizes(minibench::Benchmark* b) {
-    for (int s : {64, 128, 256, 512, 1024, 2048, 4096, 8192}) {
-        b->Args({s, s, s});
-    }
-}
-
-inline void CubeBatchSizes(minibench::Benchmark* b) {
-    for (int s : {64, 128, 256}) {
-        b->Args({s, s, s, 1});
-    }
-    for (int s : {64, 128, 256}) {
-        b->Args({s, s, s, 10});
-    }
-    for (int s : {64, 128, 256, 512}) {
-        b->Args({s, s, s, 100});
-    }
-    for (int s : {64, 128, 256, 512, 1024}) {
-        b->Args({s, s, s, 1000});
-    }
-}
 
 } // namespace bench_utils

--- a/benchmarks/gemm_benchmark.cc
+++ b/benchmarks/gemm_benchmark.cc
@@ -37,9 +37,9 @@ static auto* bench_gemm_f_gpu =
 static auto* bench_gemm_d_gpu =
     minibench::RegisterBenchmark("gemm_double_gpu", BM_GEMM<double, Backend::CUDA>);
 
-bench_utils::CubeBatchSizes(bench_gemm_f_cpu);
-bench_utils::CubeBatchSizes(bench_gemm_d_cpu);
-bench_utils::CubeBatchSizes(bench_gemm_f_gpu);
-bench_utils::CubeBatchSizes(bench_gemm_d_gpu);
+minibench::CubeBatchSizes(bench_gemm_f_cpu);
+minibench::CubeBatchSizes(bench_gemm_d_cpu);
+minibench::CubeBatchSizes(bench_gemm_f_gpu);
+minibench::CubeBatchSizes(bench_gemm_d_gpu);
 
 MINI_BENCHMARK_MAIN();

--- a/benchmarks/gemm_benchmark.cc
+++ b/benchmarks/gemm_benchmark.cc
@@ -1,4 +1,4 @@
-#include <benchmark/benchmark.h>
+#include <util/minibench.hh>
 #include <blas/linalg.hh>
 #include "bench_utils.hh"
 
@@ -6,7 +6,7 @@ using namespace batchlas;
 
 // Batched GEMM benchmark
 template <typename T, Backend B>
-static void BM_GEMM(benchmark::State& state) {
+static void BM_GEMM(minibench::State& state) {
     state.PauseTiming();
     const size_t m = state.range(0);
     const size_t n = state.range(1);
@@ -22,17 +22,24 @@ static void BM_GEMM(benchmark::State& state) {
     state.ResumeTiming();
     for (auto _ : state) {
         gemm<B>(queue, A.view(), Bm.view(), C.view(), T(1), T(0), Transpose::NoTrans, Transpose::NoTrans);
-        benchmark::DoNotOptimize(C.data());
     }
     queue.wait();
-    state.counters["GFLOPS"] = benchmark::Counter(
-        static_cast<double>(batch) * 1e-9 * (2.0 * m * n * k), benchmark::Counter::kIsRate);
-    state.counters["BatchSize"] = batch;
+    state.SetMetric("GFLOPS", static_cast<double>(batch) * (1e-9 * 2.0 * m * n * k), true);
+    state.SetMetric("BatchSize", static_cast<double>(batch));
 }
 
-BENCHMARK_TEMPLATE(BM_GEMM, float, Backend::NETLIB)->Apply(bench_utils::CubeBatchSizes);
-BENCHMARK_TEMPLATE(BM_GEMM, double, Backend::NETLIB)->Apply(bench_utils::CubeBatchSizes);
-BENCHMARK_TEMPLATE(BM_GEMM, float, Backend::CUDA)->Apply(bench_utils::CubeBatchSizes);
-BENCHMARK_TEMPLATE(BM_GEMM, double, Backend::CUDA)->Apply(bench_utils::CubeBatchSizes);
+static auto* bench_gemm_f_cpu =
+    minibench::RegisterBenchmark("gemm_float_cpu", BM_GEMM<float, Backend::NETLIB>);
+static auto* bench_gemm_d_cpu =
+    minibench::RegisterBenchmark("gemm_double_cpu", BM_GEMM<double, Backend::NETLIB>);
+static auto* bench_gemm_f_gpu =
+    minibench::RegisterBenchmark("gemm_float_gpu", BM_GEMM<float, Backend::CUDA>);
+static auto* bench_gemm_d_gpu =
+    minibench::RegisterBenchmark("gemm_double_gpu", BM_GEMM<double, Backend::CUDA>);
 
-BENCHMARK_MAIN();
+bench_utils::CubeBatchSizes(bench_gemm_f_cpu);
+bench_utils::CubeBatchSizes(bench_gemm_d_cpu);
+bench_utils::CubeBatchSizes(bench_gemm_f_gpu);
+bench_utils::CubeBatchSizes(bench_gemm_d_gpu);
+
+MINI_BENCHMARK_MAIN();

--- a/benchmarks/gemv_benchmark.cc
+++ b/benchmarks/gemv_benchmark.cc
@@ -1,4 +1,4 @@
-#include <benchmark/benchmark.h>
+#include <util/minibench.hh>
 #include <blas/linalg.hh>
 #include "bench_utils.hh"
 
@@ -6,36 +6,10 @@ using namespace batchlas;
 
 // Single GEMV benchmark
 template <typename T, Backend B>
-static void BM_GEMV_Single(benchmark::State& state) {
+static void BM_GEMV(minibench::State& state) {
     const int m = state.range(0);
     const int n = state.range(1);
 
-    auto A = Matrix<T>::Random(m, n, false);
-    UnifiedVector<T> x(n);
-    UnifiedVector<T> y(m);
-
-    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
-
-    for (auto _ : state) {
-        state.PauseTiming();
-        auto y_copy = y;
-        state.ResumeTiming();
-        gemv<B>(queue, A.view(), VectorView<T>(x.data(), n, 1),
-                 VectorView<T>(y_copy.data(), m, 1), T(1), T(0),
-                 Transpose::NoTrans);
-        queue.wait();
-        benchmark::DoNotOptimize(y_copy.data());
-    }
-
-    state.counters["GFLOPS"] = benchmark::Counter(1e-9 * (2.0 * m * n),
-                                                   benchmark::Counter::kIsRate);
-}
-
-// Batched GEMV benchmark
-template <typename T, Backend B>
-static void BM_GEMV_Batched(benchmark::State& state) {
-    const int m = state.range(0);
-    const int n = state.range(1);
     const int batch = state.range(2);
 
     auto A = Matrix<T>::Random(m, n, false, batch);
@@ -52,22 +26,23 @@ static void BM_GEMV_Batched(benchmark::State& state) {
                  VectorView<T>(y_copy.data(), m, 1, m, batch), T(1), T(0),
                  Transpose::NoTrans);
         queue.wait();
-        benchmark::DoNotOptimize(y_copy.data());
     }
-
-    state.counters["GFLOPS"] = benchmark::Counter(
-        static_cast<double>(batch) * 1e-9 * (2.0 * m * n), benchmark::Counter::kIsRate);
-    state.counters["BatchSize"] = batch;
+    state.SetMetric("GFLOPS", static_cast<double>(batch) * (1e-9 * 2.0 * m * n), true);
+    state.SetMetric("BatchSize", static_cast<double>(batch));
 }
 
-BENCHMARK_TEMPLATE(BM_GEMV_Single, float, Backend::NETLIB)->Apply(bench_utils::SquareSizes);
-BENCHMARK_TEMPLATE(BM_GEMV_Single, double, Backend::NETLIB)->Apply(bench_utils::SquareSizes);
-BENCHMARK_TEMPLATE(BM_GEMV_Single, float, Backend::CUDA)->Apply(bench_utils::SquareSizes);
-BENCHMARK_TEMPLATE(BM_GEMV_Single, double, Backend::CUDA)->Apply(bench_utils::SquareSizes);
+static auto* bench_gemv_f_cpu =
+    minibench::RegisterBenchmark("gemv_float_cpu", BM_GEMV<float, Backend::NETLIB>);
+static auto* bench_gemv_d_cpu =
+    minibench::RegisterBenchmark("gemv_double_cpu", BM_GEMV<double, Backend::NETLIB>);
+static auto* bench_gemv_f_gpu =
+    minibench::RegisterBenchmark("gemv_float_gpu", BM_GEMV<float, Backend::CUDA>);
+static auto* bench_gemv_d_gpu =
+    minibench::RegisterBenchmark("gemv_double_gpu", BM_GEMV<double, Backend::CUDA>);
 
-BENCHMARK_TEMPLATE(BM_GEMV_Batched, float, Backend::NETLIB)->Apply(bench_utils::SquareBatchSizes);
-BENCHMARK_TEMPLATE(BM_GEMV_Batched, double, Backend::NETLIB)->Apply(bench_utils::SquareBatchSizes);
-BENCHMARK_TEMPLATE(BM_GEMV_Batched, float, Backend::CUDA)->Apply(bench_utils::SquareBatchSizes);
-BENCHMARK_TEMPLATE(BM_GEMV_Batched, double, Backend::CUDA)->Apply(bench_utils::SquareBatchSizes);
+bench_utils::SquareBatchSizes(bench_gemv_f_cpu);
+bench_utils::SquareBatchSizes(bench_gemv_d_cpu);
+bench_utils::SquareBatchSizes(bench_gemv_f_gpu);
+bench_utils::SquareBatchSizes(bench_gemv_d_gpu);
 
-BENCHMARK_MAIN();
+MINI_BENCHMARK_MAIN();

--- a/benchmarks/gemv_benchmark.cc
+++ b/benchmarks/gemv_benchmark.cc
@@ -38,9 +38,9 @@ static auto* bench_gemv_f_gpu =
 static auto* bench_gemv_d_gpu =
     minibench::RegisterBenchmark("gemv_double_gpu", BM_GEMV<double, Backend::CUDA>);
 
-bench_utils::SquareBatchSizes(bench_gemv_f_cpu);
-bench_utils::SquareBatchSizes(bench_gemv_d_cpu);
-bench_utils::SquareBatchSizes(bench_gemv_f_gpu);
-bench_utils::SquareBatchSizes(bench_gemv_d_gpu);
+minibench::SquareBatchSizes(bench_gemv_f_cpu);
+minibench::SquareBatchSizes(bench_gemv_d_cpu);
+minibench::SquareBatchSizes(bench_gemv_f_gpu);
+minibench::SquareBatchSizes(bench_gemv_d_gpu);
 
 MINI_BENCHMARK_MAIN();

--- a/benchmarks/gemv_benchmark.cc
+++ b/benchmarks/gemv_benchmark.cc
@@ -19,15 +19,13 @@ static void BM_GEMV(minibench::State& state) {
     Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
 
     for (auto _ : state) {
-        state.PauseTiming();
-        auto y_copy = y;
-        state.ResumeTiming();
         gemv<B>(queue, A.view(), VectorView<T>(x.data(), n, 1, n, batch),
-                 VectorView<T>(y_copy.data(), m, 1, m, batch), T(1), T(0),
+                 VectorView<T>(y.data(), m, 1, m, batch), T(1), T(0),
                  Transpose::NoTrans);
-        queue.wait();
     }
-    state.SetMetric("GFLOPS", static_cast<double>(batch) * (1e-9 * 2.0 * m * n), true);
+    queue.wait();
+    state.SetMetric("GFLOPS", static_cast<double>(batch) * (1e-9 * 2.0 * m * n),
+                    true);
     state.SetMetric("BatchSize", static_cast<double>(batch));
 }
 

--- a/benchmarks/geqrf_benchmark.cc
+++ b/benchmarks/geqrf_benchmark.cc
@@ -43,9 +43,9 @@ static auto* bench_geqrf_f_gpu =
 static auto* bench_geqrf_d_gpu =
     minibench::RegisterBenchmark("geqrf_double_gpu", BM_GEQRF<double, Backend::CUDA>);
 
-bench_utils::SquareBatchSizes(bench_geqrf_f_cpu);
-bench_utils::SquareBatchSizes(bench_geqrf_d_cpu);
-bench_utils::SquareBatchSizes(bench_geqrf_f_gpu);
-bench_utils::SquareBatchSizes(bench_geqrf_d_gpu);
+minibench::SquareBatchSizes(bench_geqrf_f_cpu);
+minibench::SquareBatchSizes(bench_geqrf_d_cpu);
+minibench::SquareBatchSizes(bench_geqrf_f_gpu);
+minibench::SquareBatchSizes(bench_geqrf_d_gpu);
 
 MINI_BENCHMARK_MAIN();

--- a/benchmarks/geqrf_benchmark.cc
+++ b/benchmarks/geqrf_benchmark.cc
@@ -1,4 +1,4 @@
-#include <benchmark/benchmark.h>
+#include <util/minibench.hh>
 #include <blas/linalg.hh>
 #include "bench_utils.hh"
 #include <vector>
@@ -11,92 +11,45 @@ using namespace batchlas;
 
 // Single matrix GEQRF benchmark
 template<typename T, Backend B>
-static void BM_GEQRF_Single(benchmark::State& state) {
-    const int m = state.range(0);
-    const int n = state.range(1);
-    
-    auto matrix = Matrix<T>::Random(m, n, false);  // Generate random matrix
-    UnifiedVector<T> tau(std::min(m, n));
-
-    // Create queue based on backend parameter
-    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
-
-    // Get buffer size and allocate workspace
-    size_t buffer_size = geqrf_buffer_size<B>(queue, matrix.view(), tau.to_span());
-    UnifiedVector<std::byte> workspace(buffer_size);
-    
-    for (auto _ : state) {
-        state.PauseTiming();
-        auto matrix_copy = matrix;  // Reset matrix for each iteration
-        state.ResumeTiming();
-        geqrf<B>(queue, matrix_copy.view(), tau.to_span(), workspace.to_span());
-        queue.wait();
-        benchmark::DoNotOptimize(matrix_copy.data());
-        benchmark::DoNotOptimize(tau.data());
-    }
-    
-    state.SetComplexityN(m * n * std::min(m, n));
-    state.counters["GFLOPS"] = benchmark::Counter(1e-9 *
-        (2 * m * n * n + (2.0 / 3.0) * n * n * n),
-        benchmark::Counter::kIsRate
-    );
-}
-
-// Batched matrix GEQRF benchmark
-template<typename T, Backend B>
-static void BM_GEQRF_Batched(benchmark::State& state) {
+static void BM_GEQRF(minibench::State& state) {
     const int m = state.range(0);
     const int n = state.range(1);
     const int batch_size = state.range(2);
-    
+
     auto matrices = Matrix<T>::Random(m, n, false, batch_size);
-    UnifiedVector<T> taus(batch_size * std::min(m, n));
-    
+    UnifiedVector<T> tau(batch_size * std::min(m, n));
+
     // Create queue based on backend parameter
     Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
 
     // Get buffer size and allocate workspace
-    size_t buffer_size = geqrf_buffer_size<B>(queue, matrices.view(), taus.to_span());
+    size_t buffer_size = geqrf_buffer_size<B>(queue, matrices.view(), tau.to_span());
     UnifiedVector<std::byte> workspace(buffer_size);
-
+    
     for (auto _ : state) {
         state.PauseTiming();
         auto matrices_copy = matrices;  // Reset matrices for each iteration
         state.ResumeTiming();
-        geqrf<B>(queue, matrices_copy.view(), taus.to_span(), workspace.to_span());
+        geqrf<B>(queue, matrices_copy.view(), tau.to_span(), workspace.to_span());
         queue.wait();
-        benchmark::DoNotOptimize(matrices_copy.data());
-        benchmark::DoNotOptimize(taus.data());
     }
-    
     state.SetComplexityN(batch_size * m * n * std::min(m, n));
-    state.counters["GFLOPS"] = benchmark::Counter(
-        1e-9 * batch_size * (2 * m * n * n + (2.0 / 3.0) * n * n * n),
-        benchmark::Counter::kIsRate
-    );
-    state.counters["BatchSize"] = batch_size;
+    state.SetMetric("GFLOPS", batch_size * (1e-9 * (2 * m * n * n + (2.0 / 3.0) * n * n * n)), true);
+    state.SetMetric("BatchSize", static_cast<double>(batch_size));
 }
 
-// Register single matrix benchmarks
-BENCHMARK_TEMPLATE(BM_GEQRF_Single, float, batchlas::Backend::NETLIB)
-    ->Apply(bench_utils::SquareSizes);
-BENCHMARK_TEMPLATE(BM_GEQRF_Single, double, batchlas::Backend::NETLIB)
-    ->Apply(bench_utils::SquareSizes);
+static auto* bench_geqrf_f_cpu =
+    minibench::RegisterBenchmark("geqrf_float_cpu", BM_GEQRF<float, Backend::NETLIB>);
+static auto* bench_geqrf_d_cpu =
+    minibench::RegisterBenchmark("geqrf_double_cpu", BM_GEQRF<double, Backend::NETLIB>);
+static auto* bench_geqrf_f_gpu =
+    minibench::RegisterBenchmark("geqrf_float_gpu", BM_GEQRF<float, Backend::CUDA>);
+static auto* bench_geqrf_d_gpu =
+    minibench::RegisterBenchmark("geqrf_double_gpu", BM_GEQRF<double, Backend::CUDA>);
 
-BENCHMARK_TEMPLATE(BM_GEQRF_Single, float, batchlas::Backend::CUDA)
-    ->Apply(bench_utils::SquareSizes);
-BENCHMARK_TEMPLATE(BM_GEQRF_Single, double, batchlas::Backend::CUDA)
-    ->Apply(bench_utils::SquareSizes);
+bench_utils::SquareBatchSizes(bench_geqrf_f_cpu);
+bench_utils::SquareBatchSizes(bench_geqrf_d_cpu);
+bench_utils::SquareBatchSizes(bench_geqrf_f_gpu);
+bench_utils::SquareBatchSizes(bench_geqrf_d_gpu);
 
-// Register batched matrix benchmarks
-BENCHMARK_TEMPLATE(BM_GEQRF_Batched, float, batchlas::Backend::NETLIB)
-    ->Apply(bench_utils::SquareBatchSizes);
-BENCHMARK_TEMPLATE(BM_GEQRF_Batched, double, batchlas::Backend::NETLIB)
-    ->Apply(bench_utils::SquareBatchSizes);
-
-BENCHMARK_TEMPLATE(BM_GEQRF_Batched, float, batchlas::Backend::CUDA)
-    ->Apply(bench_utils::SquareBatchSizes);
-BENCHMARK_TEMPLATE(BM_GEQRF_Batched, double, batchlas::Backend::CUDA)
-    ->Apply(bench_utils::SquareBatchSizes);
-
-BENCHMARK_MAIN();
+MINI_BENCHMARK_MAIN();

--- a/benchmarks/geqrf_benchmark.cc
+++ b/benchmarks/geqrf_benchmark.cc
@@ -27,13 +27,9 @@ static void BM_GEQRF(minibench::State& state) {
     UnifiedVector<std::byte> workspace(buffer_size);
     
     for (auto _ : state) {
-        state.PauseTiming();
-        auto matrices_copy = matrices;  // Reset matrices for each iteration
-        state.ResumeTiming();
-        geqrf<B>(queue, matrices_copy.view(), tau.to_span(), workspace.to_span());
-        queue.wait();
+        geqrf<B>(queue, matrices.view(), tau.to_span(), workspace.to_span());
     }
-    state.SetComplexityN(batch_size * m * n * std::min(m, n));
+    queue.wait();
     state.SetMetric("GFLOPS", batch_size * (1e-9 * (2 * m * n * n + (2.0 / 3.0) * n * n * n)), true);
     state.SetMetric("BatchSize", static_cast<double>(batch_size));
 }

--- a/benchmarks/ormqr_benchmark.cc
+++ b/benchmarks/ormqr_benchmark.cc
@@ -24,13 +24,10 @@ static void BM_ORMQR(minibench::State& state) {
     UnifiedVector<std::byte> ws(orm_ws);
 
     for (auto _ : state) {
-        state.PauseTiming();
-        auto Q_copy = Q;
-        state.ResumeTiming();
-        ormqr<B>(queue, A.view(), Q_copy.view(), Side::Left, Transpose::NoTrans,
+        ormqr<B>(queue, A.view(), Q.view(), Side::Left, Transpose::NoTrans,
                  tau.to_span(), ws.to_span());
-        queue.wait();
     }
+    queue.wait();
     state.SetMetric("GFLOPS", static_cast<double>(batch) * (1e-9 * 4.0 * m * m * m), true);
     state.SetMetric("BatchSize", static_cast<double>(batch));
 }

--- a/benchmarks/ormqr_benchmark.cc
+++ b/benchmarks/ormqr_benchmark.cc
@@ -1,4 +1,4 @@
-#include <benchmark/benchmark.h>
+#include <util/minibench.hh>
 #include <blas/linalg.hh>
 #include "bench_utils.hh"
 
@@ -6,39 +6,7 @@ using namespace batchlas;
 
 // Single ORMQR benchmark
 template <typename T, Backend B>
-static void BM_ORMQR_Single(benchmark::State& state) {
-    const int m = state.range(0);
-
-    auto A = Matrix<T>::Random(m, m, false);
-    UnifiedVector<T> tau(m);
-    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
-    size_t geqrf_ws = geqrf_buffer_size<B>(queue, A.view(), tau.to_span());
-    UnifiedVector<std::byte> ws_geqrf(geqrf_ws);
-    geqrf<B>(queue, A.view(), tau.to_span(), ws_geqrf.to_span());
-    queue.wait();
-
-    auto Q = Matrix<T>::Identity(m);
-    size_t orm_ws = ormqr_buffer_size<B>(queue, A.view(), Q.view(), Side::Left,
-                                         Transpose::NoTrans, tau.to_span());
-    UnifiedVector<std::byte> ws(orm_ws);
-
-    for (auto _ : state) {
-        state.PauseTiming();
-        auto Q_copy = Q;
-        state.ResumeTiming();
-        ormqr<B>(queue, A.view(), Q_copy.view(), Side::Left, Transpose::NoTrans,
-                 tau.to_span(), ws.to_span());
-        queue.wait();
-        benchmark::DoNotOptimize(Q_copy.data());
-    }
-
-    state.counters["GFLOPS"] = benchmark::Counter(1e-9 *
-        4.0 * m * m * m, benchmark::Counter::kIsRate);
-}
-
-// Batched ORMQR benchmark
-template <typename T, Backend B>
-static void BM_ORMQR_Batched(benchmark::State& state) {
+static void BM_ORMQR(minibench::State& state) {
     const int m = state.range(0);
     const int batch = state.range(1);
 
@@ -62,23 +30,23 @@ static void BM_ORMQR_Batched(benchmark::State& state) {
         ormqr<B>(queue, A.view(), Q_copy.view(), Side::Left, Transpose::NoTrans,
                  tau.to_span(), ws.to_span());
         queue.wait();
-        benchmark::DoNotOptimize(Q_copy.data());
     }
-
-    state.counters["GFLOPS"] = benchmark::Counter(1e-9 *
-        static_cast<double>(batch) * 4.0 * m * m * m,
-        benchmark::Counter::kIsRate);
-    state.counters["BatchSize"] = batch;
+    state.SetMetric("GFLOPS", static_cast<double>(batch) * (1e-9 * 4.0 * m * m * m), true);
+    state.SetMetric("BatchSize", static_cast<double>(batch));
 }
 
-BENCHMARK_TEMPLATE(BM_ORMQR_Single, float, Backend::NETLIB)->Apply(bench_utils::SquareSizes);
-BENCHMARK_TEMPLATE(BM_ORMQR_Single, double, Backend::NETLIB)->Apply(bench_utils::SquareSizes);
-BENCHMARK_TEMPLATE(BM_ORMQR_Single, float, Backend::CUDA)->Apply(bench_utils::SquareSizes);
-BENCHMARK_TEMPLATE(BM_ORMQR_Single, double, Backend::CUDA)->Apply(bench_utils::SquareSizes);
+static auto* bench_ormqr_f_cpu =
+    minibench::RegisterBenchmark("ormqr_float_cpu", BM_ORMQR<float, Backend::NETLIB>);
+static auto* bench_ormqr_d_cpu =
+    minibench::RegisterBenchmark("ormqr_double_cpu", BM_ORMQR<double, Backend::NETLIB>);
+static auto* bench_ormqr_f_gpu =
+    minibench::RegisterBenchmark("ormqr_float_gpu", BM_ORMQR<float, Backend::CUDA>);
+static auto* bench_ormqr_d_gpu =
+    minibench::RegisterBenchmark("ormqr_double_gpu", BM_ORMQR<double, Backend::CUDA>);
 
-BENCHMARK_TEMPLATE(BM_ORMQR_Batched, float, Backend::NETLIB)->Apply(bench_utils::SquareBatchSizes);
-BENCHMARK_TEMPLATE(BM_ORMQR_Batched, double, Backend::NETLIB)->Apply(bench_utils::SquareBatchSizes);
-BENCHMARK_TEMPLATE(BM_ORMQR_Batched, float, Backend::CUDA)->Apply(bench_utils::SquareBatchSizes);
-BENCHMARK_TEMPLATE(BM_ORMQR_Batched, double, Backend::CUDA)->Apply(bench_utils::SquareBatchSizes);
+bench_utils::SquareBatchSizes(bench_ormqr_f_cpu);
+bench_utils::SquareBatchSizes(bench_ormqr_d_cpu);
+bench_utils::SquareBatchSizes(bench_ormqr_f_gpu);
+bench_utils::SquareBatchSizes(bench_ormqr_d_gpu);
 
-BENCHMARK_MAIN();
+MINI_BENCHMARK_MAIN();

--- a/benchmarks/ormqr_benchmark.cc
+++ b/benchmarks/ormqr_benchmark.cc
@@ -41,9 +41,9 @@ static auto* bench_ormqr_f_gpu =
 static auto* bench_ormqr_d_gpu =
     minibench::RegisterBenchmark("ormqr_double_gpu", BM_ORMQR<double, Backend::CUDA>);
 
-bench_utils::SquareBatchSizes(bench_ormqr_f_cpu);
-bench_utils::SquareBatchSizes(bench_ormqr_d_cpu);
-bench_utils::SquareBatchSizes(bench_ormqr_f_gpu);
-bench_utils::SquareBatchSizes(bench_ormqr_d_gpu);
+minibench::SquareBatchSizes(bench_ormqr_f_cpu);
+minibench::SquareBatchSizes(bench_ormqr_d_cpu);
+minibench::SquareBatchSizes(bench_ormqr_f_gpu);
+minibench::SquareBatchSizes(bench_ormqr_d_gpu);
 
 MINI_BENCHMARK_MAIN();

--- a/benchmarks/spmm_benchmark.cc
+++ b/benchmarks/spmm_benchmark.cc
@@ -42,9 +42,9 @@ static auto* bench_spmm_f_gpu =
 static auto* bench_spmm_d_gpu =
     minibench::RegisterBenchmark("spmm_double_gpu", BM_SPMM<double, Backend::CUDA>);
 
-bench_utils::CubeBatchSizes(bench_spmm_f_cpu);
-bench_utils::CubeBatchSizes(bench_spmm_d_cpu);
-bench_utils::CubeBatchSizes(bench_spmm_f_gpu);
-bench_utils::CubeBatchSizes(bench_spmm_d_gpu);
+minibench::CubeBatchSizes(bench_spmm_f_cpu);
+minibench::CubeBatchSizes(bench_spmm_d_cpu);
+minibench::CubeBatchSizes(bench_spmm_f_gpu);
+minibench::CubeBatchSizes(bench_spmm_d_gpu);
 
 MINI_BENCHMARK_MAIN();

--- a/benchmarks/spmm_benchmark.cc
+++ b/benchmarks/spmm_benchmark.cc
@@ -24,14 +24,12 @@ static void BM_SPMM(minibench::State& state) {
     UnifiedVector<std::byte> workspace(ws_size);
 
     for (auto _ : state) {
-        state.PauseTiming();
-        auto C_copy = C;
-        state.ResumeTiming();
-        spmm<B>(queue, A.view(), Bm.view(), C_copy.view(), T(1), T(0),
+        spmm<B>(queue, A.view(), Bm.view(), C.view(), T(1), T(0),
                 Transpose::NoTrans, Transpose::NoTrans, workspace.to_span());
-        queue.wait();
     }
-    state.SetMetric("GFLOPS", static_cast<double>(batch) * (1e-9 * 2.0 * A.nnz() * n), true);
+    queue.wait();
+    state.SetMetric("GFLOPS", static_cast<double>(batch) *
+                        (1e-9 * 2.0 * A.nnz() * n), true);
     state.SetMetric("BatchSize", static_cast<double>(batch));
 }
 

--- a/benchmarks/spmm_benchmark.cc
+++ b/benchmarks/spmm_benchmark.cc
@@ -1,4 +1,4 @@
-#include <benchmark/benchmark.h>
+#include <util/minibench.hh>
 #include <blas/linalg.hh>
 #include "bench_utils.hh"
 
@@ -6,40 +6,7 @@ using namespace batchlas;
 
 // Single SPMM benchmark (CSR * Dense)
 template <typename T, Backend B>
-static void BM_SPMM_Single(benchmark::State& state) {
-    const int m = state.range(0);
-    const int k = state.range(1);
-    const int n = state.range(2);
-
-    // Create random dense matrix and convert to CSR for sparsity
-    auto A_dense = Matrix<T>::Random(m, k, false);
-    auto A = A_dense.template convert_to<MatrixFormat::CSR>();
-    auto Bm = Matrix<T>::Random(k, n, false);
-    auto C = Matrix<T>::Random(m, n, false);
-
-    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
-    size_t ws_size = spmm_buffer_size<B>(queue, A.view(), Bm.view(), C.view(),
-                                        T(1), T(0), Transpose::NoTrans,
-                                        Transpose::NoTrans);
-    UnifiedVector<std::byte> workspace(ws_size);
-
-    for (auto _ : state) {
-        state.PauseTiming();
-        auto C_copy = C;
-        state.ResumeTiming();
-        spmm<B>(queue, A.view(), Bm.view(), C_copy.view(), T(1), T(0),
-                Transpose::NoTrans, Transpose::NoTrans, workspace.to_span());
-        queue.wait();
-        benchmark::DoNotOptimize(C_copy.data());
-    }
-
-    state.counters["GFLOPS"] = benchmark::Counter(1e-9 *
-        2.0 * A.nnz() * n, benchmark::Counter::kIsRate);
-}
-
-// Batched SPMM benchmark
-template <typename T, Backend B>
-static void BM_SPMM_Batched(benchmark::State& state) {
+static void BM_SPMM(minibench::State& state) {
     const int m = state.range(0);
     const int k = state.range(1);
     const int n = state.range(2);
@@ -63,23 +30,23 @@ static void BM_SPMM_Batched(benchmark::State& state) {
         spmm<B>(queue, A.view(), Bm.view(), C_copy.view(), T(1), T(0),
                 Transpose::NoTrans, Transpose::NoTrans, workspace.to_span());
         queue.wait();
-        benchmark::DoNotOptimize(C_copy.data());
     }
-
-    state.counters["GFLOPS"] = benchmark::Counter(1e-9 *
-        static_cast<double>(batch) * 2.0 * A.nnz() * n,
-        benchmark::Counter::kIsRate);
-    state.counters["BatchSize"] = batch;
+    state.SetMetric("GFLOPS", static_cast<double>(batch) * (1e-9 * 2.0 * A.nnz() * n), true);
+    state.SetMetric("BatchSize", static_cast<double>(batch));
 }
 
-BENCHMARK_TEMPLATE(BM_SPMM_Single, float, Backend::NETLIB)->Apply(bench_utils::CubeSizes);
-BENCHMARK_TEMPLATE(BM_SPMM_Single, double, Backend::NETLIB)->Apply(bench_utils::CubeSizes);
-BENCHMARK_TEMPLATE(BM_SPMM_Single, float, Backend::CUDA)->Apply(bench_utils::CubeSizes);
-BENCHMARK_TEMPLATE(BM_SPMM_Single, double, Backend::CUDA)->Apply(bench_utils::CubeSizes);
+static auto* bench_spmm_f_cpu =
+    minibench::RegisterBenchmark("spmm_float_cpu", BM_SPMM<float, Backend::NETLIB>);
+static auto* bench_spmm_d_cpu =
+    minibench::RegisterBenchmark("spmm_double_cpu", BM_SPMM<double, Backend::NETLIB>);
+static auto* bench_spmm_f_gpu =
+    minibench::RegisterBenchmark("spmm_float_gpu", BM_SPMM<float, Backend::CUDA>);
+static auto* bench_spmm_d_gpu =
+    minibench::RegisterBenchmark("spmm_double_gpu", BM_SPMM<double, Backend::CUDA>);
 
-BENCHMARK_TEMPLATE(BM_SPMM_Batched, float, Backend::NETLIB)->Apply(bench_utils::CubeBatchSizes);
-BENCHMARK_TEMPLATE(BM_SPMM_Batched, double, Backend::NETLIB)->Apply(bench_utils::CubeBatchSizes);
-BENCHMARK_TEMPLATE(BM_SPMM_Batched, float, Backend::CUDA)->Apply(bench_utils::CubeBatchSizes);
-BENCHMARK_TEMPLATE(BM_SPMM_Batched, double, Backend::CUDA)->Apply(bench_utils::CubeBatchSizes);
+bench_utils::CubeBatchSizes(bench_spmm_f_cpu);
+bench_utils::CubeBatchSizes(bench_spmm_d_cpu);
+bench_utils::CubeBatchSizes(bench_spmm_f_gpu);
+bench_utils::CubeBatchSizes(bench_spmm_d_gpu);
 
-BENCHMARK_MAIN();
+MINI_BENCHMARK_MAIN();

--- a/benchmarks/trsm_benchmark.cc
+++ b/benchmarks/trsm_benchmark.cc
@@ -16,13 +16,10 @@ static void BM_TRSM(minibench::State& state) {
     Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
 
     for (auto _ : state) {
-        state.PauseTiming();
-        auto B_copy = Bm;
-        state.ResumeTiming();
-        trsm<B>(queue, A.view(), B_copy.view(), Side::Left, Uplo::Lower,
+        trsm<B>(queue, A.view(), Bm.view(), Side::Left, Uplo::Lower,
                 Transpose::NoTrans, Diag::NonUnit, T(1));
-        queue.wait();
     }
+    queue.wait();
     state.SetMetric("GFLOPS", static_cast<double>(batch) * (1e-9 * n * n), true);
     state.SetMetric("BatchSize", static_cast<double>(batch));
 }

--- a/benchmarks/trsm_benchmark.cc
+++ b/benchmarks/trsm_benchmark.cc
@@ -1,4 +1,4 @@
-#include <benchmark/benchmark.h>
+#include <util/minibench.hh>
 #include <blas/linalg.hh>
 #include "bench_utils.hh"
 
@@ -6,31 +6,7 @@ using namespace batchlas;
 
 // Single TRSM benchmark
 template <typename T, Backend B>
-static void BM_TRSM_Single(benchmark::State& state) {
-    const int n = state.range(0);
-
-    auto A = Matrix<T>::Triangular(n, Uplo::Lower, T(1), T(0.5));
-    auto Bm = Matrix<T>::Random(n, n, false);
-
-    Queue queue(B == Backend::NETLIB ? "cpu" : "gpu");
-
-    for (auto _ : state) {
-        state.PauseTiming();
-        auto B_copy = Bm;
-        state.ResumeTiming();
-        trsm<B>(queue, A.view(), B_copy.view(), Side::Left, Uplo::Lower,
-                Transpose::NoTrans, Diag::NonUnit, T(1));
-        queue.wait();
-        benchmark::DoNotOptimize(B_copy.data());
-    }
-
-    state.counters["GFLOPS"] = benchmark::Counter(1e-9 * 1.0 * n * n,
-                                                   benchmark::Counter::kIsRate);
-}
-
-// Batched TRSM benchmark
-template <typename T, Backend B>
-static void BM_TRSM_Batched(benchmark::State& state) {
+static void BM_TRSM(minibench::State& state) {
     const int n = state.range(0);
     const int batch = state.range(1);
 
@@ -46,22 +22,23 @@ static void BM_TRSM_Batched(benchmark::State& state) {
         trsm<B>(queue, A.view(), B_copy.view(), Side::Left, Uplo::Lower,
                 Transpose::NoTrans, Diag::NonUnit, T(1));
         queue.wait();
-        benchmark::DoNotOptimize(B_copy.data());
     }
-
-    state.counters["GFLOPS"] = benchmark::Counter(1e-9 *
-        static_cast<double>(batch) * n * n, benchmark::Counter::kIsRate);
-    state.counters["BatchSize"] = batch;
+    state.SetMetric("GFLOPS", static_cast<double>(batch) * (1e-9 * n * n), true);
+    state.SetMetric("BatchSize", static_cast<double>(batch));
 }
 
-BENCHMARK_TEMPLATE(BM_TRSM_Single, float, Backend::NETLIB)->Apply(bench_utils::SquareSizes);
-BENCHMARK_TEMPLATE(BM_TRSM_Single, double, Backend::NETLIB)->Apply(bench_utils::SquareSizes);
-BENCHMARK_TEMPLATE(BM_TRSM_Single, float, Backend::CUDA)->Apply(bench_utils::SquareSizes);
-BENCHMARK_TEMPLATE(BM_TRSM_Single, double, Backend::CUDA)->Apply(bench_utils::SquareSizes);
+static auto* bench_trsm_f_cpu =
+    minibench::RegisterBenchmark("trsm_float_cpu", BM_TRSM<float, Backend::NETLIB>);
+static auto* bench_trsm_d_cpu =
+    minibench::RegisterBenchmark("trsm_double_cpu", BM_TRSM<double, Backend::NETLIB>);
+static auto* bench_trsm_f_gpu =
+    minibench::RegisterBenchmark("trsm_float_gpu", BM_TRSM<float, Backend::CUDA>);
+static auto* bench_trsm_d_gpu =
+    minibench::RegisterBenchmark("trsm_double_gpu", BM_TRSM<double, Backend::CUDA>);
 
-BENCHMARK_TEMPLATE(BM_TRSM_Batched, float, Backend::NETLIB)->Apply(bench_utils::SquareBatchSizes);
-BENCHMARK_TEMPLATE(BM_TRSM_Batched, double, Backend::NETLIB)->Apply(bench_utils::SquareBatchSizes);
-BENCHMARK_TEMPLATE(BM_TRSM_Batched, float, Backend::CUDA)->Apply(bench_utils::SquareBatchSizes);
-BENCHMARK_TEMPLATE(BM_TRSM_Batched, double, Backend::CUDA)->Apply(bench_utils::SquareBatchSizes);
+bench_utils::SquareBatchSizes(bench_trsm_f_cpu);
+bench_utils::SquareBatchSizes(bench_trsm_d_cpu);
+bench_utils::SquareBatchSizes(bench_trsm_f_gpu);
+bench_utils::SquareBatchSizes(bench_trsm_d_gpu);
 
-BENCHMARK_MAIN();
+MINI_BENCHMARK_MAIN();

--- a/benchmarks/trsm_benchmark.cc
+++ b/benchmarks/trsm_benchmark.cc
@@ -1,6 +1,5 @@
 #include <util/minibench.hh>
 #include <blas/linalg.hh>
-#include "bench_utils.hh"
 
 using namespace batchlas;
 
@@ -33,9 +32,9 @@ static auto* bench_trsm_f_gpu =
 static auto* bench_trsm_d_gpu =
     minibench::RegisterBenchmark("trsm_double_gpu", BM_TRSM<double, Backend::CUDA>);
 
-bench_utils::SquareBatchSizes(bench_trsm_f_cpu);
-bench_utils::SquareBatchSizes(bench_trsm_d_cpu);
-bench_utils::SquareBatchSizes(bench_trsm_f_gpu);
-bench_utils::SquareBatchSizes(bench_trsm_d_gpu);
+minibench::SquareBatchSizes(bench_trsm_f_cpu);
+minibench::SquareBatchSizes(bench_trsm_d_cpu);
+minibench::SquareBatchSizes(bench_trsm_f_gpu);
+minibench::SquareBatchSizes(bench_trsm_d_gpu);
 
 MINI_BENCHMARK_MAIN();

--- a/include/util/minibench.hh
+++ b/include/util/minibench.hh
@@ -464,5 +464,52 @@ inline int MiniBenchMain(int argc, char** argv) {
         return minibench::MiniBenchMain(argc, argv); \
     }
 
+
+template <typename Benchmark>
+inline void SquareSizes(Benchmark* b) {
+    for (int s : {64, 128, 256, 512, 1024, 2048, 4096, 8192}) {
+        b->Args({s, s});
+    }
+}
+
+template <typename Benchmark>
+inline void SquareBatchSizes(Benchmark* b) {
+    for (int s : {64, 128, 256}) {
+        b->Args({s, s, 1});
+    }
+    for (int s : {64, 128, 256}) {
+        b->Args({s, s, 10});
+    }
+    for (int s : {64, 128, 256, 512}) {
+        b->Args({s, s, 100});
+    }
+    for (int s : {64, 128, 256, 512, 1024}) {
+        b->Args({s, s, 1000});
+    }
+}
+
+template <typename Benchmark>
+inline void CubeSizes(Benchmark* b) {
+    for (int s : {64, 128, 256, 512, 1024, 2048, 4096, 8192}) {
+        b->Args({s, s, s});
+    }
+}
+
+template <typename Benchmark>
+inline void CubeBatchSizes(Benchmark* b) {
+    for (int s : {64, 128, 256}) {
+        b->Args({s, s, s, 1});
+    }
+    for (int s : {64, 128, 256}) {
+        b->Args({s, s, s, 10});
+    }
+    for (int s : {64, 128, 256, 512}) {
+        b->Args({s, s, s, 100});
+    }
+    for (int s : {64, 128, 256, 512, 1024}) {
+        b->Args({s, s, s, 1000});
+    }
+}
+
 } // namespace minibench
 


### PR DESCRIPTION
## Summary
- swap benchmark utility to use mini-bench API
- convert benchmark sources to the mini-bench framework
- remove google-benchmark linking from benchmark CMakeLists

## Testing
- `cmake ..` *(fails: LAPACKE library not found)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad28584a08325b62fc4bc79ee4dc6