### PR TITLE
Enable CLI size override for benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,16 @@ Benchmark executables are built in the `benchmarks` directory. Each benchmark
 registers a default set of input sizes, but you can override these at runtime by
 providing custom sizes on the command line. Arguments may be integers,
 comma&#8209;separated lists or `start:end:num` ranges. When custom sizes are
-supplied they replace the registered ones for all benchmarks.
+supplied they replace the registered ones for all benchmarks. You can further
+limit execution to specific backends or floating point types using the
+`--backend` and `--type` options.
 
 Example:
 
 ```bash
 ./gemm_benchmark 512 512 128 10
 ./gemm_benchmark 64:256:4 64:256:4 64:256:4 1,2,4
+./gemm_benchmark --backend=CUDA --type=float 256 256 64 8
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ BatchLAS automatically selects the most suitable backend for your hardware, but 
 gemm<Backend::CUDA>(ctx, A, B, C, alpha, beta, Transpose::NoTrans, Transpose::NoTrans);
 ```
 
+## Benchmarks
+
+Benchmark executables are built in the `benchmarks` directory. Each benchmark
+registers a default set of input sizes, but you can override these at runtime by
+providing custom sizes on the command line. Arguments may be integers,
+comma&#8209;separated lists or `start:end:num` ranges. When custom sizes are
+supplied they replace the registered ones for all benchmarks.
+
+Example:
+
+```bash
+./gemm_benchmark 512 512 128 10
+./gemm_benchmark 64:256:4 64:256:4 64:256:4 1,2,4
+```
+
 ## License
 
 TBD

--- a/include/blas/enums.hh
+++ b/include/blas/enums.hh
@@ -1,4 +1,5 @@
 #pragma once
+#include <complex>
 namespace batchlas {
     template<typename T>
     struct base_type {

--- a/include/util/minibench.hh
+++ b/include/util/minibench.hh
@@ -470,7 +470,7 @@ inline CliOptions ParseCommandLine(int argc, char** argv) {
 inline int MiniBenchMain(int argc, char** argv) {
     auto opts = ParseCommandLine(argc, argv);
     for (auto& b : registry()) {
-        if (!opts.args_list.empty() && b.args_list.empty()) {
+        if (!opts.args_list.empty()) {
             b.args_list = opts.args_list;
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_TARGETS
     util_span_tests
     util_vector_tests
     util_device_queue_tests
+    minibench_cli_tests
     gemm_tests
     syevx_tests
     lanczos_tests

--- a/tests/minibench_cli_tests.cc
+++ b/tests/minibench_cli_tests.cc
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include <util/minibench.hh>
+
+static int last_arg = 0;
+
+static void dummy_bench(minibench::State& state) {
+    last_arg = state.range(0);
+}
+
+// Register default size which will be overridden
+MINI_BENCHMARK_REGISTER_SIZES((dummy_bench), [](auto* b){ b->Args({1}); });
+
+TEST(MiniBenchCliTest, OverridesRegisteredArgs) {
+    const char* argv[] = {"prog", "5"};
+    int argc = 2;
+    auto opts = minibench::ParseCommandLine(argc, const_cast<char**>(argv));
+
+    // Apply CLI sizes to all benchmarks
+    for (auto& b : minibench::registry()) {
+        if (!opts.args_list.empty()) {
+            b.args_list = opts.args_list;
+        }
+    }
+
+    ASSERT_EQ(minibench::registry().size(), 1u);
+    auto& bench = minibench::registry().front();
+    ASSERT_EQ(bench.args_list.size(), 1u);
+    EXPECT_EQ(bench.args_list[0][0], 5);
+
+    last_arg = 0;
+    minibench::run_benchmark(bench, bench.args_list[0], opts.cfg);
+    EXPECT_EQ(last_arg, 5);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/minibench_cli_tests.cc
+++ b/tests/minibench_cli_tests.cc
@@ -1,35 +1,58 @@
 #include <gtest/gtest.h>
 #include <util/minibench.hh>
+#include <blas/enums.hh>
 
 static int last_arg = 0;
-
-static void dummy_bench(minibench::State& state) {
-    last_arg = state.range(0);
-}
-
-// Register default size which will be overridden
+static void dummy_bench(minibench::State& state) { last_arg = state.range(0); }
 MINI_BENCHMARK_REGISTER_SIZES((dummy_bench), [](auto* b){ b->Args({1}); });
+
+// Benchmarks used for backend/type filtering
+static int called_fc = 0;
+static int called_dn = 0;
+
+template <typename T, batchlas::Backend B>
+static void typed_bench(minibench::State&) {}
+
+template <>
+void typed_bench<float, batchlas::Backend::CUDA>(minibench::State&) { ++called_fc; }
+
+template <>
+void typed_bench<double, batchlas::Backend::NETLIB>(minibench::State&) { ++called_dn; }
+
+MINI_BENCHMARK_REGISTER_SIZES((typed_bench<float, batchlas::Backend::CUDA>), [](auto* b){ b->Args({1}); });
+MINI_BENCHMARK_REGISTER_SIZES((typed_bench<double, batchlas::Backend::NETLIB>), [](auto* b){ b->Args({1}); });
 
 TEST(MiniBenchCliTest, OverridesRegisteredArgs) {
     const char* argv[] = {"prog", "5"};
     int argc = 2;
     auto opts = minibench::ParseCommandLine(argc, const_cast<char**>(argv));
 
-    // Apply CLI sizes to all benchmarks
     for (auto& b : minibench::registry()) {
-        if (!opts.args_list.empty()) {
+        if (b.name.find("dummy_bench") != std::string::npos && !opts.args_list.empty())
             b.args_list = opts.args_list;
-        }
     }
 
-    ASSERT_EQ(minibench::registry().size(), 1u);
-    auto& bench = minibench::registry().front();
+    auto it = std::find_if(minibench::registry().begin(), minibench::registry().end(),
+                           [](const auto& b){ return b.name.find("dummy_bench") != std::string::npos; });
+    ASSERT_NE(it, minibench::registry().end());
+    auto& bench = *it;
     ASSERT_EQ(bench.args_list.size(), 1u);
     EXPECT_EQ(bench.args_list[0][0], 5);
 
     last_arg = 0;
     minibench::run_benchmark(bench, bench.args_list[0], opts.cfg);
     EXPECT_EQ(last_arg, 5);
+}
+
+TEST(MiniBenchCliTest, BackendTypeFiltering) {
+    const char* argv[] = {"prog", "--backend=NETLIB", "--type=double"};
+    int argc = 3;
+    auto opts = minibench::ParseCommandLine(argc, const_cast<char**>(argv));
+
+    minibench::RunRegisteredBenchmarks(opts.cfg, "", opts.backends, opts.types);
+
+    EXPECT_EQ(called_fc, 0);
+    EXPECT_GT(called_dn, 0);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## Summary
- allow command line size arguments to override registered benchmark sizes
- document benchmark usage in README
- add unit test for CLI size override

## Testing
- `cmake -B build -DCMAKE_BUILD_TYPE=Release -DBATCHLAS_BUILD_PYTHON=OFF` *(fails: Intel SYCL compiler missing)*
- `cmake --build build -j$(nproc)` *(fails: unrecognized option `-fsycl`)*
- `ctest --test-dir build` *(fails: executables not built)*

------
https://chatgpt.com/codex/tasks/task_e_684ee7e65f488325b82c4f06fbcc8049