### PR TITLE
Improve test utilities with unified tolerance helpers

### DIFF
--- a/tests/cond_tests.cc
+++ b/tests/cond_tests.cc
@@ -27,11 +27,7 @@ protected:
     using real_t = typename base_type<T>::type;
 
     static constexpr real_t tolerance() {
-        if constexpr (std::is_same_v<T, float>) {
-            return 1e-5f;
-        } else {
-            return 1e-10;
-        }
+        return test_utils::tolerance<T>();
     }
 
     // Compute expected condition number for a diagonal matrix

--- a/tests/gemm_tests.cc
+++ b/tests/gemm_tests.cc
@@ -113,7 +113,7 @@ TYPED_TEST(GemmTest, GemmWithIdentityMatrix) {
     this->ctx->wait();
     
     // Verify result (C should be equal to A)
-    ScalarType tol = std::is_same_v<ScalarType, float> ? ScalarType(1e-5) : ScalarType(1e-10);
+    auto tol = test_utils::tolerance<ScalarType>();
     for (size_t i = 0; i < this->rows*this->cols; ++i) {
         EXPECT_NEAR(std::real(this->C_data[i]), std::real(this->A_data[i]), tol) << "Mismatch at index " << i;
     }
@@ -134,7 +134,7 @@ TYPED_TEST(GemmTest, BatchedGemm) {
     
     this->ctx->wait();
 
-    ScalarType tol = std::is_same_v<ScalarType, float> ? ScalarType(1e-5) : ScalarType(1e-10);
+    auto tol = test_utils::tolerance<ScalarType>();
     for (size_t b = 0; b < this->batch_size; ++b) {
         for (size_t i = 0; i < this->rows; ++i) {
             for (size_t j = 0; j < this->cols; ++j) {

--- a/tests/gemv_tests.cc
+++ b/tests/gemv_tests.cc
@@ -124,11 +124,7 @@ protected:
     }
 
     typename base_type<ScalarType>::type get_tolerance() {
-        if constexpr (std::is_same_v<ScalarType, float>) {
-            return 1e-4f;
-        } else {
-            return 1e-7;
-        }
+        return test_utils::tolerance<ScalarType>();
     }
     typename base_type<ScalarType>::type get_rel_error_floor() {
         if constexpr (std::is_same_v<ScalarType, float>) {

--- a/tests/norm_tests.cc
+++ b/tests/norm_tests.cc
@@ -128,11 +128,7 @@ protected:
     
     // Test tolerances based on type
     static constexpr auto tolerance() {
-        if constexpr (std::is_same_v<T, float> || std::is_same_v<T, std::complex<float>>) {
-            return 1e-5f;
-        } else {
-            return 1e-10;
-        }
+        return test_utils::tolerance<T>();
     }
 
     // Small helper to map NormType to a string for readable failure messages

--- a/tests/transpose_tests.cc
+++ b/tests/transpose_tests.cc
@@ -15,9 +15,8 @@ protected:
     }
     std::shared_ptr<Queue> ctx;
 
-    static T tolerance() {
-        if constexpr (std::is_same_v<T, float>) return T(1e-5);
-        else return T(1e-9);
+    static auto tolerance() {
+        return test_utils::tolerance<T>();
     }
 };
 


### PR DESCRIPTION
## Summary
- add `tolerance`, `expect_near`, and `assert_near` helpers in test utilities
- use these helpers in numeric tests
- apply consistent tolerances across test suites

## Testing
- `cmake -B build .` *(passes)*
- `cmake --build build -j` *(fails: `unrecognized command-line option '-fsycl'`)*

------
https://chatgpt.com/codex/tasks/task_e_6863ae692a2c832584814a4fd99392f6