### PR TITLE
Run tests only for compiled backends

### DIFF
--- a/benchmarks/gemm_benchmark.cc
+++ b/benchmarks/gemm_benchmark.cc
@@ -1,6 +1,7 @@
 #include <util/minibench.hh>
 #include <blas/linalg.hh>
 #include "bench_utils.hh"
+#include <batchlas/backend_config.h>
 
 using namespace batchlas;
 
@@ -31,9 +32,21 @@ static void BM_GEMM(minibench::State& state) {
 
 
 // Register size/batch combinations at static‑init time using macro
+#ifdef BATCHLAS_HAS_CUDA_BACKEND
 MINI_BENCHMARK_REGISTER_SIZES((BM_GEMM<float, Backend::CUDA>), CubeBatchSizes);
 MINI_BENCHMARK_REGISTER_SIZES((BM_GEMM<double, Backend::CUDA>), CubeBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_ROCM_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_GEMM<float, Backend::ROCM>), CubeBatchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_GEMM<double, Backend::ROCM>), CubeBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_MKL_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_GEMM<float, Backend::MKL>), CubeBatchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_GEMM<double, Backend::MKL>), CubeBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_HOST_BACKEND
 MINI_BENCHMARK_REGISTER_SIZES((BM_GEMM<float, Backend::NETLIB>), CubeBatchSizesNetlib);
 MINI_BENCHMARK_REGISTER_SIZES((BM_GEMM<double, Backend::NETLIB>), CubeBatchSizesNetlib);
+#endif
 
 MINI_BENCHMARK_MAIN();

--- a/benchmarks/gemm_custom.cc
+++ b/benchmarks/gemm_custom.cc
@@ -1,10 +1,13 @@
 #include <blas/linalg.hh>
 #include <util/minibench.hh>
+#include <batchlas/backend_config.h>
 
 using namespace batchlas;
 
+#if BATCHLAS_HAS_CUDA_BACKEND
 MINI_BENCHMARK(gemm_custom);
 
