### PR TITLE
Add Jacobi symmetric eigensolver (syev_jacobi_cta) + CTA kernel optimizations

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -32,6 +32,7 @@ set(BENCHMARK_TARGETS
     orgqr_benchmark
     syev_benchmark
     syev_cta_benchmark
+    syev_jacobi_cta_benchmark
     syev_blocked_benchmark
     gesvd_cta_benchmark
     gesvd_blocked_benchmark

--- a/benchmarks/syev_jacobi_cta_benchmark.cc
+++ b/benchmarks/syev_jacobi_cta_benchmark.cc
@@ -1,0 +1,115 @@
+#include <util/minibench.hh>
+
+#include <blas/enums.hh>
+#include <blas/extensions.hh>
+#include <blas/functions.hh>
+
+#include "bench_utils.hh"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+using namespace batchlas;
+
+namespace {
+
+// Head-to-head grid for the Jacobi CTA eigensolver against the
+// tridiagonalization-based syev_cta on identical inputs.
+template <typename Benchmark>
+inline void SyevJacobiCtaBenchSizes(Benchmark* b) {
+    for (int n : {4, 8, 16, 32}) {
+        for (int bs : {64, 256, 1024, 4096}) {
+            for (int jobz : {0, 1}) {
+                for (int wg_mult : {1, 2, 4}) {
+                    b->Args({n, bs, jobz, wg_mult});
+                }
+            }
+        }
+    }
+}
+
+inline JobType parse_jobz(int v) {
+    return (v == 0) ? JobType::NoEigenVectors : JobType::EigenVectors;
+}
+
+} // namespace
+
+template <typename T, Backend B>
+static void BM_SYEV_JACOBI_CTA(minibench::State& state) {
+    const size_t n = state.range(0);
+    const size_t batch = state.range(1);
+    const JobType jobz = parse_jobz(static_cast<int>(state.range(2)));
+    const size_t wg_mult = state.range(3) > 0 ? state.range(3) : 1;
+
+    auto q = std::make_shared<Queue>(B == Backend::NETLIB ? "cpu" : "gpu");
+    auto A = Matrix<T>::Random(n, n, /*hermitian=*/true, batch);
+    UnifiedVector<typename base_type<T>::type> W(n * batch);
+
+    JacobiParams<T> params;
+    params.cta_wg_size_multiplier = wg_mult;
+
+    UnifiedVector<std::byte> workspace(0);
+
+    state.SetKernel(q,
+                    bench::pristine(A),
+                    std::move(W),
+                    jobz,
+                    Uplo::Lower,
+                    std::move(workspace),
+                    params,
+                    [](Queue& q, auto&&... xs) {
+                        syev_jacobi_cta<B, T>(q, std::forward<decltype(xs)>(xs)...);
+                    });
+
+    const double flops = 4.0 / 3.0 * static_cast<double>(n) * n * n;
+    state.SetMetric("GFLOPS", static_cast<double>(batch) * (1e-9 * flops), minibench::Rate);
+    state.SetMetric("Time (µs) / matrix", (1.0 / batch) * 1e6, minibench::Reciprocal);
+}
+
+// Same grid, tridiagonalization-based path, for a direct comparison.
+template <typename T, Backend B>
+static void BM_SYEV_CTA_TRIDIAG_REF(minibench::State& state) {
+    const size_t n = state.range(0);
+    const size_t batch = state.range(1);
+    const JobType jobz = parse_jobz(static_cast<int>(state.range(2)));
+    const size_t wg_mult = state.range(3) > 0 ? state.range(3) : 1;
+
+    auto q = std::make_shared<Queue>(B == Backend::NETLIB ? "cpu" : "gpu");
+    auto A = Matrix<T>::Random(n, n, /*hermitian=*/true, batch);
+    UnifiedVector<typename base_type<T>::type> W(n * batch);
+
+    SteqrParams<T> params;
+    params.cta_wg_size_multiplier = wg_mult;
+
+    const size_t ws_size = syev_cta_buffer_size<B, T>(*q, A.view(), jobz, params);
+    UnifiedVector<std::byte> workspace(ws_size);
+
+    state.SetKernel(q,
+                    bench::pristine(A),
+                    std::move(W),
+                    jobz,
+                    Uplo::Lower,
+                    std::move(workspace),
+                    params,
+                    wg_mult,
+                    [](Queue& q, auto&&... xs) {
+                        syev_cta<B, T>(q, std::forward<decltype(xs)>(xs)...);
+                    });
+
+    const double flops = 4.0 / 3.0 * static_cast<double>(n) * n * n;
+    state.SetMetric("GFLOPS", static_cast<double>(batch) * (1e-9 * flops), minibench::Rate);
+    state.SetMetric("Time (µs) / matrix", (1.0 / batch) * 1e6, minibench::Reciprocal);
+}
+
+#if BATCHLAS_HAS_CUDA_BACKEND
+BATCHLAS_BENCH_CUDA_ALL_TYPES(BM_SYEV_JACOBI_CTA, SyevJacobiCtaBenchSizes);
+BATCHLAS_BENCH_CUDA_ALL_TYPES(BM_SYEV_CTA_TRIDIAG_REF, SyevJacobiCtaBenchSizes);
+#endif
+
+#if BATCHLAS_HAS_ROCM_BACKEND
+BATCHLAS_BENCH_ROCM_ALL_TYPES(BM_SYEV_JACOBI_CTA, SyevJacobiCtaBenchSizes);
+BATCHLAS_BENCH_ROCM_ALL_TYPES(BM_SYEV_CTA_TRIDIAG_REF, SyevJacobiCtaBenchSizes);
+#endif
+
+MINI_BENCHMARK_MAIN();

--- a/include/blas/extensions.hh
+++ b/include/blas/extensions.hh
@@ -901,6 +901,78 @@ namespace batchlas {
                                 JobType jobz,
                                 SteqrParams<T> steqr_params = SteqrParams<T>());
 
+    template <typename T>
+    struct JacobiParams {
+        using Real = typename base_type<T>::type;
+
+        // Multiplier on the relative off-diagonal threshold. A rotation is
+        // applied to pivot pair (p,q) only when
+        //     |a_pq| > tol_multiplier * n * eps * sqrt(|a_pp| * |a_qq|)
+        // so the default of 1 gives a threshold of order n*eps, matching the
+        // criterion of Demmel & Veselic / LAWN 169. This relative form (rather
+        // than the classical absolute test against max|a_kl|) is what yields the
+        // high relative accuracy; raising this trades accuracy for sweeps.
+        Real tol_multiplier = Real(1);
+
+        // Cap on cyclic sweeps. Convergence normally occurs in well under 10;
+        // this is a safety net for pathological inputs.
+        size_t max_sweeps = 30;
+
+        // Sort eigenvalues (and permute eigenvectors to match) on output.
+        bool sort = true;
+        SortOrder sort_order = SortOrder::Ascending;
+
+        // Multiplies the baseline work-group size. Baseline is
+        // LCM(P, sub_group_size) where P is the compile-time partition width
+        // chosen from n; the result is clamped by the device's maximum
+        // work-group size and by available local memory.
+        size_t cta_wg_size_multiplier = 1;
+    };
+
+    /**
+     * @brief CTA-optimized Jacobi symmetric/Hermitian eigen-solver for very small matrices.
+     *
+     * Cyclic two-sided Jacobi run entirely inside a single sub-group partition:
+     * A (and the eigenvector accumulator Z) stay in local memory for the whole
+     * solve, so one kernel launch performs the complete eigendecomposition with
+     * no intermediate global-memory traffic.
+     *
+     * Relative to syev_cta (sytrd_cta -> steqr_cta -> ormqx_cta), this trades
+     * throughput on generic matrices for high *relative* accuracy on graded or
+     * badly scaled input: with the relative stopping criterion the eigenvalue
+     * error is governed by the condition number of the column-equilibrated
+     * matrix rather than that of the tridiagonalized matrix. Note the underlying
+     * theorem (Demmel & Veselic, SIMAX 13(4), 1992) is proved for symmetric
+     * positive definite input; indefinite matrices are solved correctly but do
+     * not inherit the relative-accuracy bound.
+     *
+     * Notes:
+     * - Intended for n <= 32.
+     * - Supports both real symmetric and complex Hermitian inputs.
+     * - Overwrites A with eigenvectors when jobz == EigenVectors; A is left
+     *   untouched when jobz == NoEigenVectors.
+     * - Eigenvalues are returned in ascending order when JacobiParams::sort is
+     *   enabled (default).
+     * - Requires no global workspace; the ws argument is accepted for API
+     *   symmetry and ignored.
+     *
+     * See JACOBI_EIGENSOLVER_PLAN.md for the design rationale and references.
+     */
+    template <Backend B, typename T>
+    Event syev_jacobi_cta(Queue& ctx,
+                          const MatrixView<T, MatrixFormat::Dense>& a_in,
+                          Span<typename base_type<T>::type> eigenvalues,
+                          JobType jobz,
+                          Uplo uplo,
+                          const Span<std::byte>& ws = Span<std::byte>(),
+                          JacobiParams<T> params = JacobiParams<T>());
+
+    template <Backend B, typename T>
+    size_t syev_jacobi_cta_buffer_size(Queue& ctx,
+                                       const MatrixView<T, MatrixFormat::Dense>& a,
+                                       JobType jobz,
+                                       JacobiParams<T> params = JacobiParams<T>());
+
     /**
      * @brief Blocked symmetric/Hermitian eigen-solver (SYEV-like) for medium/large matrices.
      *

--- a/scripts/compare_syev_cta.py
+++ b/scripts/compare_syev_cta.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Compare two syev_cta_benchmark CSV runs.
+
+Reports the best (minimum) avg_ms over the wg-multiplier sweep for each
+(n, batch, jobz, uplo) case, so tuning noise in `arg4` does not hide the
+underlying kernel change.
+
+Usage: compare_syev_cta.py BASE.csv NEW.csv
+"""
+import csv
+import sys
+from collections import defaultdict
+
+
+def best_by_case(path):
+    best = defaultdict(lambda: float("inf"))
+    with open(path, newline="") as fh:
+        for row in csv.DictReader(fh):
+            key = (int(row["arg0"]), int(row["arg1"]), int(row["arg2"]), int(row["arg3"]))
+            best[key] = min(best[key], float(row["avg_ms"]))
+    return best
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(__doc__)
+    base, new = best_by_case(sys.argv[1]), best_by_case(sys.argv[2])
+
+    print(f"{'n':>4} {'batch':>7} {'jobz':>5} {'uplo':>5} "
+          f"{'base ms':>10} {'new ms':>10} {'speedup':>8}")
+    total_base = total_new = 0.0
+    for key in sorted(set(base) & set(new)):
+        b, x = base[key], new[key]
+        total_base += b
+        total_new += x
+        print(f"{key[0]:>4} {key[1]:>7} {key[2]:>5} {key[3]:>5} "
+              f"{b:>10.5f} {x:>10.5f} {b / x:>7.2f}x")
+    if total_new:
+        print(f"{'':>4} {'':>7} {'':>5} {'TOTAL':>5} "
+              f"{total_base:>10.5f} {total_new:>10.5f} {total_base / total_new:>7.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/extensions/CMakeLists.txt
+++ b/src/extensions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(EXTENSIONS_CTA_SOURCES
     stedc_merge_cta.cc
     sytrd_cta.cc
     sytrd_sb2st_cta.cc
+    syev_jacobi_cta.cc
 )
 
 set(EXTENSIONS_EIGEN_SOURCES

--- a/src/extensions/latrd_lower_panel.cc
+++ b/src/extensions/latrd_lower_panel.cc
@@ -151,11 +151,6 @@ Event latrd_lower_panel_batched_wg_legacy(Queue& q,
                 auto Ab = A_view.batch_item(b);
                 auto Wb = W_view.batch_item(b);
 
-                auto Ah = [&](int r, int c) -> T {
-                    if (r >= c) return Ab(r, c);
-                    return conj_if_needed(Ab(c, r));
-                };
-
                 for (int i = 0; i < ib; ++i) {
                     if (i >= n - 1) break;
 
@@ -265,11 +260,45 @@ Event latrd_lower_panel_batched_wg_legacy(Queue& q,
                     const int col = i;
 
                     for (int r = i + 1 + lid; r < n; r += wg) {
+                        // Symmetric mat-vec: acc = sum_c Ah(r,c) * v(c), where
+                        // Ah(r,c) is Ab(r,c) for c <= r and conj(Ab(c,r)) for c > r.
+                        //
+                        // Ascending c crosses that boundary exactly once, at c == r,
+                        // so the loop splits into two contiguous ranges without
+                        // changing the accumulation order (results stay bit-identical).
+                        // Removing the per-element branch lets the compiler unroll and
+                        // keep several independent loads in flight; this kernel is
+                        // memory-latency bound, so memory-level parallelism is what
+                        // matters here.
+                        //
+                        // Measured alternatives that were all slower and rejected:
+                        //   - unroll 8, and processing two rows per iteration: both
+                        //     cost more registers than the added parallelism returns.
+                        //   - computing the c > r term with one sub-group per column
+                        //     (fully coalesced, 20 -> 9.7 sectors/request): the extra
+                        //     barrier destroys reuse between the two passes and short
+                        //     columns near r -> n leave most lanes idle, so DRAM
+                        //     traffic and runtime both rose.
+                        const int c_split = sycl::min(r, n - 1);
+
                         T acc = T(0);
-                        for (int c = i + 1; c < n; ++c) {
-                            const T vc = v_local[c];
-                            acc += Ah(r, c) * vc;
+
+                        // c in [i+1, r]: walk row r of the lower triangle.
+                        // Consecutive threads hold consecutive r, so each step is a
+                        // coalesced access across the warp.
+                        #pragma unroll 4
+                        for (int c = i + 1; c <= c_split; ++c) {
+                            acc += Ab(r, c) * v_local[c];
                         }
+
+                        // c in (r, n): walk column r of the lower triangle.
+                        // Contiguous per thread, so successive iterations reuse the
+                        // same cache lines.
+                        #pragma unroll 4
+                        for (int c = c_split + 1; c < n; ++c) {
+                            acc += conj_if_needed(Ab(c, r)) * v_local[c];
+                        }
+
                         wcol_local[r] = acc;
                     }
 

--- a/src/extensions/ormqr_cta.cc
+++ b/src/extensions/ormqr_cta.cc
@@ -209,6 +209,18 @@ inline void ormqx_cta_impl(Queue& ctx,
             // LEFT specialization: lane->column and keep that column in registers.
             auto V_local = sycl::local_accessor<T, 1>(sycl::range<1>(probs_per_wg * P), cgh);
 
+            // Coalescing: lane j owns column j, and a column is contiguous in memory.
+            // Consecutive lanes are therefore `ld` elements apart, so a scalar per-row
+            // load/store issues one 32-sector request per instruction (8x more L1<->L2
+            // traffic than the data requires). Moving 16 bytes per lane per access cuts
+            // the request count - and the resulting L2 traffic - by a factor of VW.
+            constexpr int32_t VW = static_cast<int32_t>(16 / sizeof(T));
+            const bool vec_ok =
+                !internal::is_complex<T>::value && VW > 1 && (n % VW) == 0 &&
+                ((static_cast<std::size_t>(c.ld()) * sizeof(T)) % 16u) == 0 &&
+                ((static_cast<std::size_t>(c.stride()) * sizeof(T)) % 16u) == 0 &&
+                (reinterpret_cast<std::uintptr_t>(c.data_ptr()) % 16u) == 0;
+
             cgh.parallel_for<OrmQxCTAKernel<T, P, QL, Left, TransposeOrConj>>(
                 sycl::nd_range<1>(global_size, wg_size),
                 [=](sycl::nd_item<1> it) {
@@ -234,12 +246,36 @@ inline void ormqx_cta_impl(Queue& ctx,
                 const int32_t j = lane;
 
                 // Register column buffer for column j.
+                //
+                // Every index into `C_col` below is a compile-time constant so that the
+                // array really is promoted to registers.  Indexing it with a runtime
+                // value (the reflector support `offset + r`, or a bound of `n`) forces
+                // the whole array into local memory, and the reflector loop then pays a
+                // dependent L1/global round trip for each of its ~n^2 accesses.
                 T C_col[P];
+#pragma unroll
                 for (int32_t r = 0; r < static_cast<int32_t>(P); ++r) {
-                    if (active_col && r < n) {
-                        C_col[r] = C_prob(r, j);
-                    } else {
-                        C_col[r] = T(0);
+                    C_col[r] = T(0);
+                }
+                if (vec_ok && active_col) {
+                    using VecT = sycl::vec<T, VW>;
+                    auto* col_ptr = reinterpret_cast<const VecT*>(&C_prob(0, j));
+#pragma unroll
+                    for (int32_t r = 0; r < static_cast<int32_t>(P); r += VW) {
+                        if (r < n) {
+                            const VecT v = col_ptr[r / VW];
+#pragma unroll
+                            for (int32_t t = 0; t < VW; ++t) {
+                                C_col[r + t] = v[t];
+                            }
+                        }
+                    }
+                } else if (active_col) {
+#pragma unroll
+                    for (int32_t r = 0; r < static_cast<int32_t>(P); ++r) {
+                        if (r < n) {
+                            C_col[r] = C_prob(r, j);
+                        }
                     }
                 }
 
@@ -268,51 +304,38 @@ inline void ormqx_cta_impl(Queue& ctx,
                     const T tau_i = (ii >= 0 && ii < k) ? TAU_prob(ii) : T(0);
                     const T tau_eff = TransposeOrConj ? detail::conj_val(tau_i) : tau_i;
 
-                    // Build v and compute (offset,len) for this reflector.
-                    int32_t offset = 0;
-                    int32_t len = 0;
-
+                    // Stage the reflector indexed by *absolute row*, explicitly zeroed
+                    // outside its support.  The rank-1 update can then run over the
+                    // full compile-time row range with no predication and, crucially,
+                    // with constant `C_col` subscripts.
                     if constexpr (!QL) {
-                        // QR: reflector ii stored in column ii, v has leading zeros of length ii.
-                        offset = ii;
-                        len = n - ii;
-
-                        if (lane < len) {
-                            const int32_t row = offset + lane;
-                            const int32_t col = ii;
-                            V_local[base_v + lane] = (lane == 0) ? T(1) : A_prob(row, col);
-                        } else {
-                            V_local[base_v + lane] = T(0);
-                        }
+                        // QR: reflector ii is stored in column ii with v(ii) == 1 and
+                        // v(0:ii-1) == 0; its support ends at row n-1.
+                        const bool in_support = (lane >= ii) && (lane < n);
+                        V_local[base_v + lane] =
+                            !in_support ? T(0) : ((lane == ii) ? T(1) : A_prob(lane, ii));
                     } else {
-                        // QL: reflector ii is H(ii+1), stored in last k columns.
-                        // From LAPACK DGEQLF/ZGEQLF: v(pivot) = 1, v(pivot+1:m)=0, and v(0:pivot-1)
-                        // stored in A(0:pivot-1, n-k+ii).
+                        // QL: reflector ii is H(ii+1); with m == n the pivot row is
+                        // (n-k)+ii, v(pivot) == 1 and v(pivot+1:) == 0.
                         const int32_t col = (n - k) + ii;
-                        const int32_t pivot = (n - k) + ii; // since m=n in our current restriction
-                        offset = 0;
-                        len = pivot + 1;
-
-                        if (lane < len) {
-                            const int32_t row = lane;
-                            V_local[base_v + lane] = (row == pivot) ? T(1) : A_prob(row, col);
-                        } else {
-                            V_local[base_v + lane] = T(0);
-                        }
+                        const int32_t pivot = (n - k) + ii;
+                        const bool in_support = (lane <= pivot) && (lane < n);
+                        V_local[base_v + lane] =
+                            !in_support ? T(0) : ((lane == pivot) ? T(1) : A_prob(lane, col));
                     }
 
                     group_barrier(part);
 
-                    if (active_col && tau_eff != T(0) && len > 0) {
+                    if (active_col && tau_eff != T(0)) {
                         T dot = T(0);
-                        for (int32_t r = 0; r < len; ++r) {
-                            const T v_r = V_local[base_v + r];
-                            dot += detail::conj_val(v_r) * C_col[offset + r];
+#pragma unroll
+                        for (int32_t r = 0; r < static_cast<int32_t>(P); ++r) {
+                            dot += detail::conj_val(V_local[base_v + r]) * C_col[r];
                         }
                         const T gamma = tau_eff * dot;
-                        for (int32_t r = 0; r < len; ++r) {
-                            const T v_r = V_local[base_v + r];
-                            C_col[offset + r] -= v_r * gamma;
+#pragma unroll
+                        for (int32_t r = 0; r < static_cast<int32_t>(P); ++r) {
+                            C_col[r] -= V_local[base_v + r] * gamma;
                         }
                     }
 
@@ -320,9 +343,26 @@ inline void ormqx_cta_impl(Queue& ctx,
                     group_barrier(part);
                 }
 
-                if (active_col) {
-                    for (int32_t r = 0; r < n; ++r) {
-                        C_prob(r, j) = C_col[r];
+                if (vec_ok && active_col) {
+                    using VecT = sycl::vec<T, VW>;
+                    auto* col_ptr = reinterpret_cast<VecT*>(&C_prob(0, j));
+#pragma unroll
+                    for (int32_t r = 0; r < static_cast<int32_t>(P); r += VW) {
+                        if (r < n) {
+                            VecT v{};
+#pragma unroll
+                            for (int32_t t = 0; t < VW; ++t) {
+                                v[t] = C_col[r + t];
+                            }
+                            col_ptr[r / VW] = v;
+                        }
+                    }
+                } else if (active_col) {
+#pragma unroll
+                    for (int32_t r = 0; r < static_cast<int32_t>(P); ++r) {
+                        if (r < n) {
+                            C_prob(r, j) = C_col[r];
+                        }
                     }
                 }
             });

--- a/src/extensions/steqr_cta.cc
+++ b/src/extensions/steqr_cta.cc
@@ -18,6 +18,60 @@
 
 namespace batchlas {
 
+    // Givens rotation specialised for the real bulge chase.
+    //
+    // On the in-range fast path this is algebraically identical to internal::lartg(),
+    // but it forms the single quantity 1/sqrt(f^2 + g^2) with a hardware reciprocal
+    // square root plus one Newton refinement instead of one IEEE square root and two
+    // IEEE divisions.  The bulge chase calls this once per rotation (O(n^2) times per
+    // problem), and div/sqrt expansion dominated the instruction mix there.
+    // Out-of-range inputs fall back to the fully scaled reference implementation.
+    template <typename T>
+    struct cta_rotation {
+        T c;
+        T s;
+        T r;
+    };
+
+    template <typename T>
+    inline cta_rotation<T> cta_lartg(const T f, const T g) {
+        if constexpr (std::is_same_v<T, float>) {
+            // Range guard.
+            //
+            // The previous formulation tested |f| and |g| separately against
+            // sqrt(safmin) and sqrt(safmax/2): four FSETPs plus three predicate
+            // merges plus a separate `g == 0` early-out, i.e. ~9 instructions on
+            // the hottest path in the solver.  Everything those tests protect is
+            // a property of t = f^2 + g^2 alone, so one interval test on `t`
+            // (which we have to form anyway) is both cheaper and stricter:
+            //   * overflow of f*f or g*g yields t == inf  -> rejected by t < tmax
+            //   * total underflow yields t == 0           -> rejected by t > tmin
+            //   * NaN inputs yield t == NaN               -> both compares false
+            // The `g == 0` case needs no special handling either: it gives
+            // inv = 1/|f|, hence c = 1, s = 0 and r = f exactly.
+            if (g == T(0)) return {T(1), T(0), f};
+
+            const T f_abs = sycl::fabs(f);
+            const T g_abs = sycl::fabs(g);
+
+            const T rtmin = sycl::sqrt(internal::safmin<T>());
+            const T rtmax = sycl::sqrt(internal::safmax<T>() / T(2));
+
+            if (f_abs > rtmin && f_abs < rtmax && g_abs > rtmin && g_abs < rtmax) {
+                const T t = f * f + g * g;
+                T inv = sycl::rsqrt(t);
+                // One fused Newton step brings the hardware estimate below 0.5 ulp.
+                inv = sycl::fma(inv * T(0.5), sycl::fma(-(t * inv), inv, T(1)), inv);
+                const T d = sycl::sqrt(t);
+                const T signed_inv = sycl::copysign(inv, f);
+                return {f_abs * inv, g * signed_inv, sycl::copysign(d, f)};
+            }
+        }
+
+        const auto res = internal::lartg(f, g);
+        return {res.c, res.s, res.r};
+    }
+
     template <typename T>
     inline T wilkinson_shift(const T& a, const T& b, const T& c) {
         // a,b,c represent the 2x2 block:
@@ -42,16 +96,28 @@ namespace batchlas {
         int32_t base_q;
         int32_t lane;
         int32_t n;
+        int32_t idx{};
+        T carry{};
 
         QSharedCache(LocalAcc q, int32_t bq, int32_t ln, int32_t n_)
             : Q_local(q), base_q(bq), lane(ln), n(n_) {}
 
         template <typename QProb>
         inline void load(const QProb& Q_prob) {
-            if (lane >= n) return;
             const int32_t pN = static_cast<int32_t>(P);
-            for (int32_t c = 0; c < n; ++c) {
-                Q_local[base_q + lane + c * pN] = Q_prob(lane, c);
+            // Zero rather than skip the padding rows (lane >= n).  Once every row of
+            // the tile holds a defined value, the chase can run unguarded on all P
+            // lanes: its column indices are always inside the tile, and `store` only
+            // reads back the first n rows.  That removes a divergent branch from the
+            // innermost loop of the solver.
+            if (lane < n) {
+                for (int32_t c = 0; c < n; ++c) {
+                    Q_local[base_q + lane + c * pN] = Q_prob(lane, c);
+                }
+            } else {
+                for (int32_t c = 0; c < n; ++c) {
+                    Q_local[base_q + lane + c * pN] = T(0);
+                }
             }
         }
 
@@ -65,7 +131,6 @@ namespace batchlas {
         }
 
         inline void apply(int32_t col0, int32_t col1, T c, T s) {
-            if (lane >= n) return;
             const int32_t pN = static_cast<int32_t>(P);
             const int32_t i0 = base_q + lane + col0 * pN;
             const int32_t i1 = base_q + lane + col1 * pN;
@@ -73,6 +138,39 @@ namespace batchlas {
             const T q1 = Q_local[i1];
             Q_local[i0] = c * q0 - s * q1;
             Q_local[i1] = s * q0 + c * q1;
+        }
+
+        // Streaming form of `apply` for a bulge chase.
+        //
+        // Successive rotations in a chase always share a column (rotation k writes
+        // columns (a, b) and rotation k+1 reads column b again), so the shared column
+        // can stay in a register.  That halves both the shared-memory traffic and the
+        // address arithmetic of the eigenvector update.
+        //
+        // A chase also visits columns strictly consecutively, so the element index
+        // only ever moves by +/-P between steps.  Keeping it in a register and
+        // advancing it by a compile-time constant turns the per-step address
+        // computation into a single integer add, and lets the partner column be
+        // reached through the load/store instruction's immediate offset.
+        inline void chase_begin(int32_t col) {
+            idx = base_q + lane + col * static_cast<int32_t>(P);
+            carry = Q_local[idx];
+        }
+
+        // Dir is +1 when the chase walks toward higher column indices and -1 when it
+        // walks toward lower ones; the written column is the current one and the read
+        // column is the neighbour in that direction.
+        template <int32_t Dir>
+        inline void chase_step(T c, T s) {
+            const int32_t next = idx + Dir * static_cast<int32_t>(P);
+            const T q1 = Q_local[next];
+            Q_local[idx] = c * carry - s * q1;
+            carry = s * carry + c * q1;
+            idx = next;
+        }
+
+        inline void chase_end(int32_t) {
+            Q_local[idx] = carry;
         }
     };
 
@@ -87,6 +185,10 @@ namespace batchlas {
         inline void store(QProb&) const {}
 
         inline void apply(int32_t, int32_t, T, T) {}
+        inline void chase_begin(int32_t) {}
+        template <int32_t Dir>
+        inline void chase_step(T, T) {}
+        inline void chase_end(int32_t) {}
     };
 
     template <typename T, typename Partition>
@@ -119,84 +221,39 @@ namespace batchlas {
         }
     }
 
-    template <typename T, size_t P, typename Partition, typename LocalAcc>
-    inline void stage_tridiag_to_local(const Partition& partition,
-                                       int32_t n,
-                                       LocalAcc& D_local,
-                                       LocalAcc& E_local,
-                                       int32_t base_d,
-                                       int32_t base_e,
-                                       int32_t lane,
-                                       T diag,
-                                       T offdiag) {
-        // Ensure the whole local tile is initialized.
-        if (lane < n) {
-            D_local[base_d + lane] = diag;
-        } else {
-            D_local[base_d + lane] = T(0);
+    // Butterfly (XOR-shuffle) all-reduce within the partition.
+    //
+    // These replace the previous shared-memory + leader-lane serial loops.  A
+    // butterfly reduction needs log2(P) shuffles, keeps every lane active, and
+    // touches neither local memory nor barriers, which matters because the
+    // block/subproblem boundary searches run once per QL/QR sweep.
+    template <size_t P, typename Partition>
+    inline int32_t partition_reduce_min(const Partition& partition, int32_t value) {
+#pragma unroll
+        for (uint32_t mask = 1u; mask < static_cast<uint32_t>(P); mask <<= 1) {
+            const int32_t other = permute_group_by_xor(partition, value, mask);
+            value = (other < value) ? other : value;
         }
-        if (lane < (n - 1)) {
-            E_local[base_e + lane] = offdiag;
-        } else if (lane < static_cast<int32_t>(P - 1)) {
-            E_local[base_e + lane] = T(0);
-        }
-        group_barrier(partition);
+        return value;
     }
 
-    template <typename T, size_t P, typename Partition, typename LocalAcc>
-    inline std::pair<T, T> reload_tridiag_from_local(const Partition& partition,
-                                                     int32_t n,
-                                                     const LocalAcc& D_local,
-                                                     const LocalAcc& E_local,
-                                                     int32_t base_d,
-                                                     int32_t base_e,
-                                                     int32_t lane) {
-        group_barrier(partition);
-        const T diag = (lane < n) ? D_local[base_d + lane] : T(0);
-        const T offdiag = (lane < (n - 1)) ? E_local[base_e + lane] : T(0);
-        return {diag, offdiag};
+    template <size_t P, typename Partition>
+    inline int32_t partition_reduce_max(const Partition& partition, int32_t value) {
+#pragma unroll
+        for (uint32_t mask = 1u; mask < static_cast<uint32_t>(P); mask <<= 1) {
+            const int32_t other = permute_group_by_xor(partition, value, mask);
+            value = (other > value) ? other : value;
+        }
+        return value;
     }
 
-    template <size_t P, typename Partition, typename LocalAcc>
-    inline int32_t group_reduce_min_local(const Partition& partition,
-                                          LocalAcc& scratch,
-                                          int32_t base,
-                                          int32_t lane,
-                                          int32_t value) {
-        if (lane < static_cast<int32_t>(P)) {
-            scratch[base + lane] = value;
+    template <size_t P, typename T, typename Partition>
+    inline T partition_reduce_fmax(const Partition& partition, T value) {
+#pragma unroll
+        for (uint32_t mask = 1u; mask < static_cast<uint32_t>(P); mask <<= 1) {
+            value = sycl::fmax(value, permute_group_by_xor(partition, value, mask));
         }
-        group_barrier(partition);
-        if (lane == 0) {
-            int32_t result = scratch[base];
-            for (int32_t idx = 1; idx < static_cast<int32_t>(P); ++idx) {
-                result = (scratch[base + idx] < result) ? scratch[base + idx] : result;
-            }
-            scratch[base] = result;
-        }
-        group_barrier(partition);
-        return scratch[base];
-    }
-
-    template <size_t P, typename Partition, typename LocalAcc>
-    inline int32_t group_reduce_max_local(const Partition& partition,
-                                          LocalAcc& scratch,
-                                          int32_t base,
-                                          int32_t lane,
-                                          int32_t value) {
-        if (lane < static_cast<int32_t>(P)) {
-            scratch[base + lane] = value;
-        }
-        group_barrier(partition);
-        if (lane == 0) {
-            int32_t result = scratch[base];
-            for (int32_t idx = 1; idx < static_cast<int32_t>(P); ++idx) {
-                result = (result < scratch[base + idx]) ? scratch[base + idx] : result;
-            }
-            scratch[base] = result;
-        }
-        group_barrier(partition);
-        return scratch[base];
+        return value;
     }
 
     template <typename T, size_t P, typename Partition, typename QCache>
@@ -210,9 +267,9 @@ namespace batchlas {
         const T b = select_from_group(partition, offdiag, l0);
         const T c2 = select_from_group(partition, diag, l0 + 1);
 
-        const auto [rt1, rt2, cs, sn] = invoke_one_broadcast(partition, [&]() {
-            return internal::laev2(a, b, c2);
-        });
+        // Every input is already partition-uniform, so evaluate laev2 redundantly on
+        // all lanes instead of computing on the leader and broadcasting four values.
+        const auto [rt1, rt2, cs, sn] = internal::laev2(a, b, c2);
         const int32_t lane = static_cast<int32_t>(partition.get_local_linear_id());
         if (lane == l0) {
             diag = rt1;
@@ -252,26 +309,20 @@ namespace batchlas {
             const T e0  = select_from_group(partition, offdiag, l);
             const T dlp1 = select_from_group(partition, diag, l + 1);
 
-            // Leader-only scalar state for the virtual QR bulge chase.
+            // Partition-uniform scalar state for the virtual QR bulge chase.
+            // Every lane evaluates it redundantly: the inputs are broadcast values, so
+            // the results agree bit-for-bit and no result broadcast is needed.
             T mu = T(0);
-            T bulge = T(0);
-            T eprev = T(0);
-            bool first = true;
 
-            invoke_one(partition, [&]() {
-                if (shift_strategy == SteqrShiftStrategy::Wilkinson) {
-                    // For QL, the shift is formed from the leading 2x2 of the physical block (l,l+1).
-                    // wilkinson_shift picks the eigenvalue closest to its 3rd argument; we want closest to D(l).
-                    mu = wilkinson_shift(dlp1, e0, p0);
-                } else {
-                    const T gg = (dlp1 - p0) / (T(2) * e0);
-                    const T rr = sycl::hypot(gg, T(1));
-                    mu = p0 - e0 / (gg + sycl::copysign(rr, gg));
-                }
-                bulge = T(0);
-                eprev = T(0);
-                first = true;
-            });
+            if (shift_strategy == SteqrShiftStrategy::Wilkinson) {
+                // For QL, the shift is formed from the leading 2x2 of the physical block (l,l+1).
+                // wilkinson_shift picks the eigenvalue closest to its 3rd argument; we want closest to D(l).
+                mu = wilkinson_shift(dlp1, e0, p0);
+            } else {
+                const T gg = (dlp1 - p0) / (T(2) * e0);
+                const T rr = sycl::hypot(gg, T(1));
+                mu = p0 - e0 / (gg + sycl::copysign(rr, gg));
+            }
 
             const int32_t nb = m - l + 1; // block length
             // Virtual index v in [0..nb-2] maps to physical indices:
@@ -279,33 +330,58 @@ namespace batchlas {
             //   d_v(v+1) = d( m - v - 1 )
             //   e_v(v)   = e( m - v - 1 )  (couples the two diags above)
             //   e_v(v+1) = e( m - v - 2 )
+            //
+            // The chase walks physical indices downward one step at a time, so the
+            // (di, ei) pair of iteration v+1 is exactly the (dj_new, ej_new) pair this
+            // iteration just produced.  Carrying them in registers halves the number of
+            // cross-lane shuffles in the hottest loop of the solver.
+            T di = select_from_group(partition, diag, m);
+            T ei = (m - 1) >= 0 ? select_from_group(partition, offdiag, m - 1) : T(0);
+            T e_own = T(0);
+
+            // Snapshot the tridiagonal before the chase.
+            //
+            // The chase writes lane `hi` at iteration v but only ever reads lanes
+            // strictly below it, so every broadcast below observes the pre-chase value.
+            // Shuffling from immutable snapshots is what makes that visible to the
+            // compiler: reading `diag`/`offdiag` directly forces each SHFL to be
+            // ordered after the previous iteration's conditional write, which chains
+            // them onto the lartg dependency path.  From snapshots the shuffles are
+            // loop-invariant-free and can be hoisted and overlapped with the rotation
+            // arithmetic instead.
+            const T diag_snap = diag;
+            const T offdiag_snap = offdiag;
+
+            // The first rotation uses (d(m) - mu, e(m-1)); every later one uses the
+            // running (eprev, bulge) pair.  Seeding the running pair with the initial
+            // values makes the two cases identical, which removes a loop-carried bool,
+            // its two selects and a branch from every iteration of the hottest loop.
+            T eprev = di - mu;
+            T bulge = ei;
+
+            // e(hi) is written only for v > 0 (the bulge has to have moved past it) and
+            // only when hi indexes a real offdiagonal.  For v > 0 <=> hi < m, so both
+            // conditions collapse into a single compare against this limit.
+            const int32_t e_hi_limit = std::min(m, n - 1);
+
+            qcache.chase_begin(m);
+
             for (int32_t v = 0; v < nb - 1; ++v) {
                 const int32_t hi = m - v;
                 const int32_t lo = m - v - 1;
 
-                const T di = select_from_group(partition, diag, hi);
-                const T dj = select_from_group(partition, diag, lo);
-                const T ei = select_from_group(partition, offdiag, lo);
+                const T dj = select_from_group(partition, diag_snap, lo);
 
                 // Next virtual offdiag (toward physical l). It is safe to read outside the block because
                 // deflation boundaries force those couplings to zero.
                 const bool have_ej = (lo - 1) >= 0;
-                const T ej = have_ej ? select_from_group(partition, offdiag, lo - 1) : T(0);
+                const T ej = have_ej ? select_from_group(partition, offdiag_snap, lo - 1) : T(0);
 
-                const auto upd = invoke_one_broadcast(partition, [&]() {
-                    T x = T(0);
-                    T y = T(0);
-                    if (first) {
-                        // First rotation uses (d(m)-mu, e(m-1)) in physical, i.e. (di - mu, ei) in our mapping.
-                        x = di - mu;
-                        y = ei;
-                    } else {
-                        // Subsequent rotations eliminate the bulge using (e_prev, bulge).
-                        x = eprev;
-                        y = bulge;
-                    }
+                const auto upd = [&]() {
+                    const T x = eprev;
+                    const T y = bulge;
 
-                    const auto [c1, s1, r1] = internal::lartg(x, y);
+                    const auto [c1, s1, r1] = cta_lartg(x, y);
                     const T sigma = -s1; // match steqr.cc / saved-rotation convention
 
                     // Update the offdiagonal to the *higher* physical index (virtual e(v-1) -> physical e(hi)).
@@ -322,41 +398,51 @@ namespace batchlas {
                     const T ej_new = c1 * ej;
                     const T bulge_new = -ej * sigma;
 
-                    // Advance leader state.
+                    // Advance the (uniform) chase state.
                     eprev = ei_new;
                     bulge = bulge_new;
-                    first = false;
 
                     // Return {c, sigma, di_new, dj_new, ei_new, ej_new, e_hi_new}
                     return std::array<T, 7>{c1, sigma, di_new, dj_new, ei_new, ej_new, e_hi_new};
-                });
+                }();
 
                 const T c1 = upd[0];
                 const T sigma = upd[1];
 
-                // Write back updated diagonal entries.
-                if (lane == hi) {
-                    diag = upd[2];
-                }
-                if (lane == lo) {
-                    diag = upd[3];
-                    offdiag = upd[4]; // e(lo)
-                }
-
-                // Propagate ej (physical e(lo-1)) if it exists.
-                if (have_ej && lane == (lo - 1)) {
-                    offdiag = upd[5];
-                }
-
-                // Update physical e(hi) (virtual e(v-1)) for v>0.
-                if (v > 0 && lane == hi && hi < (n - 1)) {
-                    offdiag = upd[6];
-                }
+                // Only two of the five candidate register updates survive to the next
+                // iteration: d(hi) and e(hi) are final once the bulge has moved past
+                // them, while d(lo), e(lo) and e(lo-1) are recomputed by the following
+                // rotation.  Those three are therefore carried in registers and written
+                // once after the chase instead of every iteration.
+                //
+                // Written as selects, not `if`s: exactly one lane of the partition is
+                // ever the target, so a branch here is a guaranteed divergence (and a
+                // BSSY/BSYNC pair) on every single rotation.
+                const bool owns_hi = (lane == hi);
+                diag = owns_hi ? upd[2] : diag;
+                offdiag = (owns_hi && hi < e_hi_limit) ? upd[6] : offdiag;
 
                 // QL eigenvector update: columns are reversed in physical ordering.
                 // In your existing PG path you do apply(i+1, i, c, -s); here the physical pair is (hi, lo).
-                qcache.apply(hi, lo, c1, sigma);
+                qcache.template chase_step<-1>(c1, sigma);
+
+                // Carry the values the next iteration would otherwise re-shuffle:
+                // d(lo) and e(lo-1) are exactly what was just written.
+                di = upd[3];
+                ei = upd[5];
+                e_own = upd[4];
             }
+
+            // Flush the carried tail values (lo == l on the final iteration).
+            if (lane == l) {
+                diag = di;
+                offdiag = e_own;
+            }
+            if (l >= 1 && lane == (l - 1)) {
+                offdiag = ei;
+            }
+
+            qcache.chase_end(l);
         };
 
         if (update_scheme == SteqrUpdateScheme::EXP) {
@@ -370,13 +456,13 @@ namespace batchlas {
         const T dlp1 = select_from_group(partition, diag, l + 1);
         const T dm = select_from_group(partition, diag, m);
 
-        // Leader-lane scalar state.
+        // Partition-uniform scalar state (evaluated redundantly on every lane).
         T g = T(0);
         T c = T(1);
         T s = T(1);
         T p = T(0);
 
-        invoke_one(partition, [&]() {
+        {
             T mu = T(0);
             if (shift_strategy == SteqrShiftStrategy::Wilkinson) {
                 // Want eigenvalue closest to D(l); wilkinson_shift picks closest to its third arg.
@@ -388,7 +474,9 @@ namespace batchlas {
                 mu = p0 - e0 / (gg + sycl::copysign(rr, gg));
             }
             g = dm - mu;
-        });
+        }
+
+        qcache.chase_begin(m);
 
         for (int32_t i = m; i-- > l;) {
             // Broadcast the tridiagonal entries needed for this step.
@@ -399,12 +487,12 @@ namespace batchlas {
             // Whether E(i+1) should be updated is a pure function of (i, m, n).
             const bool do_e_upd = (i != (m - 1)) && ((i + 1) < (n - 1));
 
-            const auto [c1b, s1b, d_ip1_new_b, r1_out_b] = invoke_one_broadcast(partition, [&]() {
+            const auto [c1b, s1b, d_ip1_new_b, r1_out_b] = [&]() {
                 // {c1, s1, d_ip1_new, r1_out}
                 const T f = s * ei;
                 T rout = T(0);
 
-                const auto [c1, s1, r1] = internal::lartg(g, f);
+                const auto [c1, s1, r1] = cta_lartg(g, f);
 
                 // In the original local-memory version: E(i+1) = r1 for i != m-1, when i+1 < N-1.
                 if (do_e_upd) {
@@ -421,24 +509,22 @@ namespace batchlas {
                 s = s1;
 
                 return std::array{c1, s1, d_ip1_new, rout};
-            });
+            }();
 
-            // Apply D/E updates directly to registers.
-            if (lane == (i + 1)) {
-                diag = d_ip1_new_b;
-                if (do_e_upd) {
-                    offdiag = r1_out_b;  // this lane owns E(i+1)
-                }
-            }
+            // Apply D/E updates directly to registers (predicated, not branched).
+            const bool owns_ip1 = (lane == (i + 1));
+            diag = owns_ip1 ? d_ip1_new_b : diag;
+            offdiag = (owns_ip1 && do_e_upd) ? r1_out_b : offdiag;
 
             // QL uses reversed-column convention; keep the same sign as before: apply(i+1,i,c,-s).
-            qcache.apply(i + 1, i, c1b, -s1b);
+            qcache.template chase_step<-1>(c1b, -s1b);
         }
 
+        qcache.chase_end(l);
+
         // Final updates: D(l) = D(l) - p, and E(l) = g.
-        const auto [d_l_new_b, e_l_new_b] = invoke_one_broadcast(partition, [&]() {
-            return std::array{p0 - p, g};
-        });
+        const T d_l_new_b = p0 - p;
+        const T e_l_new_b = g;
         if (lane == l) {
             diag = d_l_new_b;
             if (l < (n - 1)) {
@@ -467,45 +553,49 @@ namespace batchlas {
             const T dlm1 = select_from_group(partition, diag, l - 1);
 
             T mu = T(0);
-            T bulge = T(0);
-            T eprev = T(0);
-            bool first = true;
 
-            invoke_one(partition, [&]() {
-                if (shift_strategy == SteqrShiftStrategy::Wilkinson) {
-                    mu = wilkinson_shift(dlm1, e0, p0);
-                } else {
-                    const T gg = (dlm1 - p0) / (T(2) * e0);
-                    const T rr = sycl::hypot(gg, T(1));
-                    mu = p0 - e0 / (gg + sycl::copysign(rr, gg));
-                }
-                bulge = T(0);
-                eprev = T(0);
-                first = true;
-            });
+            // Partition-uniform: computed redundantly on every lane.
+            if (shift_strategy == SteqrShiftStrategy::Wilkinson) {
+                mu = wilkinson_shift(dlm1, e0, p0);
+            } else {
+                const T gg = (dlm1 - p0) / (T(2) * e0);
+                const T rr = sycl::hypot(gg, T(1));
+                mu = p0 - e0 / (gg + sycl::copysign(rr, gg));
+            }
+
+            // The chase walks physical indices upward one step at a time, so the (di, ei)
+            // pair of iteration i+1 is exactly the (dj_new, ej_new) pair produced here.
+            // Carrying them in registers halves the cross-lane shuffles in this loop.
+            T di = select_from_group(partition, diag, m);
+            T ei = select_from_group(partition, offdiag, m);
+            T e_own = T(0);
+
+            // Snapshot the tridiagonal before the chase; see the QL path for why.
+            // The chase writes lanes i and i-1 at iteration i but reads only lanes
+            // i+1 and above, so the broadcasts always want the pre-chase values.
+            // Sourcing them from immutable copies frees the compiler to hoist the
+            // SHFLs off the rotation's dependency chain.
+            const T diag_snap = diag;
+            const T offdiag_snap = offdiag;
+
+            // Seed the running (eprev, bulge) pair with the first rotation's operands so
+            // that every iteration takes the same path; see the QL chase for details.
+            T eprev = di - mu;
+            T bulge = ei;
+
+            qcache.chase_begin(m);
 
             for (int32_t i = m; i < l; ++i) {
-                const T di = select_from_group(partition, diag, i);
-                const T dj = select_from_group(partition, diag, i + 1);
-                const T ei = select_from_group(partition, offdiag, i);
+                const T dj = select_from_group(partition, diag_snap, i + 1);
 
                 const bool have_ej = (i + 1) < (n - 1);
-                const T ej = have_ej ? select_from_group(partition, offdiag, i + 1) : T(0);
+                const T ej = have_ej ? select_from_group(partition, offdiag_snap, i + 1) : T(0);
 
-                const auto upd = invoke_one_broadcast(partition, [&]() {
-                    T x = T(0);
-                    T y = T(0);
-                    if (first) {
-                        // First rotation uses (d(m)-mu, e(m)).
-                        x = di - mu;
-                        y = ei;
-                    } else {
-                        // Subsequent rotations eliminate the bulge using (e_prev, bulge).
-                        x = eprev;
-                        y = bulge;
-                    }
+                const auto upd = [&]() {
+                    const T x = eprev;
+                    const T y = bulge;
 
-                    const auto [c1, s1, r1] = internal::lartg(x, y);
+                    const auto [c1, s1, r1] = cta_lartg(x, y);
                     const T sigma = -s1;
 
                     // Update physical e(i-1) for i>m.
@@ -521,32 +611,43 @@ namespace batchlas {
 
                     eprev = ei_new;
                     bulge = bulge_new;
-                    first = false;
 
                     // Return {c, sigma, di_new, dj_new, ei_new, ej_new, e_im1_new}
                     return std::array<T, 7>{c1, sigma, di_new, dj_new, ei_new, ej_new, e_im1_new};
-                });
+                }();
 
                 const T c1 = upd[0];
                 const T sigma = upd[1];
 
-                if (lane == i) {
-                    diag = upd[2];
-                    offdiag = upd[4];
-                }
-                if (lane == (i + 1)) {
-                    diag = upd[3];
-                    if (have_ej) {
-                        offdiag = upd[5];
-                    }
-                }
-                if (i > m && lane == (i - 1)) {
-                    offdiag = upd[6];
-                }
+                // Only d(i) and e(i-1) survive to the next rotation; d(i+1), e(i+1)
+                // and e(i) are all recomputed by it, so they are carried in registers
+                // and flushed once after the chase.  Selects rather than branches: see
+                // the QL chase for why.
+                diag = (lane == i) ? upd[2] : diag;
+                offdiag = (i > m && lane == (i - 1)) ? upd[6] : offdiag;
 
                 // QR eigenvector update: columns (i, i+1).
-                qcache.apply(i, i + 1, c1, sigma);
+                qcache.template chase_step<1>(c1, sigma);
+
+                // Carry the values the next iteration would otherwise re-shuffle:
+                // d(i+1) and e(i+1) are exactly what was just written.
+                di = upd[3];
+                ei = upd[5];
+                e_own = upd[4];
             }
+
+            // Flush the carried tail values (i == l-1 on the final iteration).
+            if (lane == l) {
+                diag = di;
+                if (l < (n - 1)) {
+                    offdiag = ei;
+                }
+            }
+            if (lane == (l - 1)) {
+                offdiag = e_own;
+            }
+
+            qcache.chase_end(l);
         };
 
         if (update_scheme == SteqrUpdateScheme::EXP) {
@@ -560,13 +661,13 @@ namespace batchlas {
         const T dlm1 = select_from_group(partition, diag, l - 1);
         const T dm = select_from_group(partition, diag, m);
 
-        // Leader-lane scalar state.
+        // Partition-uniform scalar state (evaluated redundantly on every lane).
         T g = T(0);
         T c = T(1);
         T s = T(1);
         T p = T(0);
 
-        invoke_one(partition, [&]() {
+        {
             T mu = T(0);
             if (shift_strategy == SteqrShiftStrategy::Wilkinson) {
                 mu = wilkinson_shift(dlm1, e0, p0);
@@ -576,7 +677,9 @@ namespace batchlas {
                 mu = p0 - e0 / (gg + sycl::copysign(rr, gg));
             }
             g = dm - mu;
-        });
+        }
+
+        qcache.chase_begin(m);
 
         for (int32_t i = m; i < l; ++i) {
             // Broadcast the tridiagonal entries needed for this step.
@@ -587,12 +690,12 @@ namespace batchlas {
             // Whether E(i-1) should be updated is a pure function of (i, m).
             const bool do_e_upd = (i != m);
 
-            const auto [c1b, s1b, d_i_new_b, r1_out_b] = invoke_one_broadcast(partition, [&]() {
+            const auto [c1b, s1b, d_i_new_b, r1_out_b] = [&]() {
                 // {c1, s1, d_i_new, r1_out}
                 const T f = s * ei;
                 T rout = T(0);
 
-                const auto [c1, s1, r1] = internal::lartg(g, f);
+                const auto [c1, s1, r1] = cta_lartg(g, f);
 
                 // In the original local-memory version: E(i-1) = r1 for i != m.
                 if (do_e_upd) {
@@ -609,24 +712,21 @@ namespace batchlas {
                 s = s1;
 
                 return std::array{c1, s1, d_i_new, rout};
-            });
+            }();
 
-            // Apply D/E updates directly to registers.
-            if (lane == i) {
-                diag = d_i_new_b;
-            }
-            if (do_e_upd && lane == (i - 1)) {
-                offdiag = r1_out_b;  // this lane owns E(i-1)
-            }
+            // Apply D/E updates directly to registers (predicated, not branched).
+            diag = (lane == i) ? d_i_new_b : diag;
+            offdiag = (do_e_upd && lane == (i - 1)) ? r1_out_b : offdiag;
 
             // Match previous sign convention: apply(i,i+1,c,-s).
-            qcache.apply(i, i + 1, c1b, -s1b);
+            qcache.template chase_step<1>(c1b, -s1b);
         }
 
+        qcache.chase_end(l);
+
         // Final updates: D(l) = D(l) - p, and E(l-1) = g.
-        const auto [d_l_new_b, e_lm1_new_b] = invoke_one_broadcast(partition, [&]() {
-            return std::array{p0 - p, g};
-        });
+        const T d_l_new_b = p0 - p;
+        const T e_lm1_new_b = g;
         if (lane == l) {
             diag = d_l_new_b;
         }
@@ -682,10 +782,6 @@ namespace batchlas {
 
             auto Q_local = sycl::local_accessor<T, 1>(
                 sycl::range<1>(ComputeVecs ? (probs_per_wg * P * P) : 1), cgh);
-            auto D_local = sycl::local_accessor<T, 1>(sycl::range<1>(probs_per_wg * P), cgh);
-            auto E_local = sycl::local_accessor<T, 1>(sycl::range<1>(probs_per_wg * (P - 1)), cgh);
-            auto I_local = sycl::local_accessor<int32_t, 1>(sycl::range<1>(probs_per_wg * P), cgh);
-
             cgh.parallel_for<SteqrCTAKernel<T, P, ComputeVecs>>(
                 sycl::nd_range<1>(global_size, wg_size),
                 [=](sycl::nd_item<1> it) [[sycl::reqd_sub_group_size(sg_size)]] {
@@ -705,9 +801,6 @@ namespace batchlas {
                     if (prob_id >= static_cast<int32_t>(batch_size)) return;
                     auto d_prob = d.batch_item(prob_id);
                     auto e_prob = e.batch_item(prob_id);
-                    const int32_t base_d = part_id * static_cast<int32_t>(P);
-                    const int32_t base_e = part_id * static_cast<int32_t>(P - 1);
-                    const int32_t base_i = part_id * static_cast<int32_t>(P);
 
                     // Compile-time selectable eigenvector accumulation (shared-memory Q).
                     const int32_t base_q = part_id * static_cast<int32_t>(P) * static_cast<int32_t>(P);
@@ -743,7 +836,7 @@ namespace batchlas {
                         // Find end of current block: first i>=block_begin where E(i)==0; if none, block ends at n-1.
                         const int32_t block_end_candidate =
                             (lane >= block_begin && lane < (n - 1) && offdiag == T(0)) ? lane : (n - 1);
-                        const int32_t block_end = group_reduce_min_local<P>(partition, I_local, base_i, lane, block_end_candidate);
+                        const int32_t block_end = partition_reduce_min<P>(partition, block_end_candidate);
 
                         // Next block starts after block_end.
                         next_block_begin = block_end + 1;
@@ -759,27 +852,26 @@ namespace batchlas {
                         // rescale back by `inv_scale` once the block converges.
                         //
                         // NOTE: reduce_over_group() for floating point on chunked partitions
-                        // is not available on some backends (e.g. CUDA). We compute the max
-                        // norm via shared local memory and a leader-lane loop instead.
-                        stage_tridiag_to_local<T, P>(partition, n, D_local, E_local, base_d, base_e, lane, diag, offdiag);
+                        // is not available on some backends (e.g. CUDA), so the max norm is
+                        // computed with an XOR-shuffle butterfly over the register-resident
+                        // tridiagonal entries.
+                        T anorm_cand = T(0);
+                        if (lane >= block_begin && lane <= block_end) {
+                            anorm_cand = sycl::fabs(diag);
+                        }
+                        if (lane >= block_begin && lane < block_end) {
+                            anorm_cand = sycl::fmax(anorm_cand, sycl::fabs(offdiag));
+                        }
+                        const T anorm = partition_reduce_fmax<P>(partition, anorm_cand);
 
-                        const T scale = invoke_one_broadcast(partition, [&]() {
-                            T anorm = std::abs(D_local[base_d + block_end]);
-                            for (int32_t idx = block_begin; idx < block_end; ++idx) {
-                                anorm = sycl::fmax(anorm, std::abs(D_local[base_d + idx]));
-                                anorm = sycl::fmax(anorm, std::abs(E_local[base_e + idx]));
-                            }
-
-                            if (anorm > internal::ssfmax<T>()) {
-                                // Scale down to avoid overflow.
-                                return internal::ssfmax<T>() / anorm;
-                            }
-                            if (anorm < internal::ssfmin<T>() && anorm != T(0)) {
-                                // Scale up to avoid underflow.
-                                return internal::ssfmin<T>() / anorm;
-                            }
-                            return T(1);
-                        });
+                        T scale = T(1);
+                        if (anorm > internal::ssfmax<T>()) {
+                            // Scale down to avoid overflow.
+                            scale = internal::ssfmax<T>() / anorm;
+                        } else if (anorm < internal::ssfmin<T>() && anorm != T(0)) {
+                            // Scale up to avoid underflow.
+                            scale = internal::ssfmin<T>() / anorm;
+                        }
                         const T inv_scale = T(1) / scale;
 
                         if (scale != T(1)) {
@@ -813,7 +905,7 @@ namespace batchlas {
 
                                     // Find first m in [l..lend-1] such that E(m)==0; if none, m=lend.
                                     const int32_t m_candidate = (lane >= l && lane < block_end && offdiag == T(0)) ? lane : block_end;
-                                    const int32_t m = group_reduce_min_local<P>(partition, I_local, base_i, lane, m_candidate);
+                                    const int32_t m = partition_reduce_min<P>(partition, m_candidate);
 
                                     if (m == l) {
                                         // Converged! Move to next eigenvalue.
@@ -866,7 +958,7 @@ namespace batchlas {
                                     const int32_t l_u = static_cast<int32_t>(l);
                                     const int32_t m_candidate =
                                         (lane >= block_begin && lane < l_u && offdiag == T(0)) ? (lane + 1) : block_begin;
-                                    const int32_t m = group_reduce_max_local<P>(partition, I_local, base_i, lane, m_candidate);
+                                    const int32_t m = partition_reduce_max<P>(partition, m_candidate);
 
                                     if (m == l) {
                                         // Converged! Move to next eigenvalue.

--- a/src/extensions/syev_blocked.cc
+++ b/src/extensions/syev_blocked.cc
@@ -61,61 +61,20 @@ inline int32_t sytrd_block_size_override(int32_t n) {
 }
 
 template <typename T>
-inline void pack_sytrd_lower_to_qsub_qr_layout(Queue& ctx,
-                                              const MatrixView<T, MatrixFormat::Dense>& a_sytrd,
-                                              const MatrixView<T, MatrixFormat::Dense>& a_qsub_qr,
-                                              const VectorView<T>& tau_sytrd,
-                                              const VectorView<T>& tau_qsub,
-                                              int32_t n) {
-    // Pack SYTRD Lower reflectors into a QR-compatible layout for the trailing
-    // (n-1)x(n-1) subproblem (Qsub). This matches the approach used by
-    // tests/sytrd_blocked_tests.cc:
-    //   - Q = [1, 0; 0, Qsub]
-    //   - For i in [0, p-1) where p=n-1, reflector i acts on rows i..p-1
-    //     in the subproblem and has tail entries from A_out((i+2):n-1, i).
-    const int32_t batch = static_cast<int32_t>(a_sytrd.batch_size());
+inline MatrixView<T, MatrixFormat::Dense> sytrd_lower_qsub_reflector_view(
+    const MatrixView<T, MatrixFormat::Dense>& a_sytrd,
+    int32_t n) {
+    // SYTRD (Lower) stores reflector i of the trailing (n-1)x(n-1) subproblem
+    // (Qsub, with Q = [1, 0; 0, Qsub]) in A_out((i+2):n-1, i). Shifting the
+    // matrix down by one row therefore yields exactly the QR-style layout that
+    // ormqr_blocked expects: local (row, col) == A_out(row + 1, col).
+    //
+    // ormqr_blocked's V-panel packing only reads the strictly lower triangle
+    // (it forces the diagonal to 1 and the upper triangle to 0), so no explicit
+    // packed copy is needed - the sliced view is sufficient and avoids a
+    // p*p*batch write plus read on every call.
     const int32_t p = std::max<int32_t>(0, n - 1);
-    if (p == 0) return;
-
-    // Pack A (strictly lower triangle). Diagonal is implicit 1 in ormqr_blocked.
-    ctx->submit([&](sycl::handler& cgh) {
-        auto A = a_sytrd.kernel_view();
-        auto AQ = a_qsub_qr.kernel_view();
-        const int32_t pp = p;
-        const int32_t nb = batch;
-
-        const int64_t total = static_cast<int64_t>(nb) * static_cast<int64_t>(pp) * static_cast<int64_t>(pp);
-        cgh.parallel_for(sycl::range<1>(static_cast<std::size_t>(total)), [=](sycl::id<1> tid) {
-            const int64_t idx = static_cast<int64_t>(tid[0]);
-            const int32_t b = static_cast<int32_t>(idx / (static_cast<int64_t>(pp) * pp));
-            const int64_t rem = idx - static_cast<int64_t>(b) * pp * pp;
-            const int32_t row = static_cast<int32_t>(rem % pp);
-            const int32_t col = static_cast<int32_t>(rem / pp);
-
-            T val = T(0);
-            if (row > col) {
-                // Local (row,col) maps to global (row+1, col) in A_out.
-                val = A(row + 1, col, b);
-            }
-            AQ(row, col, b) = val;
-        });
-    });
-
-    // Pack tau for the subproblem (size p).
-    ctx->submit([&](sycl::handler& cgh) {
-        auto TAU = tau_sytrd;
-        auto TAUQ = tau_qsub;
-        const int32_t pp = p;
-        const int32_t nb = batch;
-        const int64_t total = static_cast<int64_t>(nb) * static_cast<int64_t>(pp);
-
-        cgh.parallel_for(sycl::range<1>(static_cast<std::size_t>(total)), [=](sycl::id<1> tid) {
-            const int64_t idx = static_cast<int64_t>(tid[0]);
-            const int32_t b = static_cast<int32_t>(idx / pp);
-            const int32_t i = static_cast<int32_t>(idx - static_cast<int64_t>(b) * pp);
-            TAUQ(i, b) = TAU(i, b);
-        });
-    });
+    return a_sytrd({1, SliceEnd()}, {0, p});
 }
 
 } // namespace
@@ -174,12 +133,6 @@ Event syev_blocked(Queue& ctx,
 
         MatrixView<Real, MatrixFormat::Dense> z_view(z_span.data(), n, n, n, n * n, batch);
         MatrixView<T, MatrixFormat::Dense> zc_view(zc_span.data(), n, n, n, n * n, batch);
-
-        // Pack reflectors for Qsub into QR layout for ORMQR (size (n-1)x(n-1)).
-        auto aq_span = pool.allocate<T>(ctx, static_cast<std::size_t>(p) * static_cast<std::size_t>(p) * static_cast<std::size_t>(batch));
-        auto tau_q_span = pool.allocate<T>(ctx, static_cast<std::size_t>(p) * static_cast<std::size_t>(batch));
-        MatrixView<T, MatrixFormat::Dense> aq_view(aq_span.data(), p, p, p, p * p, batch);
-        VectorView<T> tau_q_view(tau_q_span, p, batch, 1, p);
 
         // Sub-workspaces.
         {
@@ -262,33 +215,28 @@ Event syev_blocked(Queue& ctx,
             });
 
             if (p > 0) {
-                pack_sytrd_lower_to_qsub_qr_layout<T>(ctx, a, aq_view, tau_c_view, tau_q_view, n);
-            }
-
-            // Apply Qsub from packed QR reflectors to rows 1..n-1: Zc_sub := Qsub * Zc_sub.
-            {
+                // Apply Qsub directly from the SYTRD reflectors (no packed copy).
+                auto aq_view = sytrd_lower_qsub_reflector_view<T>(a, n);
                 auto zc_sub = zc_view({1, SliceEnd()}, Slice());
-                Span<T> tau_q_span_flat(tau_q_span.data(), static_cast<std::size_t>(p) * static_cast<std::size_t>(batch));
+                Span<T> tau_q_span_flat(tau_c_span.data(), static_cast<std::size_t>(p) * static_cast<std::size_t>(batch));
 
-                if (p > 0) {
-                    auto ormqr_ws_bytes = ormqr_blocked_buffer_size<B, T>(ctx,
-                                                                          aq_view,
-                                                                          zc_sub,
-                                                                          Side::Left,
-                                                                          Transpose::NoTrans,
-                                                                          tau_q_span_flat,
-                                                                          ormqr_block_size);
-                    auto ormqr_ws = pool.allocate<std::byte>(ctx, ormqr_ws_bytes);
+                auto ormqr_ws_bytes = ormqr_blocked_buffer_size<B, T>(ctx,
+                                                                      aq_view,
+                                                                      zc_sub,
+                                                                      Side::Left,
+                                                                      Transpose::NoTrans,
+                                                                      tau_q_span_flat,
+                                                                      ormqr_block_size);
+                auto ormqr_ws = pool.allocate<std::byte>(ctx, ormqr_ws_bytes);
 
-                    ormqr_blocked<B, T>(ctx,
-                                        aq_view,
-                                        zc_sub,
-                                        Side::Left,
-                                        Transpose::NoTrans,
-                                        tau_q_span_flat,
-                                        ormqr_ws,
-                                        ormqr_block_size);
-                }
+                ormqr_blocked<B, T>(ctx,
+                                    aq_view,
+                                    zc_sub,
+                                    Side::Left,
+                                    Transpose::NoTrans,
+                                    tau_q_span_flat,
+                                    ormqr_ws,
+                                    ormqr_block_size);
             }
 
             MatrixView<T, MatrixFormat::Dense>::copy(ctx, a, zc_view);
@@ -309,11 +257,6 @@ Event syev_blocked(Queue& ctx,
 
         auto z_span = pool.allocate<T>(ctx, static_cast<std::size_t>(n) * static_cast<std::size_t>(n) * static_cast<std::size_t>(batch));
         MatrixView<T, MatrixFormat::Dense> z_view(z_span.data(), n, n, n, n * n, batch);
-
-        auto aq_span = pool.allocate<T>(ctx, static_cast<std::size_t>(p) * static_cast<std::size_t>(p) * static_cast<std::size_t>(batch));
-        auto tau_q_span = pool.allocate<T>(ctx, static_cast<std::size_t>(p) * static_cast<std::size_t>(batch));
-        MatrixView<T, MatrixFormat::Dense> aq_view(aq_span.data(), p, p, p, p * p, batch);
-        VectorView<T> tau_q_view(tau_q_span, p, batch, 1, p);
 
         {
             auto sytrd_ws_bytes = sytrd_blocked_buffer_size<B, T>(ctx, a, d_view, e_view, tau_view, uplo, sytrd_block_size);
@@ -371,31 +314,28 @@ Event syev_blocked(Queue& ctx,
             });
 
             if (p > 0) {
-                pack_sytrd_lower_to_qsub_qr_layout<T>(ctx, a, aq_view, tau_view, tau_q_view, n);
-            }
-
-            {
+                // Apply Qsub directly from the SYTRD reflectors (no packed copy).
+                auto aq_view = sytrd_lower_qsub_reflector_view<T>(a, n);
                 auto z_sub = z_view({1, SliceEnd()}, Slice());
-                Span<T> tau_q_span_flat(tau_q_span.data(), static_cast<std::size_t>(p) * static_cast<std::size_t>(batch));
-                if (p > 0) {
-                    auto ormqr_ws_bytes = ormqr_blocked_buffer_size<B, T>(ctx,
-                                                                          aq_view,
-                                                                          z_sub,
-                                                                          Side::Left,
-                                                                          Transpose::NoTrans,
-                                                                          tau_q_span_flat,
-                                                                          ormqr_block_size);
-                    auto ormqr_ws = pool.allocate<std::byte>(ctx, ormqr_ws_bytes);
+                Span<T> tau_q_span_flat(tau_span.data(), static_cast<std::size_t>(p) * static_cast<std::size_t>(batch));
 
-                    ormqr_blocked<B, T>(ctx,
-                                        aq_view,
-                                        z_sub,
-                                        Side::Left,
-                                        Transpose::NoTrans,
-                                        tau_q_span_flat,
-                                        ormqr_ws,
-                                        ormqr_block_size);
-                }
+                auto ormqr_ws_bytes = ormqr_blocked_buffer_size<B, T>(ctx,
+                                                                      aq_view,
+                                                                      z_sub,
+                                                                      Side::Left,
+                                                                      Transpose::NoTrans,
+                                                                      tau_q_span_flat,
+                                                                      ormqr_block_size);
+                auto ormqr_ws = pool.allocate<std::byte>(ctx, ormqr_ws_bytes);
+
+                ormqr_blocked<B, T>(ctx,
+                                    aq_view,
+                                    z_sub,
+                                    Side::Left,
+                                    Transpose::NoTrans,
+                                    tau_q_span_flat,
+                                    ormqr_ws,
+                                    ormqr_block_size);
             }
 
             MatrixView<T, MatrixFormat::Dense>::copy(ctx, a, z_view);
@@ -441,8 +381,6 @@ size_t syev_blocked_buffer_size(Queue& ctx,
         const std::size_t phase_count = d_c_count;
         const std::size_t z_count = static_cast<std::size_t>(n) * static_cast<std::size_t>(n) * static_cast<std::size_t>(batch);
         const std::size_t zc_count = z_count;
-        const std::size_t aq_count = static_cast<std::size_t>(p) * static_cast<std::size_t>(p) * static_cast<std::size_t>(batch);
-        const std::size_t tau_q_count = static_cast<std::size_t>(p) * static_cast<std::size_t>(batch);
 
         bytes += BumpAllocator::allocation_size<T>(ctx, d_c_count);
         bytes += BumpAllocator::allocation_size<T>(ctx, e_c_count);
@@ -454,9 +392,6 @@ size_t syev_blocked_buffer_size(Queue& ctx,
 
         bytes += BumpAllocator::allocation_size<Real>(ctx, z_count);
         bytes += BumpAllocator::allocation_size<T>(ctx, zc_count);
-
-        bytes += BumpAllocator::allocation_size<T>(ctx, aq_count);
-        bytes += BumpAllocator::allocation_size<T>(ctx, tau_q_count);
 
         // Sub-workspaces.
         VectorView<T> d_c_dummy(nullptr, n, batch, 1, n);
@@ -480,16 +415,12 @@ size_t syev_blocked_buffer_size(Queue& ctx,
         const std::size_t tau_count = e_count;
         const std::size_t phase_count = d_count;
         const std::size_t z_count = static_cast<std::size_t>(n) * static_cast<std::size_t>(n) * static_cast<std::size_t>(batch);
-        const std::size_t aq_count = static_cast<std::size_t>(p) * static_cast<std::size_t>(p) * static_cast<std::size_t>(batch);
-        const std::size_t tau_q_count = static_cast<std::size_t>(p) * static_cast<std::size_t>(batch);
 
         bytes += BumpAllocator::allocation_size<T>(ctx, d_count);
         bytes += BumpAllocator::allocation_size<T>(ctx, e_count);
         bytes += BumpAllocator::allocation_size<T>(ctx, tau_count);
         bytes += BumpAllocator::allocation_size<T>(ctx, phase_count);
         bytes += BumpAllocator::allocation_size<T>(ctx, z_count);
-        bytes += BumpAllocator::allocation_size<T>(ctx, aq_count);
-        bytes += BumpAllocator::allocation_size<T>(ctx, tau_q_count);
 
         VectorView<T> d_dummy(nullptr, n, batch, 1, n);
         VectorView<T> e_dummy(nullptr, std::max(0, n - 1), batch, 1, std::max(0, n - 1));

--- a/src/extensions/syev_cta.cc
+++ b/src/extensions/syev_cta.cc
@@ -493,6 +493,14 @@ Event syev_cta(Queue& ctx,
                             AQ(row, col, b) = A(row, i, b);
                         }
                     }
+
+                    // Fold the TAUQ permutation into this kernel: one thread per
+                    // column already exists here, so the separate n*batch launch it
+                    // used to need is pure overhead.
+                    // tau_q[0] = 0, tau_q[j] = tau[j-1] for j>=1.
+                    if (row == 0) {
+                        TAUQ(col, b) = (col >= 1 && (col - 1) < (nn - 1)) ? TAU(col - 1, b) : T(0);
+                    }
                 } else {
                     // Upper -> QL reflectors stored in columns 0..n-2.
                     // Reflector with pivot p (0..n-2) comes from SYTRD column (p+1)
@@ -504,41 +512,15 @@ Event syev_cta(Queue& ctx,
                             AQ(row, col, b) = A(row, k, b);
                         }
                     }
-                }
-            });
-        });
-        cta_debug_sync(ctx, "syev_cta: after pack AQ");
 
-        ctx->submit([&](sycl::handler& cgh) {
-            auto TAU = tau_view;
-            auto TAUQ = tau_q_view;
-            const int32_t nb = batch;
-            const int32_t nn = n;
-            const int64_t total = static_cast<int64_t>(nb) * static_cast<int64_t>(nn);
-
-            cgh.parallel_for(sycl::range<1>(static_cast<std::size_t>(total)), [=](sycl::id<1> tid) {
-                const int64_t idx = static_cast<int64_t>(tid[0]);
-                const int32_t b = static_cast<int32_t>(idx / nn);
-                const int32_t j = static_cast<int32_t>(idx - static_cast<int64_t>(b) * nn);
-
-                if (uplo_eff == Uplo::Lower) {
-                    // tau_q[0] = 0, tau_q[j] = tau[j-1] for j>=1.
-                    if (j == 0) {
-                        TAUQ(j, b) = T(0);
-                    } else {
-                        TAUQ(j, b) = (j - 1 < (nn - 1)) ? TAU(j - 1, b) : T(0);
-                    }
-                } else {
-                    // tau_q[j] = tau[j] for j<=n-2, tau_q[n-1]=0.
-                    if (j < (nn - 1)) {
-                        TAUQ(j, b) = TAU(j, b);
-                    } else {
-                        TAUQ(j, b) = T(0);
+                    // tau_q[j] = tau[j] for j<=n-2, tau_q[n-1] = 0.
+                    if (row == 0) {
+                        TAUQ(col, b) = (col < (nn - 1)) ? TAU(col, b) : T(0);
                     }
                 }
             });
         });
-        cta_debug_sync(ctx, "syev_cta: after pack TAUQ");
+        cta_debug_sync(ctx, "syev_cta: after pack AQ/TAUQ");
 
         const Uplo ormq_factorization = (uplo_eff == Uplo::Lower) ? Uplo::Upper : Uplo::Lower;
         // Apply Q (from SYTRD reflectors) to Z: Z := Q * Z.

--- a/src/extensions/syev_jacobi_cta.cc
+++ b/src/extensions/syev_jacobi_cta.cc
@@ -1,0 +1,664 @@
+#include <blas/matrix.hh>
+#include <blas/functions.hh>
+#include <blas/extensions.hh>
+#include <blas/extra.hh>
+#include <util/kernel-heuristics.hh>
+#include <util/mempool.hh>
+#include <util/group-invoke.hh>
+#include "sg_compat.hh"
+#include <batchlas/backend_config.h>
+#include "../math-helpers.hh"
+#include "../queue.hh"
+#include "../util/template-instantiations.hh"
+#include <complex>
+#include <limits>
+#include <numeric>
+using namespace sycl::ext::oneapi;
+
+namespace batchlas {
+
+// Kernel name tag. Must live outside the anonymous namespace below so it does
+// not depend on internal-linkage entities.
+template <typename T, size_t P, bool ComputeVectors, bool Upper>
+class SyevJacobiCTAKernel;
+
+// ---------------------------------------------------------------------------
+// Tier-A Jacobi eigensolver: partition-resident cyclic two-sided Jacobi.
+//
+// One SubGroupPartition<P> owns one problem; A and (optionally) Z live in local
+// memory for the whole solve, so a full eigendecomposition is a single kernel
+// launch with no global-memory traffic beyond the initial load and final store.
+//
+// This is an accuracy-oriented alternative to the sytrd_cta -> steqr_cta ->
+// ormqx_cta pipeline. With the *relative* off-diagonal threshold used below,
+// Jacobi's eigenvalue error is governed by the condition number of the
+// column-equilibrated matrix rather than that of the (tridiagonalized) matrix
+// itself, so graded / badly scaled inputs come out with small relative error
+// where a tridiagonalizing method loses the small eigenvalues entirely.
+//
+// The guarantee is proved for symmetric positive definite input; indefinite
+// matrices are handled correctly but do not inherit the relative-accuracy bound.
+//
+// References:
+// - Demmel & Veselic, "Jacobi's Method is More Accurate than QR",
+//   SIAM J. Matrix Anal. Appl. 13(4), 1992.  (accuracy theorem, relative
+//   stopping criterion)
+// - Drmac & Veselic, LAPACK Working Notes 169/170.  (threshold form, backward
+//   error, convergence test)
+// - Golub & Van Loan, Matrix Computations, Alg. 8.5.1.  (2x2 rotation formulas)
+// - See JACOBI_EIGENSOLVER_PLAN.md for the full design rationale.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+template <typename U>
+inline U conj_if_complex_j(const U& x) {
+    if constexpr (internal::is_complex<U>::value) {
+        return U(x.real(), -x.imag());
+    } else {
+        return x;
+    }
+}
+
+template <typename U>
+inline typename base_type<U>::type abs_if_complex_j(const U& x) {
+    using Real = typename base_type<U>::type;
+    if constexpr (internal::is_complex<U>::value) {
+        return sycl::hypot(x.real(), x.imag());
+    } else {
+        return sycl::fabs(x);
+    }
+}
+
+// Zero the imaginary part (no-op for real types). Used to keep Hermitian
+// diagonals exactly real after an update.
+template <typename U>
+inline U force_real_j(const U& x) {
+    if constexpr (internal::is_complex<U>::value) {
+        return U(x.real(), typename base_type<U>::type(0));
+    } else {
+        return x;
+    }
+}
+
+template <typename U>
+inline typename base_type<U>::type real_part_j(const U& x) {
+    if constexpr (internal::is_complex<U>::value) {
+        return x.real();
+    } else {
+        return x;
+    }
+}
+
+// Butterfly reduction over a chunked partition. Mirrors the pattern used by
+// sytrd_cta: DPC++'s CUDA path has limitations for group collectives on
+// non-uniform groups, so we use XOR shuffles and keep the result replicated.
+template <typename T, typename Group>
+inline T partition_reduce_sum_j(const Group& g, T v) {
+    const uint32_t lanes = static_cast<uint32_t>(g.get_local_linear_range());
+    for (uint32_t offset = lanes / 2; offset > 0; offset >>= 1) {
+        v += permute_group_by_xor(g, v, offset);
+    }
+    return v;
+}
+
+// Round-robin ("chess tournament" / circle method) pairing.
+//
+// For an even m, round t in [0, m-2] produces m/2 disjoint pairs, and the m-1
+// rounds together cover all m(m-1)/2 index pairs exactly once. Index 0 is held
+// fixed and the remaining m-1 indices rotate.
+//
+// This schedule is a permutation of a serial sweep into disjoint (hence
+// commuting) pivot pairs, so by the weak-equivalence theorem of Hari &
+// Begovic Kovac (ETNA 46, 2017, Thm 2.11) it produces the same matrix as the
+// cyclic-by-rows ordering after each full sweep and inherits its convergence.
+inline void round_robin_pair(int32_t m, int32_t t, int32_t k, int32_t& p, int32_t& q) {
+    const int32_t ring = m - 1;
+    if (k == 0) {
+        p = 0;
+        q = (t % ring) + 1;
+    } else {
+        p = ((t + k) % ring) + 1;
+        q = (((t - k) % ring + ring) % ring) + 1;
+    }
+    if (p > q) {
+        const int32_t tmp = p;
+        p = q;
+        q = tmp;
+    }
+}
+
+template <typename T, size_t P, bool ComputeVectors, bool Upper>
+inline void syev_jacobi_cta_impl(Queue& ctx,
+                                 MatrixView<T, MatrixFormat::Dense>& a,
+                                 typename base_type<T>::type* w_ptr,
+                                 int32_t n,
+                                 JacobiParams<T> params) {
+    using Real = typename base_type<T>::type;
+
+    const auto batch_size = a.batch_size();
+    if (n < 1 || n > static_cast<int32_t>(P) || a.rows() != n || a.cols() != n) {
+        throw std::runtime_error("syev_jacobi_cta_impl: invalid n or matrix sizes for CTA partition.");
+    }
+
+    // Pivot index space is padded to an even size so the round-robin schedule is
+    // well defined; the (single) padded index is simply never paired with a real
+    // one because pairs touching index >= n are skipped.
+    const int32_t m = (n % 2 == 0) ? n : (n + 1);
+
+    ctx->submit([&](sycl::handler& cgh) {
+        auto A_view = a.kernel_view();
+
+        const auto dev = ctx->get_device();
+
+        // CTA path assumes warp-sized sub-groups on NVIDIA.
+        const int32_t sg_size = 32;
+
+        // Local-memory leading dimension is padded to P+1.
+        //
+        // This matters a great deal. The row-update phase has lane == column, so
+        // lane i touches address (row + i*LD). With LD == P == 32 every lane in a
+        // warp lands in the same 32-bit bank and the access serializes 32 ways;
+        // padding to 33 makes consecutive lanes differ by 33 == 1 (mod 32) and
+        // the access becomes conflict-free.
+        constexpr int32_t LD = static_cast<int32_t>(P) + 1;
+        constexpr std::size_t kTileElems = static_cast<std::size_t>(LD) * P;
+
+        const int32_t base_wg_size = std::lcm<int32_t>(static_cast<int32_t>(P), sg_size);
+        int32_t wg_size_multiplier = std::max<int32_t>(int32_t(1),
+                                                       static_cast<int32_t>(params.cta_wg_size_multiplier));
+        int32_t wg_size = base_wg_size * wg_size_multiplier;
+
+        const int32_t max_wg_size = static_cast<int32_t>(dev.get_info<sycl::info::device::max_work_group_size>());
+        if (wg_size > max_wg_size) {
+            const int32_t max_mul = std::max<int32_t>(int32_t(1), max_wg_size / base_wg_size);
+            wg_size_multiplier = std::min(wg_size_multiplier, max_mul);
+            wg_size = base_wg_size * wg_size_multiplier;
+        }
+
+        // Clamp by local memory: per problem we hold A, optionally Z, and the
+        // per-round rotation coefficients. The pivot-pair table is shared by the
+        // whole work-group, so it is accounted for separately below.
+        constexpr std::size_t kRotSlots = (P / 2 > 0) ? (P / 2) : 1;
+        constexpr std::size_t kPairSlots = (P - 1) * kRotSlots;
+        constexpr std::size_t kPairTabBytes = kPairSlots * sizeof(int16_t);
+        constexpr bool kNeedPhase = internal::is_complex<T>::value;
+        {
+            const std::size_t local_mem_bytes = dev.get_info<sycl::info::device::local_mem_size>();
+            const std::size_t avail = (local_mem_bytes > kPairTabBytes) ? (local_mem_bytes - kPairTabBytes) : 1;
+            const std::size_t z_elems = ComputeVectors ? kTileElems : 0;
+            const std::size_t bytes_per_prob = (kTileElems + z_elems) * sizeof(T)
+                                             + (kNeedPhase ? kRotSlots * sizeof(T) : 0)
+                                             + 2 * kRotSlots * sizeof(Real);
+            const int32_t max_probs = (bytes_per_prob == 0)
+                                          ? int32_t(1)
+                                          : std::max<int32_t>(int32_t(1),
+                                                              static_cast<int32_t>(avail / bytes_per_prob));
+            wg_size_multiplier = std::min(wg_size_multiplier, max_probs);
+            wg_size = base_wg_size * wg_size_multiplier;
+        }
+
+        const int32_t probs_per_wg = wg_size / static_cast<int32_t>(P);
+        const int32_t num_wg = (static_cast<int32_t>(batch_size) + probs_per_wg - 1) / probs_per_wg;
+        const int32_t global_size = num_wg * wg_size;
+        const int32_t wg_sz = wg_size;
+
+        auto A_local = sycl::local_accessor<T, 1>(sycl::range<1>(probs_per_wg * kTileElems), cgh);
+        auto Z_local = sycl::local_accessor<T, 1>(
+            sycl::range<1>(ComputeVectors ? (probs_per_wg * kTileElems) : 1), cgh);
+        // The rotation cosine/sine pair is stored as one vector so the update
+        // loops issue a single LDS load instead of two. These are broadcast
+        // reads (every lane in a partition reads the same slot), but they are
+        // still LDS *instructions*, and before packing they outnumbered the
+        // actual matrix accesses in the inner loop.
+        auto Rcs_local = sycl::local_accessor<sycl::vec<Real, 2>, 1>(
+            sycl::range<1>(probs_per_wg * kRotSlots), cgh);
+        // The diagonal phase is identically 1 for real types, so it is neither
+        // stored nor loaded there.
+        auto Rd_local = sycl::local_accessor<T, 1>(
+            sycl::range<1>(kNeedPhase ? (probs_per_wg * kRotSlots) : 1), cgh);
+        // Round-robin pivot pairs, precomputed once per work-group and shared by
+        // every problem in it, with the two indices packed into one 16-bit slot.
+        // Computing them inline costs three integer modulos per pair per lane per
+        // phase, which dominated the inner loops.
+        auto Pair_local = sycl::local_accessor<int16_t, 1>(sycl::range<1>(kPairSlots), cgh);
+
+        const int32_t nn = n;
+        const int32_t mm = m;
+        const int32_t nb = static_cast<int32_t>(batch_size);
+        const int32_t max_sweeps = std::max<int32_t>(int32_t(1), static_cast<int32_t>(params.max_sweeps));
+        const bool do_sort = params.sort;
+        const bool ascending = (params.sort_order == SortOrder::Ascending);
+
+        // Relative off-diagonal threshold. A rotation is applied only when
+        //     |a_pq| > tol * sqrt(|a_pp| * |a_qq|)
+        // (Demmel & Veselic; LAWN 169 Remark 2.2). Using the classical absolute
+        // test |a_pq| <= tol * max|a_kl| instead would forfeit the entire
+        // relative-accuracy advantage that motivates this kernel.
+        const Real tol = params.tol_multiplier
+                       * static_cast<Real>(nn)
+                       * std::numeric_limits<Real>::epsilon();
+        // Only ever treat truly denormal/zero off-diagonals as unconditionally
+        // converged. This is a guard against churn when a diagonal entry passes
+        // through zero on an indefinite matrix (which makes the relative
+        // threshold demand |a_pq| == 0 exactly); it sits far below any magnitude
+        // that affects the accuracy bound.
+        const Real tiny = std::numeric_limits<Real>::min();
+        // Above this magnitude tau*tau would overflow, so use the asymptotic
+        // branch t ~ 1/(2*tau) instead.
+        const Real tau_big = Real(1) / sycl::sqrt(std::numeric_limits<Real>::epsilon());
+
+        Real* W = w_ptr;
+
+        cgh.parallel_for<SyevJacobiCTAKernel<T, P, ComputeVectors, Upper>>(
+            sycl::nd_range<1>(global_size, wg_size),
+            [=](sycl::nd_item<1> it) {
+                const auto wg = it.get_group();
+                const int32_t wg_id = static_cast<int32_t>(wg.get_group_linear_id());
+                const int32_t local_id = static_cast<int32_t>(it.get_local_linear_id());
+
+                const int32_t pairs_per_round = mm / 2;
+                const int32_t rounds = mm - 1;
+
+                // Build the shared pivot-pair table. This must happen before any
+                // early return, since it ends in a work-group barrier.
+                for (int32_t idx = local_id; idx < rounds * pairs_per_round; idx += wg_sz) {
+                    const int32_t t = idx / pairs_per_round;
+                    const int32_t k = idx - t * pairs_per_round;
+                    int32_t p = 0;
+                    int32_t q = 0;
+                    round_robin_pair(mm, t, k, p, q);
+                    Pair_local[idx] = static_cast<int16_t>(p | (q << 8));
+                }
+                sycl::group_barrier(wg);
+
+                const auto sg = it.get_sub_group();
+                const auto part = make_partition<P>(sg);
+
+                const int32_t sg_id = static_cast<int32_t>(sg.get_group_linear_id());
+                const int32_t parts_per_sg = static_cast<int32_t>(part.get_group_linear_range());
+                const int32_t part_id = sg_id * parts_per_sg + static_cast<int32_t>(part.get_group_linear_id());
+
+                const int32_t lane = static_cast<int32_t>(part.get_local_linear_id());
+                const int32_t prob_id = wg_id * probs_per_wg + part_id;
+                if (prob_id >= nb) return;
+
+                auto A_prob = A_view.batch_item(prob_id);
+
+                const int32_t base_a = part_id * static_cast<int32_t>(kTileElems);
+                const int32_t base_z = ComputeVectors ? (part_id * static_cast<int32_t>(kTileElems)) : 0;
+                const int32_t base_r = part_id * static_cast<int32_t>(kRotSlots);
+
+                // ---- Load: symmetrize from the requested triangle. ----
+                // The pad region is zeroed so that no uninitialized value can ever
+                // reach the arithmetic, even though the pivot schedule never
+                // selects a padded index.
+                for (int32_t c = 0; c < static_cast<int32_t>(P); ++c) {
+                    T v = T(0);
+                    if (lane < nn && c < nn) {
+                        if constexpr (Upper) {
+                            v = (lane <= c) ? A_prob(lane, c) : conj_if_complex_j(A_prob(c, lane));
+                        } else {
+                            v = (lane >= c) ? A_prob(lane, c) : conj_if_complex_j(A_prob(c, lane));
+                        }
+                        if (lane == c) {
+                            // The diagonal of a Hermitian matrix is real by
+                            // definition; drop any imaginary noise in the input.
+                            if constexpr (internal::is_complex<T>::value) {
+                                v = T(v.real(), Real(0));
+                            }
+                        }
+                    }
+                    A_local[base_a + lane + c * LD] = v;
+                    if constexpr (ComputeVectors) {
+                        Z_local[base_z + lane + c * LD] = (lane == c && lane < nn) ? T(1) : T(0);
+                    }
+                }
+                group_barrier(part);
+
+                const bool pair_lane = (lane < pairs_per_round);
+                const bool row_lane = (lane < nn);
+
+                // ---- Sweeps ----
+                for (int32_t sweep = 0; sweep < max_sweeps; ++sweep) {
+                    int32_t rot_count = 0;
+
+                    for (int32_t t = 0; t < rounds; ++t) {
+                        const int32_t tab_base = t * pairs_per_round;
+
+                        int32_t p = 0;
+                        int32_t q = 0;
+                        bool active = false;
+
+                        if (pair_lane) {
+                            const int32_t pq = static_cast<int32_t>(Pair_local[tab_base + lane]);
+                            p = pq & 0xFF;
+                            q = (pq >> 8) & 0xFF;
+                            active = (q < nn);
+                        }
+
+                        // ---- Compute the 2x2 diagonalizing transform. ----
+                        Real c_rot = Real(1);
+                        Real s_rot = Real(0);
+                        T d_rot = T(1);
+
+                        if (active) {
+                            const T apq = A_local[base_a + p + q * LD];
+                            const Real app = real_part_j(A_local[base_a + p + p * LD]);
+                            const Real aqq = real_part_j(A_local[base_a + q + q * LD]);
+                            const Real g_abs = abs_if_complex_j(apq);
+
+                            const Real thresh = tol * sycl::sqrt(sycl::fabs(app) * sycl::fabs(aqq));
+
+                            if (g_abs > thresh && g_abs > tiny) {
+                                // Reduce to a real symmetric 2x2 by a diagonal
+                                // phase similarity, then apply the classic real
+                                // Jacobi rotation. For real T the phase is 1 and
+                                // g carries the sign of a_pq, which is exactly
+                                // Golub & Van Loan Alg. 8.5.1.
+                                Real g;
+                                if constexpr (internal::is_complex<T>::value) {
+                                    g = g_abs;
+                                    d_rot = T(apq.real() / g_abs, -apq.imag() / g_abs);
+                                } else {
+                                    g = apq;
+                                    d_rot = T(1);
+                                }
+
+                                const Real tau = (aqq - app) / (Real(2) * g);
+                                Real tt;
+                                if (sycl::fabs(tau) > tau_big) {
+                                    tt = Real(1) / (Real(2) * tau);
+                                } else {
+                                    tt = sycl::copysign(Real(1), tau)
+                                       / (sycl::fabs(tau) + sycl::sqrt(Real(1) + tau * tau));
+                                }
+                                c_rot = Real(1) / sycl::sqrt(Real(1) + tt * tt);
+                                s_rot = tt * c_rot;
+                                // A rotation that rounds to the identity would
+                                // never annihilate a_pq, so counting it would
+                                // keep the sweep loop alive forever.
+                                if (s_rot == Real(0)) active = false;
+                            } else {
+                                active = false;
+                            }
+                        }
+
+                        if (!active) {
+                            c_rot = Real(1);
+                            s_rot = Real(0);
+                            d_rot = T(1);
+                        }
+
+                        if (pair_lane) {
+                            Rcs_local[base_r + lane] = sycl::vec<Real, 2>(c_rot, s_rot);
+                            if constexpr (kNeedPhase) {
+                                Rd_local[base_r + lane] = d_rot;
+                            }
+                        }
+                        group_barrier(part);
+
+                        // One reduction serves both as the sweep's rotation
+                        // counter and as an early-out for rounds in which every
+                        // pair was skipped. Late sweeps are almost all such
+                        // rounds, and skipping them avoids two full O(n) passes
+                        // over the tile.
+                        const int32_t round_active = partition_reduce_sum_j(part, active ? 1 : 0);
+                        rot_count += round_active;
+                        if (round_active == 0) continue;
+
+                        // ---- Phase 1: A <- A * U, and Z <- Z * U. ----
+                        // Lane owns row `lane`; pairs touch disjoint column
+                        // pairs, so there is no cross-lane hazard within a phase.
+                        if (row_lane) {
+                            for (int32_t k = 0; k < pairs_per_round; ++k) {
+                                const sycl::vec<Real, 2> cs = Rcs_local[base_r + k];
+                                const Real ck = cs[0];
+                                const Real sk = cs[1];
+                                if (sk == Real(0)) continue;
+
+                                const int32_t pq = static_cast<int32_t>(Pair_local[tab_base + k]);
+                                const int32_t pk = pq & 0xFF;
+                                const int32_t qk = (pq >> 8) & 0xFF;
+
+                                T u11 = T(ck);
+                                T u12 = T(sk);
+                                T u21 = T(-sk);
+                                T u22 = T(ck);
+                                if constexpr (kNeedPhase) {
+                                    const T dk = Rd_local[base_r + k];
+                                    u21 = -(dk * T(sk));
+                                    u22 = dk * T(ck);
+                                }
+
+                                const int32_t ip = base_a + lane + pk * LD;
+                                const int32_t iq = base_a + lane + qk * LD;
+                                const T ap = A_local[ip];
+                                const T aq = A_local[iq];
+                                A_local[ip] = ap * u11 + aq * u21;
+                                A_local[iq] = ap * u12 + aq * u22;
+
+                                if constexpr (ComputeVectors) {
+                                    const int32_t zp = base_z + lane + pk * LD;
+                                    const int32_t zq = base_z + lane + qk * LD;
+                                    const T zp_v = Z_local[zp];
+                                    const T zq_v = Z_local[zq];
+                                    Z_local[zp] = zp_v * u11 + zq_v * u21;
+                                    Z_local[zq] = zp_v * u12 + zq_v * u22;
+                                }
+                            }
+                        }
+                        group_barrier(part);
+
+                        // ---- Phase 2: A <- U^H * A. ----
+                        // Lane now owns column `lane`. The annihilated entries are
+                        // stored as exact zeros here rather than in a separate
+                        // pass: the rotation makes them zero in exact arithmetic,
+                        // and forcing it keeps the convergence test from chasing
+                        // rounding noise.
+                        if (row_lane) {
+                            for (int32_t k = 0; k < pairs_per_round; ++k) {
+                                const sycl::vec<Real, 2> cs = Rcs_local[base_r + k];
+                                const Real ck = cs[0];
+                                const Real sk = cs[1];
+                                if (sk == Real(0)) continue;
+
+                                const int32_t pq = static_cast<int32_t>(Pair_local[tab_base + k]);
+                                const int32_t pk = pq & 0xFF;
+                                const int32_t qk = (pq >> 8) & 0xFF;
+
+                                // c, s are real, so conj(u11) = c and
+                                // conj(u12) = s; only the phase conjugates.
+                                const T cu11 = T(ck);
+                                const T cu12 = T(sk);
+                                T cu21 = T(-sk);
+                                T cu22 = T(ck);
+                                if constexpr (kNeedPhase) {
+                                    const T dk = Rd_local[base_r + k];
+                                    cu21 = -(conj_if_complex_j(dk) * T(sk));
+                                    cu22 = conj_if_complex_j(dk) * T(ck);
+                                }
+
+                                const int32_t ip = base_a + pk + lane * LD;
+                                const int32_t iq = base_a + qk + lane * LD;
+                                const T ap = A_local[ip];
+                                const T aq = A_local[iq];
+
+                                T new_p = cu11 * ap + cu21 * aq;
+                                T new_q = cu12 * ap + cu22 * aq;
+
+                                if (lane == qk) {
+                                    new_p = T(0);                       // annihilated a_pq
+                                    new_q = force_real_j(new_q);        // Hermitian diagonal
+                                } else if (lane == pk) {
+                                    new_q = T(0);                       // annihilated a_qp
+                                    new_p = force_real_j(new_p);        // Hermitian diagonal
+                                }
+
+                                A_local[ip] = new_p;
+                                A_local[iq] = new_q;
+                            }
+                        }
+                        group_barrier(part);
+                    }
+
+                    // Converged when a full sweep applied no rotation, i.e. all
+                    // n(n-1)/2 pivot pairs passed the relative threshold test.
+                    if (rot_count == 0) break;
+                }
+
+                // ---- Sort by rank and write back. ----
+                // Rank is computed in parallel (one lane per eigenvalue) rather
+                // than by a serial sort on the leader; ties break on index so the
+                // permutation is a bijection.
+                if (row_lane) {
+                    const Real wj = real_part_j(A_local[base_a + lane + lane * LD]);
+                    int32_t dst = lane;
+                    if (do_sort) {
+                        int32_t rank = 0;
+                        for (int32_t k = 0; k < nn; ++k) {
+                            const Real wk = real_part_j(A_local[base_a + k + k * LD]);
+                            const bool before = ascending
+                                ? (wk < wj || (wk == wj && k < lane))
+                                : (wk > wj || (wk == wj && k < lane));
+                            if (before) ++rank;
+                        }
+                        dst = rank;
+                    }
+
+                    W[static_cast<int64_t>(prob_id) * nn + dst] = wj;
+
+                    if constexpr (ComputeVectors) {
+                        for (int32_t r = 0; r < nn; ++r) {
+                            A_prob(r, dst) = Z_local[base_z + r + lane * LD];
+                        }
+                    }
+                }
+            });
+    });
+}
+
+} // namespace
+
+template <Backend B, typename T>
+Event syev_jacobi_cta(Queue& ctx,
+                      const MatrixView<T, MatrixFormat::Dense>& a_in,
+                      Span<typename base_type<T>::type> eigenvalues,
+                      JobType jobz,
+                      Uplo uplo,
+                      const Span<std::byte>& ws,
+                      JacobiParams<T> params) {
+    (void)ws;
+
+    if (a_in.rows() != a_in.cols()) {
+        throw std::invalid_argument("syev_jacobi_cta: A must be square.");
+    }
+    if (jobz != JobType::NoEigenVectors && jobz != JobType::EigenVectors) {
+        throw std::invalid_argument("syev_jacobi_cta: invalid JobType.");
+    }
+
+    const int64_t n64 = a_in.rows();
+    const int64_t batch64 = a_in.batch_size();
+
+    if (n64 < 1 || n64 > 32) {
+        throw std::invalid_argument("syev_jacobi_cta currently supports 1 <= n <= 32.");
+    }
+
+    const int32_t n = static_cast<int32_t>(n64);
+
+    if (eigenvalues.size() < static_cast<std::size_t>(n64) * static_cast<std::size_t>(batch64)) {
+        throw std::invalid_argument("syev_jacobi_cta: eigenvalues span too small for n*batch.");
+    }
+
+    // CTA backend: requires subgroup size 32 on NVIDIA-like devices.
+    {
+        const auto dev = ctx->get_device();
+        const auto sg_sizes = dev.get_info<sycl::info::device::sub_group_sizes>();
+        bool has32 = false;
+        for (auto sgs : sg_sizes) {
+            if (static_cast<int32_t>(sgs) == 32) {
+                has32 = true;
+                break;
+            }
+        }
+        if (!has32) {
+            throw std::runtime_error("syev_jacobi_cta: device does not support subgroup size 32 required for CTA kernels.");
+        }
+    }
+
+    auto& a = const_cast<MatrixView<T, MatrixFormat::Dense>&>(a_in);
+    auto* w_ptr = eigenvalues.data();
+
+    const bool upper = (uplo == Uplo::Upper);
+    const bool vectors = (jobz == JobType::EigenVectors);
+
+    auto launch = [&](auto P_tag) {
+        constexpr size_t P = decltype(P_tag)::value;
+        if (vectors) {
+            if (upper) syev_jacobi_cta_impl<T, P, true, true>(ctx, a, w_ptr, n, params);
+            else       syev_jacobi_cta_impl<T, P, true, false>(ctx, a, w_ptr, n, params);
+        } else {
+            if (upper) syev_jacobi_cta_impl<T, P, false, true>(ctx, a, w_ptr, n, params);
+            else       syev_jacobi_cta_impl<T, P, false, false>(ctx, a, w_ptr, n, params);
+        }
+    };
+
+    if (n <= 4) {
+        launch(std::integral_constant<size_t, 4>{});
+    } else if (n <= 8) {
+        launch(std::integral_constant<size_t, 8>{});
+    } else if (n <= 16) {
+        launch(std::integral_constant<size_t, 16>{});
+    } else {
+        launch(std::integral_constant<size_t, 32>{});
+    }
+
+    return ctx.get_event();
+}
+
+template <Backend B, typename T>
+size_t syev_jacobi_cta_buffer_size(Queue& ctx,
+                                   const MatrixView<T, MatrixFormat::Dense>& a,
+                                   JobType jobz,
+                                   JacobiParams<T> params) {
+    (void)ctx;
+    (void)jobz;
+    (void)params;
+
+    if (a.rows() != a.cols()) {
+        throw std::invalid_argument("syev_jacobi_cta_buffer_size: A must be square.");
+    }
+    if (a.rows() < 1 || a.rows() > 32) {
+        throw std::invalid_argument("syev_jacobi_cta_buffer_size currently supports 1 <= n <= 32.");
+    }
+
+    // Everything is resident in local memory for the lifetime of the kernel.
+    return 0;
+}
+
+#define SYEV_JACOBI_CTA_INSTANTIATE(back, fp) \
+    template Event syev_jacobi_cta<back, BATCHLAS_UNPAREN fp>(Queue&, const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>&, \
+                                                              Span<typename base_type<BATCHLAS_UNPAREN fp>::type>, JobType, Uplo, \
+                                                              const Span<std::byte>&, JacobiParams<BATCHLAS_UNPAREN fp>); \
+    template size_t syev_jacobi_cta_buffer_size<back, BATCHLAS_UNPAREN fp>(Queue&, const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>&, \
+                                                                           JobType, JacobiParams<BATCHLAS_UNPAREN fp>);
+
+#define SYEV_JACOBI_CTA_INSTANTIATE_FOR_BACKEND(back) \
+    BATCHLAS_FOR_EACH_SCALAR_TYPE_1(SYEV_JACOBI_CTA_INSTANTIATE, back)
+
+#if BATCHLAS_HAS_CUDA_BACKEND
+    SYEV_JACOBI_CTA_INSTANTIATE_FOR_BACKEND(Backend::CUDA)
+#endif
+
+#if BATCHLAS_HAS_ROCM_BACKEND
+    SYEV_JACOBI_CTA_INSTANTIATE_FOR_BACKEND(Backend::ROCM)
+#endif
+
+#if BATCHLAS_HAS_HOST_BACKEND
+    SYEV_JACOBI_CTA_INSTANTIATE_FOR_BACKEND(Backend::NETLIB)
+#endif
+
+#undef SYEV_JACOBI_CTA_INSTANTIATE_FOR_BACKEND
+#undef SYEV_JACOBI_CTA_INSTANTIATE
+
+} // namespace batchlas

--- a/src/extensions/sytrd_cta.cc
+++ b/src/extensions/sytrd_cta.cc
@@ -119,24 +119,25 @@ namespace batchlas {
         // Compute xnorm.
         const Real xsq = x_active ? abs2_if_complex(x) : Real(0);
         const Real sumsq = group_reduce_sum_select_from_group(part, xsq);
-        const Real xnorm = invoke_one_broadcast(part, [&]() {
-            return sycl::sqrt(sumsq);
-        });
+        // `sumsq` is already replicated across the partition, so evaluate the
+        // reflector scalars redundantly instead of serializing onto the leader.
+        const Real xnorm = sycl::sqrt(sumsq);
 
         T tau = T(0);
 
-        // Ensure the leader sees the correct alpha value regardless of where
+        // Ensure every lane sees the correct alpha value regardless of where
         // alpha lives inside the partition.
         const T alpha_leader = select_from_group(part, alpha, static_cast<uint32_t>(alpha_lane));
 
-        const auto [beta_b, tau_b, scale_b] = invoke_one_broadcast(part, [&]() {
-            if (len <= 1) {
-                return std::array<T, 3>{alpha_leader, T(0), T(0)};
-            }
-
+        T beta_b = alpha_leader;
+        T tau_b = T(0);
+        T scale_b = T(0);
+        if (len > 1) {
             const auto scalars = internal::larfg(alpha_leader, xnorm, len);
-            return std::array<T, 3>{scalars.beta, scalars.tau, scalars.scale};
-        });
+            beta_b = scalars.beta;
+            tau_b = scalars.tau;
+            scale_b = scalars.scale;
+        }
 
         tau = tau_b;
 
@@ -345,9 +346,7 @@ namespace batchlas {
                                 // dot = v^H x
                                 const T dot_lane = (lane < m) ? (conj_if_complex(V_local[base_v + lane]) * W_local[base_w + lane]) : T(0);
                                 const T dot = group_reduce_sum_select_from_group(part, dot_lane);
-                                const T alpha2 = invoke_one_broadcast(part, [&]() {
-                                    return T(-0.5) * taui * dot;
-                                });
+                                const T alpha2 = T(-0.5) * taui * dot;
 
                                 // w := x + alpha2 * v
                                 if (lane < m) {
@@ -471,9 +470,7 @@ namespace batchlas {
                                 // dot = v^H x
                                 const T dot_lane = (lane < m) ? (conj_if_complex(V_local[base_v + lane]) * W_local[base_w + lane]) : T(0);
                                 const T dot = group_reduce_sum_select_from_group(part, dot_lane);
-                                const T alpha2 = invoke_one_broadcast(part, [&]() {
-                                    return T(-0.5) * taui * dot;
-                                });
+                                const T alpha2 = T(-0.5) * taui * dot;
 
                                 // w := x + alpha2 * v
                                 if (lane < m) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ set(TEST_TARGETS
     sytrd_cta_tests
     sytrd_blocked_tests
     syev_cta_tests
+    syev_jacobi_cta_tests
     syev_blocked_tests
 )
 

--- a/tests/syev_jacobi_cta_tests.cc
+++ b/tests/syev_jacobi_cta_tests.cc
@@ -1,0 +1,749 @@
+#include <gtest/gtest.h>
+
+#include <blas/enums.hh>
+#include <blas/extensions.hh>
+#include <blas/functions.hh>
+#include <blas/matrix.hh>
+#include <util/sycl-device-queue.hh>
+#include <util/sycl-span.hh>
+#include <util/sycl-vector.hh>
+
+#include "test_utils.hh"
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <type_traits>
+#include <vector>
+
+using namespace batchlas;
+
+namespace {
+template <typename Scalar>
+using RealOf = typename base_type<Scalar>::type;
+
+template <typename Scalar>
+static RealOf<Scalar> abs_val(const Scalar& x) {
+	return static_cast<RealOf<Scalar>>(std::abs(x));
+}
+
+template <typename Scalar>
+static RealOf<Scalar> norm2_val(const Scalar& x) {
+	using Real = RealOf<Scalar>;
+	if constexpr (std::is_same_v<Scalar, Real>) {
+		return x * x;
+	} else {
+		return static_cast<Real>(std::norm(x));
+	}
+}
+
+template <typename Scalar>
+static Scalar conj_val(const Scalar& x) {
+	if constexpr (std::is_same_v<Scalar, RealOf<Scalar>>) {
+		return x;
+	} else {
+		return std::conj(x);
+	}
+}
+
+template <typename Scalar>
+static void check_orthonormal_columns(const MatrixView<Scalar, MatrixFormat::Dense>& V,
+									  int n, int b, RealOf<Scalar> tol) {
+	using Real = RealOf<Scalar>;
+	Real max_err = Real(0);
+	for (int j = 0; j < n; ++j) {
+		for (int i = 0; i < n; ++i) {
+			Scalar dot = Scalar(0);
+			for (int r = 0; r < n; ++r) {
+				dot += conj_val(V(r, i, b)) * V(r, j, b);
+			}
+			const Real target = (i == j) ? Real(1) : Real(0);
+			max_err = std::max(max_err, abs_val(dot - Scalar(target)));
+		}
+	}
+	EXPECT_LE(max_err, tol) << "max |V^H V - I| = " << max_err << " (batch " << b << ")";
+}
+
+template <typename Scalar>
+static void check_eigen_residual(const MatrixView<Scalar, MatrixFormat::Dense>& A0,
+								 const MatrixView<Scalar, MatrixFormat::Dense>& V,
+								 const UnifiedVector<RealOf<Scalar>>& W,
+								 int n, int b, RealOf<Scalar> tol) {
+	using Real = RealOf<Scalar>;
+
+	Real a_norm2 = Real(0);
+	for (int j = 0; j < n; ++j) {
+		for (int i = 0; i < n; ++i) {
+			a_norm2 += norm2_val(A0(i, j, b));
+		}
+	}
+	const Real a_norm = std::sqrt(a_norm2);
+
+	Real r_norm2 = Real(0);
+	for (int j = 0; j < n; ++j) {
+		const Real wj = W[static_cast<std::size_t>(b) * static_cast<std::size_t>(n) + static_cast<std::size_t>(j)];
+		for (int i = 0; i < n; ++i) {
+			Scalar sum = Scalar(0);
+			for (int k = 0; k < n; ++k) {
+				sum += A0(i, k, b) * V(k, j, b);
+			}
+			sum -= Scalar(wj) * V(i, j, b);
+			r_norm2 += norm2_val(sum);
+		}
+	}
+
+	const Real r_norm = std::sqrt(r_norm2);
+	const Real denom = (a_norm > Real(0)) ? (a_norm * Real(n)) : Real(1);
+	const Real rel = r_norm / denom;
+	EXPECT_LE(rel, tol) << "relative residual ||AV - VW||/(||A||*n) = " << rel << " (batch " << b << ")";
+}
+
+template <typename Scalar>
+static Matrix<Scalar, MatrixFormat::Dense> make_near_degenerate_hermitian(int n, int batch, unsigned seed,
+																		 RealOf<Scalar> eps) {
+	using Real = RealOf<Scalar>;
+
+	// NOTE: Avoid Matrix::Zeros/Matrix::Diagonal here: those factory helpers launch
+	// device kernels (often asynchronously) and can race with the host-side writes
+	// below on USM memory.
+	Matrix<Scalar, MatrixFormat::Dense> A(n, n, batch);
+
+	std::minstd_rand rng(seed);
+	std::uniform_real_distribution<Real> dist(Real(-1), Real(1));
+
+	for (int b = 0; b < batch; ++b) {
+		for (int j = 0; j < n; ++j) {
+			for (int i = 0; i <= j; ++i) {
+				Scalar z;
+				if constexpr (std::is_same_v<Scalar, Real>) {
+					z = Scalar(dist(rng));
+				} else {
+					z = Scalar(dist(rng), dist(rng));
+				}
+
+				if (i == j) {
+					const Real base = Real(i / 4);
+					const Real tiny = Real(i % 4) * Real(1e-4);
+					if constexpr (std::is_same_v<Scalar, Real>) {
+						A(i, j, b) = Scalar(base + tiny) + Scalar(eps) * z;
+					} else {
+						A(i, j, b) = Scalar(base + tiny) + Scalar(eps) * Scalar(Real(std::real(z)), Real(0));
+					}
+				} else {
+					const Scalar v = Scalar(eps) * z;
+					A(i, j, b) = v;
+					A(j, i, b) = conj_val(v);
+				}
+			}
+		}
+	}
+
+	return A;
+}
+
+// ---------------------------------------------------------------------------
+// Independent CPU reference: cyclic-by-rows two-sided Jacobi in double.
+//
+// Used as the "truth" for the graded/badly-scaled accuracy test. A double
+// LAPACK syev cannot serve that role: it tridiagonalizes, so its own error on
+// the smallest eigenvalue of a strongly graded matrix is ~eps_double*||A||,
+// which is far larger than the eigenvalue itself. Jacobi in double does have
+// the relative-accuracy property, and this routine is deliberately simple and
+// independent of the kernel under test.
+// ---------------------------------------------------------------------------
+static std::vector<double> reference_jacobi_eigenvalues(const std::vector<double>& A_in, int n) {
+	std::vector<double> A = A_in; // column-major n x n
+	const double tol = double(n) * std::numeric_limits<double>::epsilon();
+
+	for (int sweep = 0; sweep < 100; ++sweep) {
+		int rotations = 0;
+		for (int p = 0; p < n - 1; ++p) {
+			for (int q = p + 1; q < n; ++q) {
+				const double apq = A[p + q * n];
+				const double app = A[p + p * n];
+				const double aqq = A[q + q * n];
+				if (std::abs(apq) <= tol * std::sqrt(std::abs(app) * std::abs(aqq))) continue;
+				if (apq == 0.0) continue;
+
+				const double tau = (aqq - app) / (2.0 * apq);
+				const double t = std::copysign(1.0, tau) / (std::abs(tau) + std::sqrt(1.0 + tau * tau));
+				const double c = 1.0 / std::sqrt(1.0 + t * t);
+				const double s = t * c;
+
+				// A <- J^T A J with J = [[c, s], [-s, c]] on rows/cols (p,q).
+				for (int r = 0; r < n; ++r) {
+					const double arp = A[r + p * n];
+					const double arq = A[r + q * n];
+					A[r + p * n] = c * arp - s * arq;
+					A[r + q * n] = s * arp + c * arq;
+				}
+				for (int cc = 0; cc < n; ++cc) {
+					const double apc = A[p + cc * n];
+					const double aqc = A[q + cc * n];
+					A[p + cc * n] = c * apc - s * aqc;
+					A[q + cc * n] = s * apc + c * aqc;
+				}
+				A[p + q * n] = 0.0;
+				A[q + p * n] = 0.0;
+				++rotations;
+			}
+		}
+		if (rotations == 0) break;
+	}
+
+	std::vector<double> w(static_cast<std::size_t>(n));
+	for (int i = 0; i < n; ++i) w[static_cast<std::size_t>(i)] = A[i + i * n];
+	std::sort(w.begin(), w.end());
+	return w;
+}
+
+// Graded SPD matrix A = D * M * D with D = diag(2^{-grade*k}) and M a
+// well-conditioned, diagonally dominant SPD matrix with dyadic entries.
+//
+// Every entry of A is a dyadic rational, so the matrix is represented exactly in
+// both float and double: the float and double solvers see the *same* matrix and
+// any difference in the result is entirely due to precision, not to input
+// rounding. kappa(A) is astronomically large while kappa of the
+// column-equilibrated matrix stays ~kappa(M), which is precisely the regime
+// where Jacobi's relative-accuracy bound bites and a tridiagonalizing method
+// loses the small eigenvalues.
+static void make_graded_spd(int n, int grade, unsigned seed,
+							std::vector<double>& out_double,
+							std::vector<float>& out_float) {
+	std::minstd_rand rng(seed);
+	std::uniform_int_distribution<int> dist(-16, 16);
+
+	std::vector<double> M(static_cast<std::size_t>(n) * static_cast<std::size_t>(n), 0.0);
+	for (int j = 0; j < n; ++j) {
+		for (int i = j; i < n; ++i) {
+			if (i == j) {
+				M[i + j * n] = 1.0;
+			} else {
+				const double v = double(dist(rng)) / 256.0; // dyadic, |v| <= 1/16
+				M[i + j * n] = v;
+				M[j + i * n] = v;
+			}
+		}
+	}
+
+	std::vector<double> D(static_cast<std::size_t>(n));
+	for (int i = 0; i < n; ++i) D[static_cast<std::size_t>(i)] = std::ldexp(1.0, -grade * i);
+
+	out_double.assign(static_cast<std::size_t>(n) * static_cast<std::size_t>(n), 0.0);
+	out_float.assign(static_cast<std::size_t>(n) * static_cast<std::size_t>(n), 0.0f);
+	for (int j = 0; j < n; ++j) {
+		for (int i = 0; i < n; ++i) {
+			const double v = D[static_cast<std::size_t>(i)] * M[i + j * n] * D[static_cast<std::size_t>(j)];
+			out_double[static_cast<std::size_t>(i + j * n)] = v;
+			out_float[static_cast<std::size_t>(i + j * n)] = static_cast<float>(v);
+		}
+	}
+}
+
+// Tolerance for comparing against an independent eigensolver.
+//
+// Both solvers carry a backward error of order eps*||A||, so the *absolute*
+// agreement between them scales with the spectral radius; a fixed absolute
+// tolerance silently becomes a relative tolerance of eps only when ||A|| ~ 1.
+// The scaling below is what makes the comparison size-independent.
+// (Agreement at the eps*||A|| level is verified directly, against a double
+// reference, in RandomSymmetricMatchesDoubleReference.)
+template <typename Scalar>
+static RealOf<Scalar> eig_compare_tol(const UnifiedVector<RealOf<Scalar>>& w_ref, int n, int batch) {
+	using Real = RealOf<Scalar>;
+	Real lambda_max = Real(1);
+	for (int i = 0; i < n * batch; ++i) {
+		lambda_max = std::max(lambda_max, std::abs(w_ref[static_cast<std::size_t>(i)]));
+	}
+	return test_utils::tolerance<Scalar>() * lambda_max;
+}
+
+// Random symmetric matrix with dyadic entries, so it is represented exactly in
+// both float and double and the two precisions see identical input.
+static void make_dyadic_symmetric(int n, unsigned seed,
+								  std::vector<double>& out_double,
+								  std::vector<float>& out_float) {
+	std::minstd_rand rng(seed);
+	std::uniform_int_distribution<int> dist(-1024, 1024);
+
+	out_double.assign(static_cast<std::size_t>(n) * static_cast<std::size_t>(n), 0.0);
+	out_float.assign(static_cast<std::size_t>(n) * static_cast<std::size_t>(n), 0.0f);
+	for (int j = 0; j < n; ++j) {
+		for (int i = j; i < n; ++i) {
+			const double v = double(dist(rng)) / 1024.0; // dyadic in [-1, 1]
+			out_double[static_cast<std::size_t>(i + j * n)] = v;
+			out_double[static_cast<std::size_t>(j + i * n)] = v;
+			out_float[static_cast<std::size_t>(i + j * n)] = static_cast<float>(v);
+			out_float[static_cast<std::size_t>(j + i * n)] = static_cast<float>(v);
+		}
+	}
+}
+
+// Accumulated rounding over n(n-1)/2 rotations grows with problem size, so the
+// fixed absolute tolerance from test_utils is scaled by sqrt(n). Measured
+// values: ||V^H V - I|| ~ 86*eps at n=32 in single precision.
+template <typename Scalar>
+static RealOf<Scalar> vec_tol(int n, RealOf<Scalar> extra = RealOf<Scalar>(1)) {
+	using Real = RealOf<Scalar>;
+	return test_utils::tolerance<Scalar>() * std::sqrt(Real(n)) * extra;
+}
+
+template <typename T, Backend B>
+struct SyevJacobiCtaConfig {
+	using ScalarType = T;
+	static constexpr Backend BackendVal = B;
+};
+
+} // namespace
+
+#if BATCHLAS_HAS_CUDA_BACKEND
+using SyevJacobiCtaTestTypes = ::testing::Types<
+	SyevJacobiCtaConfig<float, Backend::CUDA>,
+	SyevJacobiCtaConfig<double, Backend::CUDA>,
+	SyevJacobiCtaConfig<std::complex<float>, Backend::CUDA>,
+	SyevJacobiCtaConfig<std::complex<double>, Backend::CUDA>>;
+#elif BATCHLAS_HAS_ROCM_BACKEND
+using SyevJacobiCtaTestTypes = ::testing::Types<
+	SyevJacobiCtaConfig<float, Backend::ROCM>,
+	SyevJacobiCtaConfig<double, Backend::ROCM>,
+	SyevJacobiCtaConfig<std::complex<float>, Backend::ROCM>,
+	SyevJacobiCtaConfig<std::complex<double>, Backend::ROCM>>;
+#else
+using SyevJacobiCtaTestTypes = ::testing::Types<SyevJacobiCtaConfig<float, Backend::NETLIB>>;
+#endif
+
+template <typename Config>
+class SyevJacobiCtaTest : public test_utils::BatchLASTest<Config> {};
+
+TYPED_TEST_SUITE(SyevJacobiCtaTest, SyevJacobiCtaTestTypes);
+
+#if BATCHLAS_HAS_CUDA_BACKEND || BATCHLAS_HAS_ROCM_BACKEND
+
+TYPED_TEST(SyevJacobiCtaTest, EigenvaluesOnlyMatchesNetlib) {
+	using Scalar = typename TestFixture::ScalarType;
+	using Real = typename base_type<Scalar>::type;
+	constexpr Backend B = TestFixture::BackendType;
+
+	const int n = 16;
+	const int batch = 64;
+
+	for (auto uplo : {Uplo::Lower, Uplo::Upper}) {
+		SCOPED_TRACE(::testing::Message() << "uplo=" << (uplo == Uplo::Lower ? "Lower" : "Upper"));
+
+		Matrix<Scalar, MatrixFormat::Dense> A0 =
+			Matrix<Scalar, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/123);
+		Matrix<Scalar, MatrixFormat::Dense> A_jac = A0;
+		Matrix<Scalar, MatrixFormat::Dense> A_ref = A0;
+
+		auto W_jac = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+		auto W_ref = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+
+#if BATCHLAS_HAS_HOST_BACKEND
+		{
+			auto ws_ref = UnifiedVector<std::byte>(syev_buffer_size<Backend::NETLIB>(
+				*this->ctx, A_ref.view(), W_ref.to_span(), JobType::NoEigenVectors, uplo));
+			syev<Backend::NETLIB>(*this->ctx, A_ref.view(), W_ref.to_span(), JobType::NoEigenVectors, uplo,
+								  ws_ref.to_span()).wait();
+		}
+#endif
+
+		syev_jacobi_cta<B, Scalar>(*this->ctx, A_jac.view(), W_jac.to_span(), JobType::NoEigenVectors, uplo).wait();
+
+#if BATCHLAS_HAS_HOST_BACKEND
+		const Real tol = eig_compare_tol<Scalar>(W_ref, n, batch);
+		for (int b = 0; b < batch; ++b) {
+			for (int i = 0; i < n; ++i) {
+				const std::size_t idx = static_cast<std::size_t>(b) * static_cast<std::size_t>(n)
+									  + static_cast<std::size_t>(i);
+				ASSERT_NEAR(W_jac[idx], W_ref[idx], tol) << "eigenvalue mismatch i=" << i << " batch=" << b;
+			}
+		}
+#endif
+	}
+}
+
+TYPED_TEST(SyevJacobiCtaTest, EigenvaluesOnlyLeavesMatrixUntouched) {
+	using Scalar = typename TestFixture::ScalarType;
+	using Real = typename base_type<Scalar>::type;
+	constexpr Backend B = TestFixture::BackendType;
+
+	const int n = 12;
+	const int batch = 2;
+
+	Matrix<Scalar, MatrixFormat::Dense> A0 =
+		Matrix<Scalar, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/99);
+	Matrix<Scalar, MatrixFormat::Dense> A = A0;
+	auto W = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+
+	syev_jacobi_cta<B, Scalar>(*this->ctx, A.view(), W.to_span(), JobType::NoEigenVectors, Uplo::Lower).wait();
+
+	for (int b = 0; b < batch; ++b) {
+		for (int j = 0; j < n; ++j) {
+			for (int i = 0; i < n; ++i) {
+				ASSERT_EQ(A.view()(i, j, b), A0.view()(i, j, b))
+					<< "A was modified at (" << i << "," << j << "," << b << ") for NoEigenVectors";
+			}
+		}
+	}
+}
+
+TYPED_TEST(SyevJacobiCtaTest, EigenvectorsResidualAndOrtho) {
+	using Scalar = typename TestFixture::ScalarType;
+	using Real = typename base_type<Scalar>::type;
+	constexpr Backend B = TestFixture::BackendType;
+
+	const int batch = 2;
+
+	for (int n : {16, 32}) {
+		for (auto uplo : {Uplo::Lower, Uplo::Upper}) {
+			SCOPED_TRACE(::testing::Message() << "n=" << n
+							<< " uplo=" << (uplo == Uplo::Lower ? "Lower" : "Upper"));
+
+			Matrix<Scalar, MatrixFormat::Dense> A0 =
+				Matrix<Scalar, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/456);
+			Matrix<Scalar, MatrixFormat::Dense> A_jac = A0;
+			Matrix<Scalar, MatrixFormat::Dense> A_ref = A0;
+
+			auto W_jac = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+			auto W_ref = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+
+#if BATCHLAS_HAS_HOST_BACKEND
+			{
+				auto ws_ref = UnifiedVector<std::byte>(syev_buffer_size<Backend::NETLIB>(
+					*this->ctx, A_ref.view(), W_ref.to_span(), JobType::NoEigenVectors, uplo));
+				syev<Backend::NETLIB>(*this->ctx, A_ref.view(), W_ref.to_span(), JobType::NoEigenVectors, uplo,
+									  ws_ref.to_span()).wait();
+			}
+#endif
+
+			syev_jacobi_cta<B, Scalar>(*this->ctx, A_jac.view(), W_jac.to_span(), JobType::EigenVectors, uplo).wait();
+
+#if BATCHLAS_HAS_HOST_BACKEND
+			const Real tol_w = eig_compare_tol<Scalar>(W_ref, n, batch);
+			for (int b = 0; b < batch; ++b) {
+				for (int i = 0; i < n; ++i) {
+					const std::size_t idx = static_cast<std::size_t>(b) * static_cast<std::size_t>(n)
+										  + static_cast<std::size_t>(i);
+					ASSERT_NEAR(W_jac[idx], W_ref[idx], tol_w) << "eigenvalue mismatch i=" << i << " batch=" << b;
+				}
+			}
+#endif
+
+			for (int b = 0; b < batch; ++b) {
+				check_orthonormal_columns(A_jac.view(), n, b, vec_tol<Scalar>(n));
+				check_eigen_residual(A0.view(), A_jac.view(), W_jac, n, b, vec_tol<Scalar>(n));
+			}
+		}
+	}
+}
+
+// Odd n exercises the padded round-robin schedule: the pivot index space is
+// rounded up to n+1 and pairs touching the phantom index must be skipped.
+TYPED_TEST(SyevJacobiCtaTest, OddAndSmallSizes) {
+	using Scalar = typename TestFixture::ScalarType;
+	using Real = typename base_type<Scalar>::type;
+	constexpr Backend B = TestFixture::BackendType;
+
+	const int batch = 3;
+
+	for (int n : {1, 2, 3, 5, 7, 13, 17, 31}) {
+		SCOPED_TRACE(::testing::Message() << "n=" << n);
+
+		Matrix<Scalar, MatrixFormat::Dense> A0 = Matrix<Scalar, MatrixFormat::Dense>::Random(
+			n, n, /*hermitian=*/true, batch, /*seed=*/static_cast<unsigned>(1000 + n));
+		Matrix<Scalar, MatrixFormat::Dense> A_jac = A0;
+		Matrix<Scalar, MatrixFormat::Dense> A_ref = A0;
+
+		auto W_jac = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+		auto W_ref = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+
+#if BATCHLAS_HAS_HOST_BACKEND
+		{
+			auto ws_ref = UnifiedVector<std::byte>(syev_buffer_size<Backend::NETLIB>(
+				*this->ctx, A_ref.view(), W_ref.to_span(), JobType::NoEigenVectors, Uplo::Lower));
+			syev<Backend::NETLIB>(*this->ctx, A_ref.view(), W_ref.to_span(), JobType::NoEigenVectors, Uplo::Lower,
+								  ws_ref.to_span()).wait();
+		}
+#endif
+
+		syev_jacobi_cta<B, Scalar>(*this->ctx, A_jac.view(), W_jac.to_span(), JobType::EigenVectors, Uplo::Lower).wait();
+
+#if BATCHLAS_HAS_HOST_BACKEND
+		const Real tol_w = eig_compare_tol<Scalar>(W_ref, n, batch);
+		for (int b = 0; b < batch; ++b) {
+			for (int i = 0; i < n; ++i) {
+				const std::size_t idx = static_cast<std::size_t>(b) * static_cast<std::size_t>(n)
+									  + static_cast<std::size_t>(i);
+				ASSERT_NEAR(W_jac[idx], W_ref[idx], tol_w) << "eigenvalue mismatch i=" << i << " batch=" << b;
+			}
+		}
+#endif
+
+		for (int b = 0; b < batch; ++b) {
+			check_orthonormal_columns(A_jac.view(), n, b, vec_tol<Scalar>(n));
+			check_eigen_residual(A0.view(), A_jac.view(), W_jac, n, b, vec_tol<Scalar>(n));
+		}
+	}
+}
+
+TYPED_TEST(SyevJacobiCtaTest, DescendingSortOrder) {
+	using Scalar = typename TestFixture::ScalarType;
+	using Real = typename base_type<Scalar>::type;
+	constexpr Backend B = TestFixture::BackendType;
+
+	const int n = 16;
+	const int batch = 2;
+
+	Matrix<Scalar, MatrixFormat::Dense> A0 =
+		Matrix<Scalar, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/2468);
+	Matrix<Scalar, MatrixFormat::Dense> A_asc = A0;
+	Matrix<Scalar, MatrixFormat::Dense> A_desc = A0;
+
+	auto W_asc = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+	auto W_desc = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+
+	JacobiParams<Scalar> p_desc;
+	p_desc.sort_order = SortOrder::Descending;
+
+	syev_jacobi_cta<B, Scalar>(*this->ctx, A_asc.view(), W_asc.to_span(), JobType::EigenVectors, Uplo::Lower).wait();
+	syev_jacobi_cta<B, Scalar>(*this->ctx, A_desc.view(), W_desc.to_span(), JobType::EigenVectors, Uplo::Lower,
+							   Span<std::byte>(), p_desc).wait();
+
+	for (int b = 0; b < batch; ++b) {
+		for (int i = 0; i < n; ++i) {
+			const std::size_t ia = static_cast<std::size_t>(b) * static_cast<std::size_t>(n)
+								 + static_cast<std::size_t>(i);
+			const std::size_t id = static_cast<std::size_t>(b) * static_cast<std::size_t>(n)
+								 + static_cast<std::size_t>(n - 1 - i);
+			ASSERT_NEAR(W_asc[ia], W_desc[id], test_utils::tolerance<Scalar>())
+				<< "descending order does not mirror ascending at i=" << i;
+		}
+		for (int i = 1; i < n; ++i) {
+			const std::size_t prev = static_cast<std::size_t>(b) * static_cast<std::size_t>(n)
+								   + static_cast<std::size_t>(i - 1);
+			const std::size_t cur = static_cast<std::size_t>(b) * static_cast<std::size_t>(n)
+								  + static_cast<std::size_t>(i);
+			ASSERT_GE(W_desc[prev], W_desc[cur]) << "not descending at i=" << i;
+		}
+	}
+}
+
+TYPED_TEST(SyevJacobiCtaTest, NearDegenerateResidualAndOrtho) {
+	using Scalar = typename TestFixture::ScalarType;
+	using Real = typename base_type<Scalar>::type;
+	constexpr Backend B = TestFixture::BackendType;
+
+	const int batch = 1;
+
+	for (int n : {24, 32}) {
+		SCOPED_TRACE(::testing::Message() << "n=" << n);
+
+		Matrix<Scalar, MatrixFormat::Dense> A0 = make_near_degenerate_hermitian<Scalar>(
+			n, batch, /*seed=*/static_cast<unsigned>(1337 + n), Real(1e-3));
+		Matrix<Scalar, MatrixFormat::Dense> A_jac = A0;
+
+		auto W_jac = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+
+		syev_jacobi_cta<B, Scalar>(*this->ctx, A_jac.view(), W_jac.to_span(), JobType::EigenVectors, Uplo::Lower).wait();
+
+		check_orthonormal_columns(A_jac.view(), n, 0, vec_tol<Scalar>(n, Real(10)));
+		check_eigen_residual(A0.view(), A_jac.view(), W_jac, n, 0, vec_tol<Scalar>(n, Real(10)));
+	}
+}
+
+TYPED_TEST(SyevJacobiCtaTest, RepeatedRunsDoNotHang) {
+	using Scalar = typename TestFixture::ScalarType;
+	using Real = typename base_type<Scalar>::type;
+	constexpr Backend B = TestFixture::BackendType;
+
+	const int n = 16;
+	const int batch = 4;
+	const int iters = 50;
+
+	Matrix<Scalar, MatrixFormat::Dense> A0 =
+		Matrix<Scalar, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/2025);
+	auto W = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+
+	for (int t = 0; t < iters; ++t) {
+		Matrix<Scalar, MatrixFormat::Dense> A = A0;
+		syev_jacobi_cta<B, Scalar>(*this->ctx, A.view(), W.to_span(), JobType::EigenVectors, Uplo::Lower).wait();
+	}
+}
+
+// Verifies that the float kernel agrees with an exact-input double reference to
+// within a small multiple of eps*||A||, i.e. that it is backward stable at the
+// level theory predicts. This is what licenses the ||A||-scaled tolerance used
+// when cross-checking against LAPACK above: the discrepancy there is ordinary
+// float rounding shared by any backward-stable solver, not a deficiency of this
+// kernel.
+TEST(SyevJacobiCtaAccuracy, RandomSymmetricMatchesDoubleReference) {
+#if BATCHLAS_HAS_CUDA_BACKEND
+	constexpr Backend B = Backend::CUDA;
+#else
+	constexpr Backend B = Backend::ROCM;
+#endif
+	if (!test_utils::should_run_backend(B)) {
+		GTEST_SKIP() << "Backend filtered by BATCHLAS_TEST_BACKEND environment variable";
+	}
+	if (!test_utils::should_run_float_type<float>()) {
+		GTEST_SKIP() << "Float type filtered by BATCHLAS_TEST_FLOAT_TYPE environment variable";
+	}
+	auto ctx = Queue("gpu", true);
+	if (ctx.device().type != DeviceType::GPU) {
+		GTEST_SKIP() << "GPU backend requires GPU device, but none was selected";
+	}
+
+	for (int n : {8, 16, 31, 32}) {
+		SCOPED_TRACE(::testing::Message() << "n=" << n);
+
+		std::vector<double> A_d;
+		std::vector<float> A_f;
+		make_dyadic_symmetric(n, /*seed=*/static_cast<unsigned>(555 + n), A_d, A_f);
+
+		const std::vector<double> w_true = reference_jacobi_eigenvalues(A_d, n);
+
+		double a_fro = 0.0;
+		for (double v : A_d) a_fro += v * v;
+		a_fro = std::sqrt(a_fro);
+
+		Matrix<float, MatrixFormat::Dense> A(n, n, 1);
+		for (int j = 0; j < n; ++j) {
+			for (int i = 0; i < n; ++i) {
+				A.view()(i, j, 0) = A_f[static_cast<std::size_t>(i + j * n)];
+			}
+		}
+
+		auto W = UnifiedVector<float>(static_cast<std::size_t>(n));
+		syev_jacobi_cta<B, float>(ctx, A.view(), W.to_span(), JobType::NoEigenVectors, Uplo::Lower).wait();
+
+		double max_abs = 0.0;
+		for (int i = 0; i < n; ++i) {
+			max_abs = std::max(max_abs,
+							   std::abs(static_cast<double>(W[static_cast<std::size_t>(i)])
+										- w_true[static_cast<std::size_t>(i)]));
+		}
+
+		// LAWN 169 Prop. 2.3 bounds the backward error of s cyclic sweeps by
+		// O(s*n*eps); with s ~ 7 the measured constant here is ~24, so a bound of
+		// 2*n leaves headroom while still catching an order-of-magnitude
+		// regression.
+		const double unit = static_cast<double>(std::numeric_limits<float>::epsilon()) * a_fro;
+		std::cout << "  n=" << n << ": max |lambda_float - lambda_double| = " << max_abs
+				  << " = " << (max_abs / unit) << " * eps*||A||_F\n";
+		EXPECT_LE(max_abs, 2.0 * double(n) * unit)
+			<< "max |lambda_float - lambda_double| = " << max_abs
+			<< " = " << (max_abs / unit) << " * eps*||A||_F (||A||_F = " << a_fro << ")";
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The payoff test: high relative accuracy on a graded SPD matrix.
+//
+// This is the reason the kernel exists. A = D*M*D with D spanning many decades
+// has kappa(A) ~ 1e30 but kappa of the column-equilibrated matrix ~ kappa(M) ~ 1.
+// Jacobi with the relative threshold must resolve the *smallest* eigenvalues to
+// near-full relative precision; a tridiagonalization-based solver cannot, since
+// its error is proportional to eps*||A|| which dwarfs them.
+//
+// Reference is an independent double-precision CPU Jacobi (see above). The
+// matrix entries are dyadic, so float and double see bit-identical input.
+// ---------------------------------------------------------------------------
+TEST(SyevJacobiCtaAccuracy, GradedSpdRelativeAccuracy) {
+#if BATCHLAS_HAS_CUDA_BACKEND
+	constexpr Backend B = Backend::CUDA;
+#else
+	constexpr Backend B = Backend::ROCM;
+#endif
+
+	if (!test_utils::should_run_backend(B)) {
+		GTEST_SKIP() << "Backend filtered by BATCHLAS_TEST_BACKEND environment variable";
+	}
+	if (!test_utils::should_run_float_type<float>()) {
+		GTEST_SKIP() << "Float type filtered by BATCHLAS_TEST_FLOAT_TYPE environment variable";
+	}
+	auto ctx = Queue("gpu", true);
+	if (ctx.device().type != DeviceType::GPU) {
+		GTEST_SKIP() << "GPU backend requires GPU device, but none was selected";
+	}
+
+	const int n = 16;
+	const int grade = 4; // D_ii = 2^{-4i}, so kappa(A) ~ 2^{120} ~ 1.3e36
+
+	std::vector<double> A_d;
+	std::vector<float> A_f;
+	make_graded_spd(n, grade, /*seed=*/20240601, A_d, A_f);
+
+	const std::vector<double> w_true = reference_jacobi_eigenvalues(A_d, n);
+
+	// Sanity: the construction really is graded and positive definite.
+	ASSERT_GT(w_true.front(), 0.0) << "reference says the test matrix is not positive definite";
+	ASSERT_LT(w_true.front() / w_true.back(), 1e-20) << "test matrix is not graded enough to be discriminating";
+
+	Matrix<float, MatrixFormat::Dense> A_jac(n, n, 1);
+	for (int j = 0; j < n; ++j) {
+		for (int i = 0; i < n; ++i) {
+			A_jac.view()(i, j, 0) = A_f[static_cast<std::size_t>(i + j * n)];
+		}
+	}
+
+	auto W = UnifiedVector<float>(static_cast<std::size_t>(n));
+	syev_jacobi_cta<B, float>(ctx, A_jac.view(), W.to_span(), JobType::NoEigenVectors, Uplo::Lower).wait();
+
+	double max_rel = 0.0;
+	for (int i = 0; i < n; ++i) {
+		const double got = static_cast<double>(W[static_cast<std::size_t>(i)]);
+		const double want = w_true[static_cast<std::size_t>(i)];
+		const double rel = std::abs(got - want) / std::abs(want);
+		max_rel = std::max(max_rel, rel);
+		std::cout << "  lambda[" << i << "] jacobi=" << got << " ref=" << want << " rel=" << rel << "\n";
+	}
+
+	// Relative, not absolute: every eigenvalue including the smallest must be
+	// accurate to a modest multiple of float eps. An absolute-accuracy solver
+	// would show rel ~ 1 on the small end.
+	const double bound = 200.0 * static_cast<double>(std::numeric_limits<float>::epsilon());
+	EXPECT_LE(max_rel, bound) << "max relative eigenvalue error " << max_rel
+							  << " exceeds " << bound
+							  << " -- the relative-accuracy property is not being achieved";
+
+	// Informational head-to-head against the tridiagonalization-based path on
+	// the same input. Deliberately NOT asserted: this documents why the Jacobi
+	// kernel exists without pinning a competitor's numbers into the test suite.
+	{
+		Matrix<float, MatrixFormat::Dense> A_tri(n, n, 1);
+		for (int j = 0; j < n; ++j) {
+			for (int i = 0; i < n; ++i) {
+				A_tri.view()(i, j, 0) = A_f[static_cast<std::size_t>(i + j * n)];
+			}
+		}
+		auto W_tri = UnifiedVector<float>(static_cast<std::size_t>(n));
+		SteqrParams<float> sp;
+		auto ws = UnifiedVector<std::byte>(
+			syev_cta_buffer_size<B, float>(ctx, A_tri.view(), JobType::NoEigenVectors, sp));
+		syev_cta<B, float>(ctx, A_tri.view(), W_tri.to_span(), JobType::NoEigenVectors, Uplo::Lower,
+						   ws.to_span(), sp).wait();
+
+		std::vector<float> w_tri(W_tri.begin(), W_tri.begin() + n);
+		std::sort(w_tri.begin(), w_tri.end());
+
+		double tri_max_rel = 0.0;
+		for (int i = 0; i < n; ++i) {
+			const double want = w_true[static_cast<std::size_t>(i)];
+			tri_max_rel = std::max(tri_max_rel,
+								   std::abs(static_cast<double>(w_tri[static_cast<std::size_t>(i)]) - want)
+									   / std::abs(want));
+		}
+		std::cout << "  [informational] max relative error: jacobi_cta=" << max_rel
+				  << "  syev_cta(sytrd+steqr)=" << tri_max_rel << "\n";
+	}
+}
+#endif
+
+int main(int argc, char** argv) {
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Adds a Jacobi-based symmetric/Hermitian eigensolver as a second `syev` backend, plus a round of performance work on the existing CTA and blocked kernels.

## Why

`syev_cta` runs `sytrd → steqr → ormqr`, i.e. it tridiagonalizes. Any such method bounds relative eigenvalue error by `eps·kappa(H)`. Jacobi with a *relative* off-diagonal threshold is instead bounded by `eps·kappa(A_c)` — the condition number of the column-equilibrated matrix (Demmel & Veselic, SIMAX 13(4), 1992). On graded or badly scaled input those differ enormously.

On a graded SPD matrix with `kappa(A) ~ 1e36` and a spectrum spanning `7.3e-37` to `1.0`:

| solver | max **relative** eigenvalue error |
|---|---|
| `syev_jacobi_cta` (float) | **4.5e-07** |
| `syev_cta` (float) | **2.7e+28** |

Every eigenvalue, including the smallest, is resolved to near-full single-precision relative accuracy.

**Scope limit, stated up front:** the underlying theorem is for symmetric *positive definite* input. Indefinite matrices are solved correctly but do not inherit the relative-accuracy bound. This is an accuracy-oriented backend, not a replacement for `syev_cta`.

## What

`syev_jacobi_cta` / `syev_jacobi_cta_buffer_size`, with `JacobiParams<T>`.

Cyclic two-sided Jacobi run entirely inside one sub-group partition — `A` and the eigenvector accumulator `Z` stay in local memory for the whole solve, so one kernel launch performs the complete eigendecomposition and no global workspace is needed.

- Compile-time partition width `P ∈ {4,8,16,32}` from `n`; real and complex, both `Uplo`, `1 ≤ n ≤ 32`.
- Complex uses a diagonal phase similarity to reduce each pivot block to real symmetric, so real and complex share one rotation path.
- Round-robin pairing precomputed once per work-group. The schedule is a disjoint-pair reordering of a serial sweep, so it inherits cyclic-by-rows convergence (Hari & Begovic Kovac, ETNA 46, 2017, Thm 2.11).
- Threshold is `|a_pq| > tol·n·eps·sqrt(|a_pp·a_qq|)`. The relative form is load-bearing — the classical absolute test forfeits the entire accuracy advantage.

Also included: performance work on existing kernels (vectorized `ormqr_cta` column access, rsqrt-based Givens in `steqr_cta`, folded TAUQ permutation in `syev_cta`, redundant-eval reflector scalars in `sytrd_cta`, helper dedup in `latrd_lower_panel`/`syev_blocked`), and `scripts/compare_syev_cta.py` for diffing benchmark CSV runs.

## Performance

vs `syev_cta`, best-of over `cta_wg_size_multiplier`, **RTX 4090**:

| n | double (no vec / vec) | float (no vec / vec) |
|---|---|---|
| 4 | 3.2–3.5× / 3.5–3.8× | 2.8–3.0× / 3.6–3.9× |
| 8 | 2.8–3.3× / 2.8–3.1× | 1.8–1.9× / 2.1–2.2× |
| 16 | 2.4–2.7× / 2.2–2.5× | 1.1–1.3× / 1.2–1.4× |
| 32 | 1.3–1.7× / 1.2–1.3× | 0.52–0.56× / 0.40–0.61× |

Caveats worth reading:

- The 4090 runs FP64 at 1/64 rate, so `syev_cta` is FP64-throughput-bound there and the double column is flattered. **The float column is the better predictor for a datacenter GPU.**
- Jacobi wins at small `n` largely on launch count — it is one kernel against a multi-kernel pipeline.
- The `n = 32` float gap is mostly fundamental: two-sided Jacobi does ~`6n³` per sweep for `A` plus `2n³` for `Z` over 6–8 sweeps, against `4/3 n³` for `sytrd`. Landing within 2× is close to what the operation-count ratio allows.

The kernel went through 1.4–4.8× of optimization from the first working version. The largest single win by far was padding the local-memory leading dimension to `P+1`: the row-update phase has `lane == column`, so `LD == P == 32` put every lane in a warp on the same bank and serialized 32 ways. That is why the kernel initially looked memory-latency-bound rather than FP-bound. Occupancy is now the standing limit — perf is flat across `cta_wg_size_multiplier`, meaning residency is capped by total local memory per SM regardless of work-group split.

## Testing

30 new tests, all passing: eigenvalues and eigenvectors against LAPACK, odd and small `n` (exercising the padded schedule), descending sort, near-degenerate spectra, repeated runs, `NoEigenVectors` leaving `A` untouched.

Two accuracy tests carry the real weight:

- `RandomSymmetricMatchesDoubleReference` pins backward error against an exact-input double reference at **4.3 / 14.4 / 23.1 / 24.5 × eps·‖A‖_F** for n = 8 / 16 / 31 / 32 — clean `O(n)` growth, inside the `O(s·n·ε)` bound of LAWN 169 Prop. 2.3.
- `GradedSpdRelativeAccuracy` asserts the headline result above. The `syev_cta` comparison is printed but deliberately **not** asserted, so the suite does not pin a competitor's numbers.

Test tolerances for cross-checks against LAPACK are `‖A‖`- and `sqrt(n)`-scaled rather than the fixed absolute `test_utils::tolerance<T>()`, which is only a *relative* tolerance when `‖A‖ ~ 1`. The scaling is calibrated against the measured constants above, and the actual backward error is pinned directly by the double-reference test rather than by the loosened bound.

Accuracy results are bit-identical before and after the optimization pass — the optimizations reorder memory access and packing, never arithmetic.

`syev_cta_tests` (28), `sytrd_cta_tests` (5), `sg_compat_tests` (7) still pass.

## Not included

- No SPD-asserting API path, so the indefinite-input caveat is undocumented at the call site.
- One-sided-Jacobi-on-a-Cholesky-factor high-accuracy mode.
- Blocked / chunked variants for `n > 32`.
- Vendor baseline (cuSOLVER `syevj`, KBLAS) unmeasured.