+#if BATCHLAS_HAS_CUDA_BACKEND
 static void gemm_custom(minibench::State& state) {
     state.PauseTiming();
     size_t m = state.range(0);
@@ -27,10 +30,12 @@ static void gemm_custom(minibench::State& state) {
     queue.wait();
     state.StopTiming();
 }
-
+#endif
+#if BATCHLAS_HAS_CUDA_BACKEND
 static auto* bench_cfg = BENCHMARK_gemm_custom
     ->Args({32, 32, 32, 1280}) ->Args({64, 64, 64, 1280})
     ->Args({128, 128, 128, 1280}) ->Args({256, 256, 256, 1280})
     ->Args({512, 512, 512, 1280}) ->Args({1024, 1024, 1024, 1280});
 
 MINI_BENCHMARK_MAIN();
+#endif

--- a/benchmarks/gemv_benchmark.cc
+++ b/benchmarks/gemv_benchmark.cc
@@ -1,6 +1,7 @@
 #include <util/minibench.hh>
 #include <blas/linalg.hh>
 #include "bench_utils.hh"
+#include <batchlas/backend_config.h>
 
 using namespace batchlas;
 
@@ -30,9 +31,21 @@ static void BM_GEMV(minibench::State& state) {
 }
 
 
+#ifdef BATCHLAS_HAS_CUDA_BACKEND
 MINI_BENCHMARK_REGISTER_SIZES((BM_GEMV<float, Backend::CUDA>), SquareBatchSizes);
 MINI_BENCHMARK_REGISTER_SIZES((BM_GEMV<double, Backend::CUDA>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_ROCM_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_GEMV<float, Backend::ROCM>), SquareBatchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_GEMV<double, Backend::ROCM>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_MKL_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_GEMV<float, Backend::MKL>), SquareBatchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_GEMV<double, Backend::MKL>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_HOST_BACKEND
 MINI_BENCHMARK_REGISTER_SIZES((BM_GEMV<float, Backend::NETLIB>), SquareBatchSizesNetlib);
 MINI_BENCHMARK_REGISTER_SIZES((BM_GEMV<double, Backend::NETLIB>), SquareBatchSizesNetlib);
+#endif
 
 MINI_BENCHMARK_MAIN();

--- a/benchmarks/geqrf_benchmark.cc
+++ b/benchmarks/geqrf_benchmark.cc
@@ -1,6 +1,7 @@
 #include <util/minibench.hh>
 #include <blas/linalg.hh>
 #include "bench_utils.hh"
+#include <batchlas/backend_config.h>
 #include <vector>
 #include <random>
 #include <memory>
@@ -37,9 +38,21 @@ static void BM_GEQRF(minibench::State& state) {
 }
 
 
+#ifdef BATCHLAS_HAS_CUDA_BACKEND
 MINI_BENCHMARK_REGISTER_SIZES((BM_GEQRF<float, Backend::CUDA>), SquareBatchSizes);
 MINI_BENCHMARK_REGISTER_SIZES((BM_GEQRF<double, Backend::CUDA>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_ROCM_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_GEQRF<float, Backend::ROCM>), SquareBatchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_GEQRF<double, Backend::ROCM>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_MKL_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_GEQRF<float, Backend::MKL>), SquareBatchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_GEQRF<double, Backend::MKL>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_HOST_BACKEND
 MINI_BENCHMARK_REGISTER_SIZES((BM_GEQRF<float, Backend::NETLIB>), SquareBatchSizesNetlib);
 MINI_BENCHMARK_REGISTER_SIZES((BM_GEQRF<double, Backend::NETLIB>), SquareBatchSizesNetlib);
+#endif
 
 MINI_BENCHMARK_MAIN();

--- a/benchmarks/lanczos_benchmark.cc
+++ b/benchmarks/lanczos_benchmark.cc
@@ -1,6 +1,7 @@
 #include <util/minibench.hh>
 #include <blas/functions.hh>
 #include <blas/extensions.hh>
+#include <batchlas/backend_config.h>
 using namespace batchlas;
 
 // Symmetric eigenvalue decomposition benchmark
@@ -35,9 +36,21 @@ static void BM_LANCZOS(minibench::State& state) {
     state.SetMetric("Time (µs) / Batch", (1.0 / batch) * time * 1e3, false);
 }
 
+#ifdef BATCHLAS_HAS_CUDA_BACKEND
 MINI_BENCHMARK_REGISTER_SIZES((BM_LANCZOS<float, Backend::CUDA>), SquareBatchSizes);
 MINI_BENCHMARK_REGISTER_SIZES((BM_LANCZOS<double, Backend::CUDA>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_ROCM_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_LANCZOS<float, Backend::ROCM>), SquareBatchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_LANCZOS<double, Backend::ROCM>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_MKL_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_LANCZOS<float, Backend::MKL>), SquareBatchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_LANCZOS<double, Backend::MKL>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_HOST_BACKEND
 //MINI_BENCHMARK_REGISTER_SIZES((BM_LANCZOS<float, Backend::NETLIB>), SquareBatchSizesNetlib);
 //MINI_BENCHMARK_REGISTER_SIZES((BM_LANCZOS<double, Backend::NETLIB>), SquareBatchSizesNetlib);
+#endif
 
 MINI_BENCHMARK_MAIN();

--- a/benchmarks/ormqr_benchmark.cc
+++ b/benchmarks/ormqr_benchmark.cc
@@ -1,6 +1,7 @@
 #include <util/minibench.hh>
 #include <blas/linalg.hh>
 #include "bench_utils.hh"
+#include <batchlas/backend_config.h>
 
 using namespace batchlas;
 
@@ -36,9 +37,21 @@ static void BM_ORMQR(minibench::State& state) {
 }
 
 
+#ifdef BATCHLAS_HAS_CUDA_BACKEND
 MINI_BENCHMARK_REGISTER_SIZES((BM_ORMQR<float, Backend::CUDA>), SquareBatchSizes);
 MINI_BENCHMARK_REGISTER_SIZES((BM_ORMQR<double, Backend::CUDA>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_ROCM_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_ORMQR<float, Backend::ROCM>), SquareBatchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_ORMQR<double, Backend::ROCM>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_MKL_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_ORMQR<float, Backend::MKL>), SquareBatchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_ORMQR<double, Backend::MKL>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_HOST_BACKEND
 MINI_BENCHMARK_REGISTER_SIZES((BM_ORMQR<float, Backend::NETLIB>), SquareBatchSizesNetlib);
 MINI_BENCHMARK_REGISTER_SIZES((BM_ORMQR<double, Backend::NETLIB>), SquareBatchSizesNetlib);
+#endif
 
 MINI_BENCHMARK_MAIN();

--- a/benchmarks/spmm_benchmark.cc
+++ b/benchmarks/spmm_benchmark.cc
@@ -1,6 +1,7 @@
 #include <util/minibench.hh>
 #include <blas/linalg.hh>
 #include "bench_utils.hh"
+#include <batchlas/backend_config.h>
 
 using namespace batchlas;
 
@@ -35,9 +36,21 @@ static void BM_SPMM(minibench::State& state) {
 }
 
 
+#ifdef BATCHLAS_HAS_CUDA_BACKEND
 MINI_BENCHMARK_REGISTER_SIZES((BM_SPMM<float, Backend::CUDA>), CubeBatchSizes);
 MINI_BENCHMARK_REGISTER_SIZES((BM_SPMM<double, Backend::CUDA>), CubeBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_ROCM_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_SPMM<float, Backend::ROCM>), CubeBatchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_SPMM<double, Backend::ROCM>), CubeBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_MKL_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_SPMM<float, Backend::MKL>), CubeBatchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_SPMM<double, Backend::MKL>), CubeBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_HOST_BACKEND
 MINI_BENCHMARK_REGISTER_SIZES((BM_SPMM<float, Backend::NETLIB>), CubeBatchSizesNetlib);
 MINI_BENCHMARK_REGISTER_SIZES((BM_SPMM<double, Backend::NETLIB>), CubeBatchSizesNetlib);
+#endif
 
 MINI_BENCHMARK_MAIN();

--- a/benchmarks/syevx_benchmark.cc
+++ b/benchmarks/syevx_benchmark.cc
@@ -1,6 +1,7 @@
 #include <util/minibench.hh>
 #include <blas/extensions.hh>
 #include <blas/functions.hh>
+#include <batchlas/backend_config.h>
 
 using namespace batchlas;
 
@@ -40,9 +41,21 @@ static void BM_SYEVX(minibench::State& state) {
 }
 
 
+#ifdef BATCHLAS_HAS_CUDA_BACKEND
 MINI_BENCHMARK_REGISTER_SIZES((BM_SYEVX<float, Backend::CUDA>), SyevxBenchSizes);
 MINI_BENCHMARK_REGISTER_SIZES((BM_SYEVX<double, Backend::CUDA>), SyevxBenchSizes);
+#endif
+#ifdef BATCHLAS_HAS_ROCM_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_SYEVX<float, Backend::ROCM>), SyevxBenchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_SYEVX<double, Backend::ROCM>), SyevxBenchSizes);
+#endif
+#ifdef BATCHLAS_HAS_MKL_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_SYEVX<float, Backend::MKL>), SyevxBenchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_SYEVX<double, Backend::MKL>), SyevxBenchSizes);
+#endif
+#ifdef BATCHLAS_HAS_HOST_BACKEND
 //MINI_BENCHMARK_REGISTER_SIZES((BM_SYEVX<float, Backend::NETLIB>), SyevxBenchSizesNetlib);
 //MINI_BENCHMARK_REGISTER_SIZES((BM_SYEVX<double, Backend::NETLIB>), SyevxBenchSizesNetlib);
+#endif
 
 MINI_BENCHMARK_MAIN();

--- a/benchmarks/trsm_benchmark.cc
+++ b/benchmarks/trsm_benchmark.cc
@@ -1,5 +1,6 @@
 #include <util/minibench.hh>
 #include <blas/linalg.hh>
+#include <batchlas/backend_config.h>
 
 using namespace batchlas;
 
@@ -25,9 +26,21 @@ static void BM_TRSM(minibench::State& state) {
 }
 
 
+#ifdef BATCHLAS_HAS_CUDA_BACKEND
 MINI_BENCHMARK_REGISTER_SIZES((BM_TRSM<float, Backend::CUDA>), SquareBatchSizes);
 MINI_BENCHMARK_REGISTER_SIZES((BM_TRSM<double, Backend::CUDA>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_ROCM_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_TRSM<float, Backend::ROCM>), SquareBatchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_TRSM<double, Backend::ROCM>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_MKL_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_TRSM<float, Backend::MKL>), SquareBatchSizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_TRSM<double, Backend::MKL>), SquareBatchSizes);
+#endif
+#ifdef BATCHLAS_HAS_HOST_BACKEND
 MINI_BENCHMARK_REGISTER_SIZES((BM_TRSM<float, Backend::NETLIB>), SquareBatchSizesNetlib);
 MINI_BENCHMARK_REGISTER_SIZES((BM_TRSM<double, Backend::NETLIB>), SquareBatchSizesNetlib);
+#endif
 
 MINI_BENCHMARK_MAIN();

--- a/tests/cond_tests.cc
+++ b/tests/cond_tests.cc
@@ -3,10 +3,13 @@
 #include <blas/matrix.hh>
 #include <util/sycl-device-queue.hh>
 #include <util/sycl-vector.hh>
+#include <batchlas/backend_config.h>
 #include <cmath>
 #include <vector>
 
 using namespace batchlas;
+
+#if BATCHLAS_HAS_CUDA_BACKEND
 
 // Typed test fixture for condition number computations
 template <typename T>
@@ -108,4 +111,6 @@ TYPED_TEST(CondTest, DiagonalMatrix) {
         }
     }
 }
+
+#endif // BATCHLAS_HAS_CUDA_BACKEND
 

--- a/tests/gemm_tests.cc
+++ b/tests/gemm_tests.cc
@@ -15,11 +15,35 @@ struct TestConfig {
     static constexpr batchlas::Backend BackendVal = B;
 };
 
+#include <batchlas/backend_config.h>
+
 using GemmTestTypes = ::testing::Types<
+#if BATCHLAS_HAS_HOST_BACKEND
     TestConfig<float, batchlas::Backend::NETLIB>,
-    TestConfig<double, batchlas::Backend::NETLIB>,
+    TestConfig<double, batchlas::Backend::NETLIB>
+#if BATCHLAS_HAS_CUDA_BACKEND || BATCHLAS_HAS_ROCM_BACKEND || BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_CUDA_BACKEND
     TestConfig<float, batchlas::Backend::CUDA>,
-    TestConfig<double, batchlas::Backend::CUDA>>;
+    TestConfig<double, batchlas::Backend::CUDA>
+#if BATCHLAS_HAS_ROCM_BACKEND || BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_ROCM_BACKEND
+    TestConfig<float, batchlas::Backend::ROCM>,
+    TestConfig<double, batchlas::Backend::ROCM>
+#if BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_MKL_BACKEND
+    TestConfig<float, batchlas::Backend::MKL>,
+    TestConfig<double, batchlas::Backend::MKL>
+#endif
+>;
 
 template <typename Config>
 class GemmTest : public ::testing::Test {

--- a/tests/gemv_tests.cc
+++ b/tests/gemv_tests.cc
@@ -18,11 +18,33 @@ struct TestConfig {
 };
 
 // Define the types to be tested
+#include <batchlas/backend_config.h>
 using MyTypes = ::testing::Types<
+#if BATCHLAS_HAS_HOST_BACKEND
     TestConfig<float, batchlas::Backend::NETLIB>,
-    TestConfig<double, batchlas::Backend::NETLIB>,
+    TestConfig<double, batchlas::Backend::NETLIB>
+#if BATCHLAS_HAS_CUDA_BACKEND || BATCHLAS_HAS_ROCM_BACKEND || BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_CUDA_BACKEND
     TestConfig<float, batchlas::Backend::CUDA>,
     TestConfig<double, batchlas::Backend::CUDA>
+#if BATCHLAS_HAS_ROCM_BACKEND || BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_ROCM_BACKEND
+    TestConfig<float, batchlas::Backend::ROCM>,
+    TestConfig<double, batchlas::Backend::ROCM>
+#if BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_MKL_BACKEND
+    TestConfig<float, batchlas::Backend::MKL>,
+    TestConfig<double, batchlas::Backend::MKL>
+#endif
 >;
 
 // Test fixture for GEMV operations using MatrixView/VectorView, now templated

--- a/tests/inverse_tests.cc
+++ b/tests/inverse_tests.cc
@@ -2,9 +2,13 @@
 #include <blas/linalg.hh>
 #include <util/sycl-device-queue.hh>
 #include <util/sycl-vector.hh>
+#include <batchlas/backend_config.h>
 
 using namespace batchlas;
 
+#if BATCHLAS_HAS_CUDA_BACKEND
+
+#if BATCHLAS_HAS_CUDA_BACKEND
 TEST(InverseTest, InverseIdentityCheck) {
     Queue ctx(Device::default_device());
 
@@ -34,6 +38,7 @@ TEST(InverseTest, InverseIdentityCheck) {
         }
     }
 }
+#endif // BATCHLAS_HAS_CUDA_BACKEND
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/tests/lanczos_tests.cc
+++ b/tests/lanczos_tests.cc
@@ -4,12 +4,14 @@
 #include <blas/functions.hh>
 #include <blas/extensions.hh>
 #include <sycl/sycl.hpp>
+#include <batchlas/backend_config.h>
 #include <iostream>
 #include <vector>
 #include <cmath>
 
 
 using namespace batchlas;
+#if BATCHLAS_HAS_CUDA_BACKEND
 // Test fixture for SYEVX operations
 class LanczosTestBase : public ::testing::Test {
 protected:
@@ -301,3 +303,4 @@ int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
+#endif // BATCHLAS_HAS_CUDA_BACKEND

--- a/tests/minibench_cli_tests.cc
+++ b/tests/minibench_cli_tests.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <util/minibench.hh>
 #include <blas/enums.hh>
+#include <batchlas/backend_config.h>
 
 static int last_arg = 0;
 static void dummy_bench(minibench::State& state) { last_arg = state.range(0); }
@@ -13,14 +14,29 @@ static int called_dn = 0;
 template <typename T, batchlas::Backend B>
 static void typed_bench(minibench::State&) {}
 
+#ifdef BATCHLAS_HAS_CUDA_BACKEND
 template <>
 void typed_bench<float, batchlas::Backend::CUDA>(minibench::State&) { ++called_fc; }
+MINI_BENCHMARK_REGISTER_SIZES((typed_bench<float, batchlas::Backend::CUDA>), [](auto* b){ b->Args({1}); });
+#endif
 
+#ifdef BATCHLAS_HAS_ROCM_BACKEND
+template <>
+void typed_bench<float, batchlas::Backend::ROCM>(minibench::State&) { ++called_fc; }
+MINI_BENCHMARK_REGISTER_SIZES((typed_bench<float, batchlas::Backend::ROCM>), [](auto* b){ b->Args({1}); });
+#endif
+
+#ifdef BATCHLAS_HAS_MKL_BACKEND
+template <>
+void typed_bench<float, batchlas::Backend::MKL>(minibench::State&) { ++called_fc; }
+MINI_BENCHMARK_REGISTER_SIZES((typed_bench<float, batchlas::Backend::MKL>), [](auto* b){ b->Args({1}); });
+#endif
+
+#ifdef BATCHLAS_HAS_HOST_BACKEND
 template <>
 void typed_bench<double, batchlas::Backend::NETLIB>(minibench::State&) { ++called_dn; }
-
-MINI_BENCHMARK_REGISTER_SIZES((typed_bench<float, batchlas::Backend::CUDA>), [](auto* b){ b->Args({1}); });
 MINI_BENCHMARK_REGISTER_SIZES((typed_bench<double, batchlas::Backend::NETLIB>), [](auto* b){ b->Args({1}); });
+#endif
 
 TEST(MiniBenchCliTest, OverridesRegisteredArgs) {
     const char* argv[] = {"prog", "5"};
@@ -45,14 +61,37 @@ TEST(MiniBenchCliTest, OverridesRegisteredArgs) {
 }
 
 TEST(MiniBenchCliTest, BackendTypeFiltering) {
+#if BATCHLAS_HAS_HOST_BACKEND
     const char* argv[] = {"prog", "--backend=NETLIB", "--type=double"};
     int argc = 3;
     auto opts = minibench::ParseCommandLine(argc, const_cast<char**>(argv));
-
     minibench::RunRegisteredBenchmarks(opts.cfg, "", opts.backends, opts.types);
-
     EXPECT_EQ(called_fc, 0);
     EXPECT_GT(called_dn, 0);
+#elif BATCHLAS_HAS_CUDA_BACKEND
+    const char* argv[] = {"prog", "--backend=CUDA", "--type=float"};
+    int argc = 3;
+    auto opts = minibench::ParseCommandLine(argc, const_cast<char**>(argv));
+    minibench::RunRegisteredBenchmarks(opts.cfg, "", opts.backends, opts.types);
+    EXPECT_EQ(called_dn, 0);
+    EXPECT_GT(called_fc, 0);
+#elif BATCHLAS_HAS_ROCM_BACKEND
+    const char* argv[] = {"prog", "--backend=ROCM", "--type=float"};
+    int argc = 3;
+    auto opts = minibench::ParseCommandLine(argc, const_cast<char**>(argv));
+    minibench::RunRegisteredBenchmarks(opts.cfg, "", opts.backends, opts.types);
+    EXPECT_EQ(called_dn, 0);
+    EXPECT_GT(called_fc, 0);
+#elif BATCHLAS_HAS_MKL_BACKEND
+    const char* argv[] = {"prog", "--backend=MKL", "--type=float"};
+    int argc = 3;
+    auto opts = minibench::ParseCommandLine(argc, const_cast<char**>(argv));
+    minibench::RunRegisteredBenchmarks(opts.cfg, "", opts.backends, opts.types);
+    EXPECT_EQ(called_dn, 0);
+    EXPECT_GT(called_fc, 0);
+#else
+    GTEST_SKIP() << "No supported backend compiled";
+#endif
 }
 
 int main(int argc, char **argv) {

--- a/tests/orgqr_tests.cc
+++ b/tests/orgqr_tests.cc
@@ -10,11 +10,34 @@ struct OrgqrConfig {
     static constexpr Backend BackendVal = B;
 };
 
+#include <batchlas/backend_config.h>
 using OrgqrTestTypes = ::testing::Types<
+#if BATCHLAS_HAS_HOST_BACKEND
     OrgqrConfig<float, Backend::NETLIB>,
-    OrgqrConfig<double, Backend::NETLIB>,
+    OrgqrConfig<double, Backend::NETLIB>
+#if BATCHLAS_HAS_CUDA_BACKEND || BATCHLAS_HAS_ROCM_BACKEND || BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_CUDA_BACKEND
     OrgqrConfig<float, Backend::CUDA>,
-    OrgqrConfig<double, Backend::CUDA>>;
+    OrgqrConfig<double, Backend::CUDA>
+#if BATCHLAS_HAS_ROCM_BACKEND || BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_ROCM_BACKEND
+    OrgqrConfig<float, Backend::ROCM>,
+    OrgqrConfig<double, Backend::ROCM>
+#if BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_MKL_BACKEND
+    OrgqrConfig<float, Backend::MKL>,
+    OrgqrConfig<double, Backend::MKL>
+#endif
+>;
 
 template <typename Config>
 class OrgqrTest : public ::testing::Test {

--- a/tests/ormqr_tests.cc
+++ b/tests/ormqr_tests.cc
@@ -10,11 +10,34 @@ struct OrmqrConfig {
     static constexpr Backend BackendVal = B;
 };
 
+#include <batchlas/backend_config.h>
 using OrmqrTestTypes = ::testing::Types<
+#if BATCHLAS_HAS_HOST_BACKEND
     OrmqrConfig<float, Backend::NETLIB>,
-    OrmqrConfig<double, Backend::NETLIB>,
+    OrmqrConfig<double, Backend::NETLIB>
+#if BATCHLAS_HAS_CUDA_BACKEND || BATCHLAS_HAS_ROCM_BACKEND || BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_CUDA_BACKEND
     OrmqrConfig<float, Backend::CUDA>,
-    OrmqrConfig<double, Backend::CUDA>>;
+    OrmqrConfig<double, Backend::CUDA>
+#if BATCHLAS_HAS_ROCM_BACKEND || BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_ROCM_BACKEND
+    OrmqrConfig<float, Backend::ROCM>,
+    OrmqrConfig<double, Backend::ROCM>
+#if BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_MKL_BACKEND
+    OrmqrConfig<float, Backend::MKL>,
+    OrmqrConfig<double, Backend::MKL>
+#endif
+>;
 
 template <typename Config>
 class OrmqrTest : public ::testing::Test {

--- a/tests/ortho_tests.cc
+++ b/tests/ortho_tests.cc
@@ -2,11 +2,13 @@
 #include <gtest/gtest.h>
 #include <blas/linalg.hh>
 #include <util/sycl-device-queue.hh>
+#include <batchlas/backend_config.h>
 #include <complex>
 #include <vector>
 #include <iostream>
 
 using namespace batchlas;
+#if BATCHLAS_HAS_CUDA_BACKEND
 
 template <typename T>
 void print_matrix(const MatrixView<T, MatrixFormat::Dense>& mat, const std::string& name) {
@@ -451,3 +453,4 @@ INSTANTIATE_TEST_SUITE_P(
     }
 );
 
+#endif // BATCHLAS_HAS_CUDA_BACKEND

--- a/tests/syevx_tests.cc
+++ b/tests/syevx_tests.cc
@@ -7,8 +7,10 @@
 #include <blas/matrix.hh>
 #include <blas/extensions.hh>
 #include <blas/extra.hh>
+#include <batchlas/backend_config.h>
 
 using namespace batchlas;
+#if BATCHLAS_HAS_CUDA_BACKEND
 // Test fixture for SYEVX operations
 class SyevxOperationsTest : public ::testing::Test {
 protected:
@@ -238,3 +240,4 @@ int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
+#endif // BATCHLAS_HAS_CUDA_BACKEND

--- a/tests/transpose_tests.cc
+++ b/tests/transpose_tests.cc
@@ -2,7 +2,9 @@
 #include <blas/linalg.hh>
 #include <util/sycl-device-queue.hh>
 #include <blas/extra.hh>
+#include <batchlas/backend_config.h>
 using namespace batchlas;
+#if BATCHLAS_HAS_CUDA_BACKEND
 
 template <typename T>
 class TransposeTest : public ::testing::Test {
@@ -88,3 +90,4 @@ TYPED_TEST(TransposeTest, SimpleTranspose) {
     }
 }
 
+#endif // BATCHLAS_HAS_CUDA_BACKEND

--- a/tests/trsm_tests.cc
+++ b/tests/trsm_tests.cc
@@ -18,11 +18,34 @@ struct TestConfig {
     static constexpr batchlas::Backend BackendVal = B;
 };
 
+#include <batchlas/backend_config.h>
 using TrsmTestTypes = ::testing::Types<
+#if BATCHLAS_HAS_HOST_BACKEND
     TestConfig<float, batchlas::Backend::NETLIB>,
-    TestConfig<double, batchlas::Backend::NETLIB>,
+    TestConfig<double, batchlas::Backend::NETLIB>
+#if BATCHLAS_HAS_CUDA_BACKEND || BATCHLAS_HAS_ROCM_BACKEND || BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_CUDA_BACKEND
     TestConfig<float, batchlas::Backend::CUDA>,
-    TestConfig<double, batchlas::Backend::CUDA>>;
+    TestConfig<double, batchlas::Backend::CUDA>
+#if BATCHLAS_HAS_ROCM_BACKEND || BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_ROCM_BACKEND
+    TestConfig<float, batchlas::Backend::ROCM>,
+    TestConfig<double, batchlas::Backend::ROCM>
+#if BATCHLAS_HAS_MKL_BACKEND
+    ,
+#endif
+#endif
+#if BATCHLAS_HAS_MKL_BACKEND
+    TestConfig<float, batchlas::Backend::MKL>,
+    TestConfig<double, batchlas::Backend::MKL>
+#endif
+>;
 
 // Template test fixture for TRSM operations
 template<typename Config>


### PR DESCRIPTION
## Summary
- register unit tests only when the corresponding backend was built
- register benchmarks for all available backends
- update MiniBench CLI tests to work without CUDA/NETLIB

## Testing
- `cmake -B build .`
- `cmake --build build -j` *(fails: unrecognized command-line option `-fsycl`)*
- `ctest --test-dir build` *(fails to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_68595828a82c8325857b19de70535373