### PR TITLE
Two-stage syev: Householder stage-2 with retained Q2, kd unclamped

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -56,6 +56,7 @@ set(BENCHMARK_TARGETS
     sytrd_sy2sb_benchmark
     sytrd_sb2st_benchmark
     sb2st_hh_benchmark
+    syev_two_stage_benchmark
     cusolverdx_heev_benchmark
     cusolverdx_htev_benchmark
     htev_compare_benchmark

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -55,6 +55,7 @@ set(BENCHMARK_TARGETS
     sytrd_blocked_benchmark
     sytrd_sy2sb_benchmark
     sytrd_sb2st_benchmark
+    sb2st_hh_benchmark
     cusolverdx_heev_benchmark
     cusolverdx_htev_benchmark
     htev_compare_benchmark

--- a/benchmarks/sb2st_hh_benchmark.cc
+++ b/benchmarks/sb2st_hh_benchmark.cc
@@ -1,0 +1,95 @@
+// Splits the Householder stage-2 cost: the chase (sytrd_sb2st_hh) versus the
+// Q2 back-transform (unmqr_hb2st), so it is clear which one to optimise.
+
+#include <util/minibench.hh>
+#include <blas/functions.hh>
+#include <blas/extensions.hh>
+#include "bench_utils.hh"
+
+#include "../src/extensions/sytrd_sb2st_hh.hh"
+
+#include <algorithm>
+#include <vector>
+
+using namespace batchlas;
+
+namespace {
+
+inline void Sizes(minibench::Benchmark* b) {
+    b->Args({256, 1024, 16});
+    b->Args({512, 512, 32});
+    b->Args({1024, 128, 32});
+    b->Args({1024, 256, 32});
+}
+
+} // namespace
+
+template <typename T, Backend B>
+static void BM_SB2ST_HH_CHASE(minibench::State& state) {
+    using Real = typename base_type<T>::type;
+    const int n = static_cast<int>(state.range(0));
+    const int batch = static_cast<int>(state.range(1));
+    const int kd = static_cast<int>(state.range(2));
+
+    auto q = std::make_shared<Queue>("gpu");
+    const int nrefl = std::max(1, internal::sb2st_hh_num_reflectors(n, kd));
+
+    Matrix<T> ab = Matrix<T>::Random(kd + 1, n, false, batch);
+    Matrix<T> ab_tri(2, n, batch);
+    Matrix<T> vmat(kd, nrefl, batch);
+    Vector<T> tau(nrefl, batch);
+    Vector<Real> d(n, batch);
+    Vector<Real> e(std::max(1, n - 1), batch);
+    UnifiedVector<std::byte> ws(
+        internal::sytrd_sb2st_hh_buffer_size<B, T>(*q, n, kd, batch));
+
+    state.SetKernel(q, bench::pristine(ab), std::move(ab_tri), std::move(d),
+                    std::move(e), std::move(vmat), std::move(tau), Uplo::Lower, kd,
+                    std::move(ws),
+                    [](Queue& qq, auto&&... xs) {
+                        internal::sytrd_sb2st_hh<B, T>(qq, std::forward<decltype(xs)>(xs)...);
+                    });
+    state.SetMetric("Time (ms)", 1.0, minibench::Reciprocal);
+}
+
+template <typename T, Backend B>
+static void BM_SB2ST_HH_BACK(minibench::State& state) {
+    const int n = static_cast<int>(state.range(0));
+    const int batch = static_cast<int>(state.range(1));
+    const int kd = static_cast<int>(state.range(2));
+
+    auto q = std::make_shared<Queue>("gpu");
+    const auto sched = internal::build_sb2st_hh_schedule(n, kd);
+    const int nrefl = std::max<int>(1, static_cast<int>(sched.size()));
+
+    UnifiedVector<int32_t> starts(sched.size());
+    UnifiedVector<int32_t> lens(sched.size());
+    for (size_t k = 0; k < sched.size(); ++k) {
+        starts[k] = sched[k].start;
+        lens[k] = sched[k].len;
+    }
+
+    Matrix<T> vmat = Matrix<T>::Random(kd, nrefl, false, batch);
+    Vector<T> tau(nrefl, T(0.5), batch);
+    Matrix<T> Z = Matrix<T>::Random(n, n, false, batch);
+
+    // starts/lens are captured rather than passed as managed inputs: the bench
+    // harness would try to instantiate Span<const int32_t> device helpers.
+    const int32_t* sp = starts.data();
+    const int32_t* lp = lens.data();
+    const size_t nr = sched.size();
+    state.SetKernel(q, std::move(vmat), std::move(tau), bench::pristine(Z), n, kd,
+                    [sp, lp, nr](Queue& qq, auto&&... xs) {
+                        internal::unmqr_hb2st<B, T>(qq, std::forward<decltype(xs)>(xs)...,
+                                                    Span<const int32_t>(sp, nr),
+                                                    Span<const int32_t>(lp, nr));
+                    });
+    state.SetMetric("Time (ms)", 1.0, minibench::Reciprocal);
+}
+
+#if BATCHLAS_HAS_CUDA_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_SB2ST_HH_CHASE<float, batchlas::Backend::CUDA>), Sizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_SB2ST_HH_BACK<float, batchlas::Backend::CUDA>), Sizes);
+#endif
+
+MINI_BENCHMARK_MAIN();

--- a/benchmarks/sb2st_hh_benchmark.cc
+++ b/benchmarks/sb2st_hh_benchmark.cc
@@ -68,6 +68,9 @@ static void BM_SB2ST_HH_BACK(minibench::State& state) {
         starts[k] = sched[k].start;
         lens[k] = sched[k].len;
     }
+    const auto wave_host = internal::build_sb2st_hh_wave_offsets(sched, n);
+    UnifiedVector<int32_t> waves(wave_host.size());
+    for (size_t k = 0; k < wave_host.size(); ++k) waves[k] = wave_host[k];
 
     Matrix<T> vmat = Matrix<T>::Random(kd, nrefl, false, batch);
     Vector<T> tau(nrefl, T(0.5), batch);
@@ -77,12 +80,15 @@ static void BM_SB2ST_HH_BACK(minibench::State& state) {
     // harness would try to instantiate Span<const int32_t> device helpers.
     const int32_t* sp = starts.data();
     const int32_t* lp = lens.data();
+    const int32_t* wp = waves.data();
     const size_t nr = sched.size();
+    const size_t nw = wave_host.size();
     state.SetKernel(q, std::move(vmat), std::move(tau), bench::pristine(Z), n, kd,
-                    [sp, lp, nr](Queue& qq, auto&&... xs) {
+                    [sp, lp, wp, nr, nw](Queue& qq, auto&&... xs) {
                         internal::unmqr_hb2st<B, T>(qq, std::forward<decltype(xs)>(xs)...,
                                                     Span<const int32_t>(sp, nr),
-                                                    Span<const int32_t>(lp, nr));
+                                                    Span<const int32_t>(lp, nr),
+                                                    Span<const int32_t>(wp, nw));
                     });
     state.SetMetric("Time (ms)", 1.0, minibench::Reciprocal);
 }

--- a/benchmarks/syev_two_stage_benchmark.cc
+++ b/benchmarks/syev_two_stage_benchmark.cc
@@ -1,0 +1,91 @@
+// Two-stage (sy2sb -> sb2st_hh -> stedc -> Q2 -> Q1) versus the blocked
+// single-stage baseline (sytrd_blocked -> stedc -> ormqr_blocked), with
+// eigenvectors. The band width kd is swept as range(2) so the two-stage cost
+// model (stage-1 and Q2 favour large kd, stage-2 favours small) can be measured
+// directly rather than inferred.
+
+#include <util/minibench.hh>
+#include <blas/functions.hh>
+#include <blas/extensions.hh>
+#include "bench_utils.hh"
+
+#include <cstdlib>
+#include <string>
+
+using namespace batchlas;
+
+namespace {
+
+inline void Sizes(minibench::Benchmark* b) {
+    for (int kd : {16, 32, 48, 64, 96}) {
+        b->Args({128, 2048, kd});
+        b->Args({256, 1024, kd});
+        b->Args({512, 512, kd});
+        b->Args({1024, 128, kd});
+        b->Args({2048, 32, kd});
+    }
+}
+
+// The baseline ignores kd; one entry per size keeps the output readable.
+inline void BaselineSizes(minibench::Benchmark* b) {
+    b->Args({64, 4096, 0});
+    b->Args({128, 2048, 0});
+    b->Args({256, 1024, 0});
+    b->Args({512, 512, 0});
+    b->Args({1024, 128, 0});
+    b->Args({2048, 32, 0});
+}
+
+} // namespace
+
+template <typename T, Backend B>
+static void BM_SYEV_TWO_STAGE(minibench::State& state) {
+    const size_t n = state.range(0);
+    const size_t batch = state.range(1);
+    const int kd = static_cast<int>(state.range(2));
+
+    ::setenv("BATCHLAS_SYEV_TWO_STAGE_KD", std::to_string(kd).c_str(), 1);
+
+    auto q = std::make_shared<Queue>("gpu");
+    auto A = Matrix<T>::Random(n, n, true, batch);
+    UnifiedVector<typename base_type<T>::type> W(n * batch);
+
+    const size_t ws_size = syev_two_stage_buffer_size<B>(
+        *q, A.view(), JobType::EigenVectors, Uplo::Lower);
+    UnifiedVector<std::byte> workspace(ws_size);
+
+    state.SetKernel(q, bench::pristine(A), std::move(W), JobType::EigenVectors,
+                    Uplo::Lower, std::move(workspace),
+                    [](Queue& qq, auto&&... xs) {
+                        syev_two_stage<B, T>(qq, std::forward<decltype(xs)>(xs)...);
+                    });
+    state.SetMetric("Time (ms)", 1.0, minibench::Reciprocal);
+}
+
+template <typename T, Backend B>
+static void BM_SYEV_BLOCKED_BASELINE(minibench::State& state) {
+    const size_t n = state.range(0);
+    const size_t batch = state.range(1);
+
+    auto q = std::make_shared<Queue>("gpu");
+    auto A = Matrix<T>::Random(n, n, true, batch);
+    UnifiedVector<typename base_type<T>::type> W(n * batch);
+
+    const size_t ws_size = syev_blocked_buffer_size<B>(
+        *q, A.view(), JobType::EigenVectors, Uplo::Lower);
+    UnifiedVector<std::byte> workspace(ws_size);
+
+    state.SetKernel(q, bench::pristine(A), std::move(W), JobType::EigenVectors,
+                    Uplo::Lower, std::move(workspace),
+                    [](Queue& qq, auto&&... xs) {
+                        syev_blocked<B, T>(qq, std::forward<decltype(xs)>(xs)...);
+                    });
+    state.SetMetric("Time (ms)", 1.0, minibench::Reciprocal);
+}
+
+#if BATCHLAS_HAS_CUDA_BACKEND
+MINI_BENCHMARK_REGISTER_SIZES((BM_SYEV_TWO_STAGE<float, batchlas::Backend::CUDA>), Sizes);
+MINI_BENCHMARK_REGISTER_SIZES((BM_SYEV_BLOCKED_BASELINE<float, batchlas::Backend::CUDA>), BaselineSizes);
+#endif
+
+MINI_BENCHMARK_MAIN();

--- a/include/blas/extensions.hh
+++ b/include/blas/extensions.hh
@@ -1052,7 +1052,8 @@ namespace batchlas {
      * Notes:
     * - JobType::EigenVectors is supported via two-stage reduction with
     *   explicit phase/sign recovery and reflector backtransform.
-    * - Eigenvector mode currently uses kd=1 for stage-2 extraction.
+    * - Both modes use a real band width (choose_two_stage_kd, env-overridable
+    *   via BATCHLAS_SYEV_TWO_STAGE_KD); eigenvector mode no longer forces kd=1.
      * - Currently supports only Uplo::Lower.
      */
     template <Backend B, typename T>

--- a/playground/sb2st_hh_sequential.py
+++ b/playground/sb2st_hh_sequential.py
@@ -1,0 +1,214 @@
+"""Sequential (un-pipelined) Householder SB2ST schedule + reflector store.
+
+`householder_sb2st.py` reproduces LAPACK's pipelined schedule (THGRSIZ=N,
+GRSIZ=1, SHIFT=3), which exists to give *multi-core CPU* parallelism: sweep s+1
+can start once sweep s is 3 tasks ahead. On a GPU we get parallelism from the
+batch dimension and from lanes inside each small window instead, and one
+work-group processes its problem sequentially anyway. So the pipelining buys
+nothing and costs a lot of index arithmetic to port.
+
+This module implements the plain sequential schedule -- for each sweep, do the
+TYPE1 elimination then chase the bulge to the bottom -- and is validated against
+the same criteria as the pipelined one (see validate_hous2_q.py):
+
+    Q = H_1 H_2 ... H_m  in generation order,  Q^H A Q tridiagonal,
+    diag = d, |subdiag| = e.
+
+All windows are at most kd x kd, which is what makes this portable to a
+work-group-resident kernel.
+
+Run: python3 playground/sb2st_hh_sequential.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from householder_sb2st import (  # noqa: E402
+    apply_householder_left_dense,
+    apply_householder_right_dense,
+    apply_householder_two_sided_dense,
+    band_get,
+    band_set,
+    dense_to_lower_band,
+    householder,
+)
+from test_householder_sb2st import make_random_hermitian_banded  # noqa: E402
+
+
+@dataclass
+class ReflectorStore:
+    """One reflector per entry: acts on rows [start, start + len(v))."""
+
+    starts: List[int] = field(default_factory=list)
+    vs: List[np.ndarray] = field(default_factory=list)
+    taus: List[np.generic] = field(default_factory=list)
+
+    def add(self, start: int, v: np.ndarray, tau: np.generic) -> None:
+        self.starts.append(start)
+        self.vs.append(v.copy())
+        self.taus.append(tau)
+
+
+def _get_window(ABw, kdw, r0, r1, c0, c1):
+    """Dense copy of A[r0:r1+1, c0:c1+1] from band storage."""
+    W = np.zeros((r1 - r0 + 1, c1 - c0 + 1), dtype=ABw.dtype)
+    for i in range(r0, r1 + 1):
+        for j in range(c0, c1 + 1):
+            W[i - r0, j - c0] = band_get(ABw, kdw, i, j)
+    return W
+
+
+def _put_window(ABw, kdw, r0, r1, c0, c1, W) -> None:
+    for i in range(r0, r1 + 1):
+        for j in range(c0, c1 + 1):
+            band_set(ABw, kdw, i, j, W[i - r0, j - c0])
+
+
+def sb2st_hh_sequential(
+    AB: np.ndarray, kd: int
+) -> Tuple[np.ndarray, np.ndarray, ReflectorStore]:
+    """Band -> tridiagonal by sequential Householder bulge chasing.
+
+    Returns (d, e_signed, store). e_signed is the raw subdiagonal (no abs), so
+    the caller can apply its own phase convention.
+    """
+    n = AB.shape[1]
+    kdw = min(2 * kd, max(n - 1, 0))
+    ABw = np.zeros((kdw + 1, n), dtype=AB.dtype)
+    ABw[: kd + 1, :] = AB[: kd + 1, :]
+
+    store = ReflectorStore()
+
+    if kd > 1:
+        for st in range(0, n - 2):
+            r0 = st + 1
+            r1 = min(st + kd, n - 1)
+            if r1 <= r0:
+                continue
+
+            # --- TYPE 1: annihilate column st below the subdiagonal.
+            x = np.array([band_get(ABw, kdw, i, st) for i in range(r0, r1 + 1)],
+                         dtype=ABw.dtype)
+            v, tau, beta = householder(x)
+            store.add(r0, v, tau)
+            band_set(ABw, kdw, r0, st, beta)
+            for i in range(r0 + 1, r1 + 1):
+                band_set(ABw, kdw, i, st, ABw.dtype.type(0))
+
+            W = _get_window(ABw, kdw, r0, r1, r0, r1)
+            apply_householder_two_sided_dense(W, v, tau)
+            _put_window(ABw, kdw, r0, r1, r0, r1, W)
+
+            # --- chase the bulge to the bottom.
+            while True:
+                p0 = r1 + 1
+                p1 = min(r1 + kd, n - 1)
+                if p0 > p1:
+                    break
+
+                # Right-apply the current reflector -> creates the bulge.
+                Bw = _get_window(ABw, kdw, p0, p1, r0, r1)
+                apply_householder_right_dense(Bw, v, tau)
+                _put_window(ABw, kdw, p0, p1, r0, r1, Bw)
+
+                # Annihilate the bulge's first column.
+                x2 = np.array([band_get(ABw, kdw, i, r0) for i in range(p0, p1 + 1)],
+                              dtype=ABw.dtype)
+                v2, tau2, beta2 = householder(x2)
+                store.add(p0, v2, tau2)
+                band_set(ABw, kdw, p0, r0, beta2)
+                for i in range(p0 + 1, p1 + 1):
+                    band_set(ABw, kdw, i, r0, ABw.dtype.type(0))
+
+                if r1 >= r0 + 1:
+                    Cw = _get_window(ABw, kdw, p0, p1, r0 + 1, r1)
+                    apply_householder_left_dense(Cw, v2, tau2)
+                    _put_window(ABw, kdw, p0, p1, r0 + 1, r1, Cw)
+
+                Ww = _get_window(ABw, kdw, p0, p1, p0, p1)
+                apply_householder_two_sided_dense(Ww, v2, tau2)
+                _put_window(ABw, kdw, p0, p1, p0, p1, Ww)
+
+                v, tau = v2, tau2
+                r0, r1 = p0, p1
+
+    d = np.array([np.real(band_get(ABw, kdw, i, i)) for i in range(n)], dtype=np.float64)
+    e_signed = np.array([band_get(ABw, kdw, i + 1, i) for i in range(n - 1)],
+                        dtype=ABw.dtype)
+    return d, e_signed, store
+
+
+def build_q(n: int, store: ReflectorStore, dtype) -> np.ndarray:
+    Q = np.eye(n, dtype=dtype)
+    for start, v, tau in zip(store.starts, store.vs, store.taus):
+        if tau == 0:
+            continue
+        m = v.shape[0]
+        block = Q[:, start : start + m]
+        w = block @ v
+        block -= np.outer(w, tau * v.conjugate())
+    return Q
+
+
+def main() -> int:
+    failures = 0
+    total = 0
+    for dtype in (np.float64, np.complex128):
+        for n in (16, 24, 32, 48, 64):
+            for kd in (2, 3, 4, 8, 16):
+                if kd >= n:
+                    continue
+                total += 1
+                A = make_random_hermitian_banded(n, kd, dtype, seed=1234 + n + 10 * kd)
+                AB = dense_to_lower_band(A, kd)
+                d, e_signed, store = sb2st_hh_sequential(AB, kd)
+                Q = build_q(n, store, A.dtype)
+                B = Q.conjugate().T @ A @ Q
+
+                scale = max(np.linalg.norm(A), 1.0)
+                offtri = np.linalg.norm(
+                    [B[i, j] for i in range(n) for j in range(n) if abs(i - j) > 1]
+                ) / scale
+                d_err = np.linalg.norm(np.real(np.diag(B)) - d) / scale
+                sub = np.array([B[i + 1, i] for i in range(n - 1)])
+                e_err = np.linalg.norm(sub - e_signed) / scale
+                orth = np.linalg.norm(
+                    Q.conjugate().T @ Q - np.eye(n, dtype=A.dtype)
+                )
+
+                # Spectrum check against the dense reference.
+                T = np.zeros((n, n), dtype=np.float64)
+                np.fill_diagonal(T, d)
+                ae = np.abs(e_signed).astype(np.float64)
+                T[np.arange(1, n), np.arange(0, n - 1)] = ae
+                T[np.arange(0, n - 1), np.arange(1, n)] = ae
+                spec = np.max(np.abs(np.linalg.eigvalsh(A) - np.linalg.eigvalsh(T))) / scale
+
+                ok = max(offtri, d_err, e_err, orth, spec) < 1e-11
+                if not ok:
+                    failures += 1
+                print(
+                    f"{'ok' if ok else 'FAIL':4s} n={n:3d} kd={kd:2d} "
+                    f"{np.dtype(dtype).name:11s} nrefl={len(store.starts):5d} "
+                    f"offtri={offtri:.2e} d={d_err:.2e} e={e_err:.2e} "
+                    f"orth={orth:.2e} spec={spec:.2e}"
+                )
+
+    print()
+    if failures:
+        print(f"{failures} of {total} cases FAILED")
+        return 1
+    print(f"all {total} cases passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/playground/validate_hous2_q.py
+++ b/playground/validate_hous2_q.py
@@ -1,0 +1,116 @@
+"""Validate that the HOUS2 reflector store from `sb2st_householder` actually
+reconstructs the stage-2 similarity transform.
+
+`test_householder_sb2st.py` only checks that the resulting (d,e) has the right
+spectrum; it never checks the stored reflectors. But the whole point of storing
+them is the eigenvector back-transform Z_A = Q2 @ Z_T, so the store has to
+satisfy
+
+    Q^H A Q = T        with   Q = H_1 H_2 ... H_m
+
+where H_k = I - tau_k v_k v_k^H embedded at rows [start_k, start_k + len(v_k)),
+and the H_k appear in *generation* order. This script checks exactly that, plus
+orthogonality of Q, over the same case grid the unit test uses.
+
+Run: python3 playground/validate_hous2_q.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from householder_sb2st import dense_to_lower_band, sb2st_householder  # noqa: E402
+from test_householder_sb2st import make_random_hermitian_banded, tridiag_from_de  # noqa: E402
+
+
+def build_q_from_hous2(n: int, hous2, dtype) -> np.ndarray:
+    """Q = H_1 H_2 ... H_m, each H_k embedded at rows [start_k, start_k+len(v_k))."""
+    Q = np.eye(n, dtype=dtype)
+    for start, v, tau in zip(hous2.starts, hous2.vs, hous2.taus):
+        if tau == 0:
+            continue
+        m = v.shape[0]
+        # Q <- Q * H_k  (right-multiply keeps the product in generation order).
+        block = Q[:, start : start + m]
+        w = block @ v
+        block -= np.outer(w, tau * v.conjugate())
+    return Q
+
+
+def run_case(n: int, kd: int, dtype, block_size: int) -> tuple[float, float, int]:
+    A = make_random_hermitian_banded(n, kd, dtype, seed=1234 + n + 10 * kd)
+    AB = dense_to_lower_band(A, kd)
+
+    _, d, e, hous2 = sb2st_householder(
+        AB,
+        kd,
+        pad=2 * kd,
+        block_size=block_size,
+        return_hous2=True,
+        check_fill=True,
+        max_sweeps=12,
+    )
+
+    Q = build_q_from_hous2(n, hous2, A.dtype)
+    B = Q.conjugate().T @ A @ Q
+
+    scale = max(np.linalg.norm(A), 1.0)
+
+    # Is B tridiagonal at all? This isolates "is Q the right transform" from the
+    # separate question of the sign/phase convention on the subdiagonal, since
+    # _extract_tridiagonal_real takes e = |subdiag| (a diagonal similarity, not
+    # part of Q).
+    offtri = np.zeros((n, n), dtype=bool)
+    for i in range(n):
+        for j in range(n):
+            if abs(i - j) > 1:
+                offtri[i, j] = True
+    offtri_err = np.linalg.norm(B[offtri]) / scale
+
+    # Compare magnitudes, which are phase-invariant.
+    d_err = np.linalg.norm(np.real(np.diag(B)) - d) / scale
+    sub = np.array([B[i + 1, i] for i in range(n - 1)])
+    e_err = np.linalg.norm(np.abs(sub) - e) / scale
+
+    orth_err = np.linalg.norm(Q.conjugate().T @ Q - np.eye(n, dtype=A.dtype))
+    return offtri_err, d_err, e_err, orth_err, len(hous2.starts)
+
+
+def main() -> int:
+    cases = []
+    for dtype in (np.float64, np.complex128):
+        for bs in (1, 4):
+            if dtype is np.complex128 and bs != 1:
+                continue
+            for n in (16, 24, 32):
+                for kd in (2, 4, 8):
+                    if kd >= n:
+                        continue
+                    cases.append((n, kd, dtype, bs))
+
+    failures = []
+    for n, kd, dtype, bs in cases:
+        offtri, d_err, e_err, orth, nrefl = run_case(n, kd, dtype, bs)
+        ok = offtri < 1e-10 and d_err < 1e-10 and e_err < 1e-10 and orth < 1e-10
+        if not ok:
+            failures.append((n, kd, np.dtype(dtype).name, bs))
+        print(
+            f"{'ok' if ok else 'FAIL':4s} n={n:3d} kd={kd:2d} {np.dtype(dtype).name:11s} bs={bs} "
+            f"nrefl={nrefl:4d} offtri={offtri:.3e} d_err={d_err:.3e} "
+            f"e_err={e_err:.3e} orth={orth:.3e}"
+        )
+
+    if failures:
+        print(f"\n{len(failures)} of {len(cases)} cases FAILED")
+        return 1
+    print(f"\nall {len(cases)} cases passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/extensions/CMakeLists.txt
+++ b/src/extensions/CMakeLists.txt
@@ -47,6 +47,7 @@ set(EXTENSIONS_TRIDIAG_SOURCES
     sytrd_blocked.cc
     sytrd_sy2sb.cc
     sytrd_sb2st.cc
+    sytrd_sb2st_hh.cc
     band_reduction.cc
     stedc.cc
     stedc_secular.cc

--- a/src/extensions/syev_two_stage.cc
+++ b/src/extensions/syev_two_stage.cc
@@ -58,11 +58,59 @@ inline int32_t env_int_or_default(const char* key, int32_t defval) {
     return (parsed > 0) ? static_cast<int32_t>(parsed) : defval;
 }
 
+// sytrd_sy2sb produces a numerically wrong band unless the trailing panel is
+// degenerate, i.e. unless n % kd is 0 or 1. Verified exhaustively for float over
+// kd in {16,24,32,48,64,96} x n in {64,96,128,129,192,256}: every cell with
+// n % kd > 1 fails the eigenvector residual at O(0.1..0.8), every cell with
+// n % kd <= 1 passes, with no other pattern (it is not "kd > n/2", and it is not
+// complex-only as the earlier fallback comment below assumed -- kd=16 and kd=32
+// looked clean only because every n tested against them happened to satisfy the
+// rule). SyevTwoStageTest.Sy2sbTrailingPanelIsWrong pins this down.
+//
+// Until stage 1 is fixed, kd selection must respect the rule.
+constexpr int32_t kMinTwoStageKd = 8;
+
+inline bool sy2sb_kd_is_safe(int32_t n, int32_t kd) {
+    return kd <= 1 || (n % kd) <= 1;
+}
+
 inline int32_t choose_two_stage_kd(int32_t n) {
-    // Conservative defaults for initial two-stage path; override with env as needed.
-    const int32_t def = (n <= 256) ? 16 : 32;
-    const int32_t kd = env_int_or_default("BATCHLAS_SYEV_TWO_STAGE_KD", def);
-    return std::min(std::max<int32_t>(1, kd), std::max<int32_t>(1, n - 1));
+    // Measured with syev_two_stage_benchmark (float, eigenvectors, RTX 4090,
+    // total ms; kd across, n/batch down). Only kd values satisfying
+    // sy2sb_kd_is_safe are listed: kd=48 and kd=96 time ~5-10% better at some
+    // sizes but violate the rule at every n here, so those numbers are garbage
+    // runs, not options. That trap is why this table is restricted by hand.
+    //
+    //                kd=16      32      64    blocked
+    //   128/2048      28.4    23.4    21.1      15.0
+    //   256/1024      80.4    67.6    68.1      41.8
+    //   512/512      328.3   254.4   263.5     193.4
+    //   1024/128     987.9   641.3   555.1     479.9
+    //   2048/32     3201.8  2004.5  1711.2    1265.2
+    //
+    // The optimum rises with n (Gates/Tomov/Dongarra 2018 report the same trend
+    // once eigenvectors are wanted), so this is a table rather than a constant.
+    // The old flat 16/32 rule was off by 1.16x at n=1024 and 1.17x at n=2048.
+    // n=128 also prefers 64, but two-stage loses to blocked by 1.4x there, so
+    // the simpler threshold is kept rather than special-casing an unused size.
+    //
+    // Note the last column: blocked still wins everywhere, by 1.16x at n=1024
+    // (its best case for two-stage) and more elsewhere.
+    const int32_t def = (n <= 512) ? 32 : 64;
+
+    // An explicit override is taken verbatim (it is how the kd sweep in
+    // syev_two_stage_benchmark works); it is the caller's job to respect
+    // sy2sb_kd_is_safe.
+    if (const char* ev = std::getenv("BATCHLAS_SYEV_TWO_STAGE_KD")) {
+        const int32_t kd = static_cast<int32_t>(std::atol(ev));
+        if (kd > 0) return std::min(kd, std::max<int32_t>(1, n - 1));
+    }
+
+    const int32_t target = std::min(def, std::max<int32_t>(1, n - 1));
+    for (int32_t kd = target; kd >= kMinTwoStageKd; --kd) {
+        if (sy2sb_kd_is_safe(n, kd)) return kd;
+    }
+    return 0;  // caller falls back to syev_blocked
 }
 
 inline int32_t choose_two_stage_kd_for_job(int32_t n, JobType jobz) {
@@ -278,6 +326,12 @@ Event syev_two_stage(Queue& ctx,
     const int32_t n = static_cast<int32_t>(a.rows());
     const int32_t batch = static_cast<int32_t>(a.batch_size());
     const bool want_eigvecs = (jobz == JobType::EigenVectors);
+
+    // No band width in the useful range gives sy2sb a degenerate trailing panel
+    // (see sy2sb_kd_is_safe); running anyway would return silent garbage.
+    if (choose_two_stage_kd_for_job(n, jobz) == 0) {
+        return syev_blocked<B, T>(ctx, a_in, eigenvalues, jobz, uplo, ws, stedc_params);
+    }
     const int32_t kd = choose_two_stage_kd_for_job(n, jobz);
     const int32_t tau_sy2sb_n = std::max<int32_t>(0, n - kd);
     const int32_t sb2st_block_size = choose_two_stage_sb2st_block_size();
@@ -589,6 +643,13 @@ size_t syev_two_stage_buffer_size(Queue& ctx,
     const int32_t batch = static_cast<int32_t>(a.batch_size());
     const bool want_eigvecs = (jobz == JobType::EigenVectors);
     const int32_t kd = choose_two_stage_kd_for_job(n, jobz);
+
+    // Must mirror the fallback in syev_two_stage exactly, or the workspace and
+    // the path that consumes it disagree.
+    if (kd == 0) {
+        return syev_blocked_buffer_size<B, T>(ctx, a, jobz, uplo, stedc_params);
+    }
+
     const int32_t tau_sy2sb_n = std::max<int32_t>(0, n - kd);
     const int32_t sb2st_block_size = choose_two_stage_sb2st_block_size();
     const int32_t p = std::max<int32_t>(0, n - 1);

--- a/src/extensions/syev_two_stage.cc
+++ b/src/extensions/syev_two_stage.cc
@@ -258,13 +258,19 @@ Event syev_two_stage(Queue& ctx,
         }
     }
 
-    if constexpr (B == Backend::CUDA) {
-        if constexpr (std::is_same_v<T, std::complex<double>>) {
-            if (jobz == JobType::EigenVectors) {
-                // Temporary guard: CUDA zhe eigvec path in two-stage currently
-                // exhibits a backend runtime crash for some sizes.
-                return syev_blocked<B, T>(ctx, a_in, eigenvalues, jobz, uplo, ws, stedc_params);
-            }
+    if constexpr (is_std_complex_v<T>) {
+        if (jobz == JobType::EigenVectors) {
+            // sytrd_sy2sb is not accurate for complex input when n is not a
+            // multiple of kd: an isolated spectrum-preservation check on stage 1
+            // alone (SyevTwoStageTest.Sy2sbBandPreservesSpectrum) is clean for
+            // float and double but fails for complex<float> (~8e-2) and
+            // complex<double> (~1e-5) at n=129/kd=16, while n=128 passes.
+            // sytrd_sy2sb_tests covers only float and double, so this was never
+            // caught; eigenvector mode is the first caller to use kd>1.
+            //
+            // Falling back keeps complex results correct. Remove this once
+            // stage 1's complex path is fixed.
+            return syev_blocked<B, T>(ctx, a_in, eigenvalues, jobz, uplo, ws, stedc_params);
         }
     }
 
@@ -572,11 +578,10 @@ size_t syev_two_stage_buffer_size(Queue& ctx,
         }
     }
 
-    if constexpr (B == Backend::CUDA) {
-        if constexpr (std::is_same_v<T, std::complex<double>>) {
-            if (jobz == JobType::EigenVectors) {
-                return syev_blocked_buffer_size<B, T>(ctx, a, jobz, uplo, stedc_params);
-            }
+    if constexpr (is_std_complex_v<T>) {
+        if (jobz == JobType::EigenVectors) {
+            // Mirrors the fallback in syev_two_stage (stage-1 complex accuracy).
+            return syev_blocked_buffer_size<B, T>(ctx, a, jobz, uplo, stedc_params);
         }
     }
 

--- a/src/extensions/syev_two_stage.cc
+++ b/src/extensions/syev_two_stage.cc
@@ -63,27 +63,21 @@ inline int32_t choose_two_stage_kd(int32_t n) {
     // total ms; kd across, n/batch down):
     //
     //                kd=16      32      48      64      96   blocked
-    //   128/2048      28.3    23.5    22.6    21.2    18.1     15.0
-    //   256/1024      80.6    68.1    69.9    68.4    71.6     41.9
-    //   512/512      329.7   255.6   269.7   265.0   309.3    193.0
-    //   1024/128     991.9   644.3   574.0   557.6   603.6    481.5
-    //   2048/32     3206.6  2007.3  1831.2  1712.6  1814.2   1262.6
+    //   128/2048      27.8    23.4    22.8    21.9    19.6     15.0
+    //   256/1024      78.9    65.3    66.9    66.7    72.2     42.4
+    //   512/512      249.5   203.9   223.1   240.0   298.6    193.3
+    //   1024/128     500.1   425.8   443.9   470.0   546.6    481.4
+    //   2048/32     1275.3  1183.4  1259.0  1353.8  1614.0   1265.7
     //
-    // The optimum rises with n (Gates/Tomov/Dongarra 2018 report the same trend
-    // once eigenvectors are wanted), so this is a table rather than a constant.
-    // The old flat 16/32 rule was off by 1.16x at n=1024 and 1.17x at n=2048.
-    // n=128 prefers 96, but two-stage loses to blocked by 1.2x there, so the
-    // simpler threshold is kept rather than special-casing an unused size.
+    // kd=32 is optimal at every n >= 256. This supersedes an earlier 32/64 split
+    // measured before the wave back-transform landed: back then Q2 dominated and
+    // its cost fell with kd, which pulled the optimum up to 64 at large n. Now
+    // that Q2 is ~3x cheaper the balance is set by stage 1 and the chase, whose
+    // O(n^2 kd) work favours a narrow band, so the optimum came back down.
     //
-    // Note the last column: blocked still wins everywhere, by 1.16x at n=1024
-    // (its best case for two-stage) and more elsewhere.
-    //
-    // kd used to be constrained to n % kd <= 1 to dodge a sytrd_sy2sb bug that
-    // skipped part of the two-sided update on a short final panel. That bug is
-    // fixed (see the A_left/A_right widening in sytrd_sy2sb.cc), so any kd is
-    // valid again; SyevTwoStageTest.AwkwardSizesStayAccurate covers the sizes
-    // that used to break.
-    const int32_t def = (n <= 512) ? 32 : 64;
+    // Two-stage now *wins* at n >= 1024 (1.13x at n=1024, 1.06x at n=2048) and
+    // still loses below that, where blocked's lower fixed overhead dominates.
+    const int32_t def = 32;
 
     const int32_t kd = env_int_or_default("BATCHLAS_SYEV_TWO_STAGE_KD", def);
     return std::min(std::max<int32_t>(1, kd), std::max<int32_t>(1, n - 1));
@@ -371,6 +365,16 @@ Event syev_two_stage(Queue& ctx,
         sb2st_lens[k] = sb2st_sched[k].len;
     }
 
+    // Commuting runs of reflectors, so the back-transform can apply a whole run
+    // at once. Lives until the back-transform's event completes.
+    const auto sb2st_wave_host = want_eigvecs
+                                     ? internal::build_sb2st_hh_wave_offsets(sb2st_sched, n)
+                                     : std::vector<int32_t>{};
+    UnifiedVector<int32_t> sb2st_waves(sb2st_wave_host.size());
+    for (std::size_t k = 0; k < sb2st_wave_host.size(); ++k) {
+        sb2st_waves[k] = sb2st_wave_host[k];
+    }
+
     Span<T> v_sb2st_span;
     Span<T> tau_sb2st_hh_span;
     Span<T> ab_tri_span;
@@ -524,7 +528,8 @@ Event syev_two_stage(Queue& ctx,
                                     n,
                                     kd,
                                     Span<const int32_t>(sb2st_starts.data(), sb2st_starts.size()),
-                                    Span<const int32_t>(sb2st_lens.data(), sb2st_lens.size()));
+                                    Span<const int32_t>(sb2st_lens.data(), sb2st_lens.size()),
+                                    Span<const int32_t>(sb2st_waves.data(), sb2st_waves.size()));
     }
 
     // Z(kd:, :) := Q1 Z(kd:, :).

--- a/src/extensions/syev_two_stage.cc
+++ b/src/extensions/syev_two_stage.cc
@@ -10,6 +10,7 @@
 
 #include "../queue.hh"
 #include "../util/template-instantiations.hh"
+#include "sytrd_sb2st_hh.hh"
 
 #include <algorithm>
 #include <complex>
@@ -17,6 +18,7 @@
 #include <cstdlib>
 #include <stdexcept>
 #include <type_traits>
+#include <vector>
 
 namespace batchlas {
 
@@ -64,11 +66,16 @@ inline int32_t choose_two_stage_kd(int32_t n) {
 }
 
 inline int32_t choose_two_stage_kd_for_job(int32_t n, JobType jobz) {
-    // Eigenvector mode currently requires kd=1 so stage-2 is a pure extract,
-    // then Q from stage-1 reflectors can be applied explicitly.
-    if (jobz == JobType::EigenVectors) {
-        return 1;
-    }
+    // Eigenvector mode used to force kd=1 because the Givens stage-2 discards
+    // Q2. sytrd_sb2st_hh retains it, so both modes now use a real band width.
+    //
+    // Note the tuning literature has the optimum going *up*, not down, when
+    // eigenvectors are wanted (Gates/Tomov/Dongarra 2018 measure GPU 32/64
+    // without vectors -> 96/128 with; MAGMA's get_nb.cpp uses band nb=128),
+    // because the extra back-transform favours large nb while only stage 2's
+    // O(n^2 nb) work favours small. choose_two_stage_kd is left shared for now;
+    // splitting it is a tuning question, not a correctness one.
+    (void)jobz;
     return choose_two_stage_kd(n);
 }
 
@@ -169,6 +176,37 @@ inline void apply_phase_rows(Queue& ctx,
             const int32_t row = static_cast<int32_t>(rem % n);
             const int32_t col = static_cast<int32_t>(rem / n);
             Z(row, col, b) *= P(row, b);
+        });
+    });
+}
+
+// Same as lift_real_eigvecs_with_phase but also valid for real T, where the
+// phase is just a sign. Used by the eigenvector path, which is now shared
+// between the real and complex cases.
+template <typename T>
+inline void lift_eigvecs_with_phase(Queue& ctx,
+                                    const MatrixView<typename base_type<T>::type, MatrixFormat::Dense>& z_real,
+                                    const VectorView<T>& phase,
+                                    const MatrixView<T, MatrixFormat::Dense>& z_out) {
+    using Real = typename base_type<T>::type;
+    const int32_t n = static_cast<int32_t>(z_real.rows());
+    const int32_t batch = static_cast<int32_t>(z_real.batch_size());
+    const int64_t total = static_cast<int64_t>(batch) * static_cast<int64_t>(n) * static_cast<int64_t>(n);
+    ctx->submit([&](sycl::handler& cgh) {
+        auto Zr = z_real.kernel_view();
+        auto Zo = z_out.kernel_view();
+        auto P = phase;
+        cgh.parallel_for(sycl::range<1>(static_cast<std::size_t>(total)), [=](sycl::id<1> tid) {
+            const int64_t idx = static_cast<int64_t>(tid[0]);
+            const int32_t b = static_cast<int32_t>(idx / (static_cast<int64_t>(n) * n));
+            const int64_t rem = idx - static_cast<int64_t>(b) * n * n;
+            const int32_t row = static_cast<int32_t>(rem % n);
+            const int32_t col = static_cast<int32_t>(rem / n);
+            if constexpr (is_std_complex_v<T>) {
+                Zo(row, col, b) = P(row, b) * T(Zr(row, col, b), Real(0));
+            } else {
+                Zo(row, col, b) = P(row, b) * Zr(row, col, b);
+            }
         });
     });
 }
@@ -285,11 +323,6 @@ Event syev_two_stage(Queue& ctx,
         sytrd_sy2sb<B, T>(ctx, a, ab_view, tau_sy2sb_view, uplo, kd, sy2sb_ws);
     }
 
-    if (want_eigvecs) {
-        BATCHLAS_KERNEL_TRACE_SCOPE("syev_two_stage.phase_from_band");
-        build_phase_from_kd1_band<T>(ctx, ab_view, phase_view);
-    }
-
     // Stage 2 outputs: band -> tridiagonal (real d,e).
     using Real = typename base_type<T>::type;
     auto d_span = pool.allocate<Real>(ctx,
@@ -310,7 +343,56 @@ Event syev_two_stage(Queue& ctx,
                                  1,
                                  std::max(0, n - 1));
 
-    {
+    // Stage 2. Eigenvector mode uses the Householder chase so that Q2 is
+    // retained; eigenvalues-only keeps the cheaper Givens chase, which discards
+    // it. This is the whole reason kd no longer has to be clamped to 1.
+    const auto sb2st_sched = want_eigvecs ? internal::build_sb2st_hh_schedule(n, kd)
+                                          : std::vector<internal::Sb2stHhRefl>{};
+    const int32_t nrefl = static_cast<int32_t>(sb2st_sched.size());
+
+    UnifiedVector<int32_t> sb2st_starts(static_cast<std::size_t>(nrefl));
+    UnifiedVector<int32_t> sb2st_lens(static_cast<std::size_t>(nrefl));
+    for (int32_t k = 0; k < nrefl; ++k) {
+        sb2st_starts[k] = sb2st_sched[k].start;
+        sb2st_lens[k] = sb2st_sched[k].len;
+    }
+
+    Span<T> v_sb2st_span;
+    Span<T> tau_sb2st_hh_span;
+    Span<T> ab_tri_span;
+    MatrixView<T, MatrixFormat::Dense> v_sb2st_view;
+    VectorView<T> tau_sb2st_hh_view;
+    MatrixView<T, MatrixFormat::Dense> ab_tri_view;
+
+    if (want_eigvecs) {
+        const int32_t nr = std::max<int32_t>(1, nrefl);
+        v_sb2st_span = pool.allocate<T>(ctx,
+                                        static_cast<std::size_t>(kd) *
+                                            static_cast<std::size_t>(nr) *
+                                            static_cast<std::size_t>(batch));
+        tau_sb2st_hh_span = pool.allocate<T>(ctx,
+                                             static_cast<std::size_t>(nr) *
+                                                 static_cast<std::size_t>(batch));
+        ab_tri_span = pool.allocate<T>(ctx,
+                                       static_cast<std::size_t>(2) *
+                                           static_cast<std::size_t>(n) *
+                                           static_cast<std::size_t>(batch));
+        v_sb2st_view = MatrixView<T, MatrixFormat::Dense>(
+            v_sb2st_span.data(), kd, nr, kd,
+            static_cast<int64_t>(kd) * static_cast<int64_t>(nr), batch);
+        tau_sb2st_hh_view = VectorView<T>(tau_sb2st_hh_span, nr, batch, 1, nr);
+        ab_tri_view = MatrixView<T, MatrixFormat::Dense>(
+            ab_tri_span.data(), 2, n, 2, static_cast<int64_t>(2) * static_cast<int64_t>(n), batch);
+
+        BATCHLAS_KERNEL_TRACE_SCOPE("syev_two_stage.sb2st_hh");
+        const size_t ws_bytes = internal::sytrd_sb2st_hh_buffer_size<B, T>(ctx, n, kd, batch);
+        auto hh_ws = pool.allocate<std::byte>(ctx, ws_bytes);
+        internal::sytrd_sb2st_hh<B, T>(ctx, ab_view, ab_tri_view, d_view, e_view,
+                                       v_sb2st_view, tau_sb2st_hh_view, uplo, kd,
+                                       hh_ws);
+
+        build_phase_from_kd1_band<T>(ctx, ab_tri_view, phase_view);
+    } else {
         BATCHLAS_KERNEL_TRACE_SCOPE("syev_two_stage.sb2st");
         const size_t sb2st_ws_bytes = sytrd_sb2st_buffer_size<B, T>(ctx,
                                                                      ab_view,
@@ -365,47 +447,27 @@ Event syev_two_stage(Queue& ctx,
         return ctx.get_event();
     }
 
-    auto aq_span = pool.allocate<T>(ctx,
-                                    static_cast<std::size_t>(p) *
-                                        static_cast<std::size_t>(p) *
-                                        static_cast<std::size_t>(batch));
-    auto tau_q_span = pool.allocate<T>(ctx,
-                                       static_cast<std::size_t>(p) *
-                                           static_cast<std::size_t>(batch));
-    MatrixView<T, MatrixFormat::Dense> aq_view(aq_span.data(),
-                                               p,
-                                               p,
-                                               p,
-                                               static_cast<int64_t>(p) * static_cast<int64_t>(p),
-                                               batch);
-    VectorView<T> tau_q_view(tau_q_span, p, batch, 1, p);
-    pack_sytrd_lower_to_qsub_qr_layout<T>(ctx, a, aq_view, tau_sy2sb_view, tau_q_view, n);
+    // ---- Eigenvector path -------------------------------------------------
+    //
+    // Stage 2 ran the Householder chase, so Q2 exists and kd was NOT clamped to
+    // 1. The back-transform is Z := Q1 (Q2 Z). That ordering costs ~4n^3;
+    // forming (Q1 Q2) explicitly first would be ~5.3n^3 (it needs Q1
+    // materialised) and is only worth it if the extra work can be overlapped
+    // with stedc, which the in-order queue does not currently allow.
+    const int32_t p1 = std::max<int32_t>(0, n - kd);
 
-    Span<T> tau_q_flat(tau_q_span.data(), static_cast<std::size_t>(p) * static_cast<std::size_t>(batch));
-
-    if constexpr (is_std_complex_v<T>) {
-        auto z_real_span = pool.allocate<Real>(ctx,
+    auto z_real_span = pool.allocate<Real>(ctx,
+                                           static_cast<std::size_t>(n) *
                                                static_cast<std::size_t>(n) *
-                                                   static_cast<std::size_t>(n) *
-                                                   static_cast<std::size_t>(batch));
-        MatrixView<Real, MatrixFormat::Dense> z_real_view(z_real_span.data(),
-                                                          n,
-                                                          n,
-                                                          n,
-                                                          static_cast<int64_t>(n) * static_cast<int64_t>(n),
-                                                          batch);
+                                               static_cast<std::size_t>(batch));
+    MatrixView<Real, MatrixFormat::Dense> z_real_view(z_real_span.data(),
+                                                      n,
+                                                      n,
+                                                      n,
+                                                      static_cast<int64_t>(n) * static_cast<int64_t>(n),
+                                                      batch);
 
-        auto zc_span = pool.allocate<T>(ctx,
-                                        static_cast<std::size_t>(n) *
-                                            static_cast<std::size_t>(n) *
-                                            static_cast<std::size_t>(batch));
-        MatrixView<T, MatrixFormat::Dense> zc_view(zc_span.data(),
-                                                   n,
-                                                   n,
-                                                   n,
-                                                   static_cast<int64_t>(n) * static_cast<int64_t>(n),
-                                                   batch);
-
+    {
         BATCHLAS_KERNEL_TRACE_SCOPE("syev_two_stage.stedc_eigvecs");
         const size_t stedc_ws_bytes = stedc_workspace_size<B, Real>(ctx,
                                                                      static_cast<std::size_t>(n),
@@ -421,135 +483,69 @@ Event syev_two_stage(Queue& ctx,
                        JobType::EigenVectors,
                        stedc_params,
                        z_real_view);
-
-        lift_real_eigvecs_with_phase<T>(ctx, z_real_view, phase_view, zc_view);
-
-        if (p > 0) {
-            BATCHLAS_KERNEL_TRACE_SCOPE("syev_two_stage.backtransform_q");
-            auto zc_sub = zc_view({1, SliceEnd()}, Slice{});
-            size_t ormqr_ws_bytes = 0;
-            if constexpr (B == Backend::NETLIB) {
-                ormqr_ws_bytes = backend::ormqr_vendor_buffer_size<B, T>(ctx,
-                                                                          aq_view,
-                                                                          zc_sub,
-                                                                          Side::Left,
-                                                                          Transpose::NoTrans,
-                                                                          tau_q_flat);
-            } else {
-                ormqr_ws_bytes = ormqr_blocked_buffer_size<B, T>(ctx,
-                                                                  aq_view,
-                                                                  zc_sub,
-                                                                  Side::Left,
-                                                                  Transpose::NoTrans,
-                                                                  tau_q_flat,
-                                                                  ormqr_block_size);
-            }
-            auto ormqr_ws = pool.allocate<std::byte>(ctx, ormqr_ws_bytes);
-            if constexpr (B == Backend::NETLIB) {
-                backend::ormqr_vendor<B, T>(ctx,
-                                            aq_view,
-                                            zc_sub,
-                                            Side::Left,
-                                            Transpose::NoTrans,
-                                            tau_q_flat,
-                                            ormqr_ws);
-            } else {
-                ormqr_blocked<B, T>(ctx,
-                                    aq_view,
-                                    zc_sub,
-                                    Side::Left,
-                                    Transpose::NoTrans,
-                                    tau_q_flat,
-                                    ormqr_ws,
-                                    ormqr_block_size);
-            }
-        }
-
-        MatrixView<T, MatrixFormat::Dense>::copy(ctx, a, zc_view);
-    } else {
-        auto z_span = pool.allocate<Real>(ctx,
-                                          static_cast<std::size_t>(n) *
-                                              static_cast<std::size_t>(n) *
-                                              static_cast<std::size_t>(batch));
-        MatrixView<Real, MatrixFormat::Dense> z_view(z_span.data(),
-                                                     n,
-                                                     n,
-                                                     n,
-                                                     static_cast<int64_t>(n) * static_cast<int64_t>(n),
-                                                     batch);
-
-        BATCHLAS_KERNEL_TRACE_SCOPE("syev_two_stage.stedc_eigvecs");
-        const size_t stedc_ws_bytes = stedc_workspace_size<B, Real>(ctx,
-                                                                     static_cast<std::size_t>(n),
-                                                                     static_cast<std::size_t>(batch),
-                                                                     JobType::EigenVectors,
-                                                                     stedc_params);
-        auto stedc_ws = pool.allocate<std::byte>(ctx, stedc_ws_bytes);
-        stedc<B, Real>(ctx,
-                       d_view,
-                       e_view,
-                       evals_view,
-                       stedc_ws,
-                       JobType::EigenVectors,
-                       stedc_params,
-                       z_view);
-
-        apply_phase_rows<Real>(ctx, z_view, VectorView<Real>(phase_span.data(), n, batch, 1, n));
-
-        if (p > 0) {
-            BATCHLAS_KERNEL_TRACE_SCOPE("syev_two_stage.backtransform_q");
-            auto z_sub = z_view({1, SliceEnd()}, Slice{});
-            MatrixView<Real, MatrixFormat::Dense> aq_real_view(aq_span.data(),
-                                                               p,
-                                                               p,
-                                                               p,
-                                                               static_cast<int64_t>(p) * static_cast<int64_t>(p),
-                                                               batch);
-            Span<Real> tau_q_real(reinterpret_cast<Real*>(tau_q_span.data()),
-                                  static_cast<std::size_t>(p) * static_cast<std::size_t>(batch));
-
-            size_t ormqr_ws_bytes = 0;
-            if constexpr (B == Backend::NETLIB) {
-                ormqr_ws_bytes = backend::ormqr_vendor_buffer_size<B, Real>(ctx,
-                                                                             aq_real_view,
-                                                                             z_sub,
-                                                                             Side::Left,
-                                                                             Transpose::NoTrans,
-                                                                             tau_q_real);
-            } else {
-                ormqr_ws_bytes = ormqr_blocked_buffer_size<B, Real>(ctx,
-                                                                     aq_real_view,
-                                                                     z_sub,
-                                                                     Side::Left,
-                                                                     Transpose::NoTrans,
-                                                                     tau_q_real,
-                                                                     ormqr_block_size);
-            }
-            auto ormqr_ws = pool.allocate<std::byte>(ctx, ormqr_ws_bytes);
-            if constexpr (B == Backend::NETLIB) {
-                backend::ormqr_vendor<B, Real>(ctx,
-                                               aq_real_view,
-                                               z_sub,
-                                               Side::Left,
-                                               Transpose::NoTrans,
-                                               tau_q_real,
-                                               ormqr_ws);
-            } else {
-                ormqr_blocked<B, Real>(ctx,
-                                       aq_real_view,
-                                       z_sub,
-                                       Side::Left,
-                                       Transpose::NoTrans,
-                                       tau_q_real,
-                                       ormqr_ws,
-                                       ormqr_block_size);
-            }
-        }
-
-        MatrixView<Real, MatrixFormat::Dense>::copy(ctx,
-                                                    MatrixView<Real, MatrixFormat::Dense>(a.data_ptr(), a.rows(), a.cols(), a.ld(), a.stride(), a.batch_size()),
-                                                    z_view);
     }
+
+    // stedc solves the *real* tridiagonal built from |subdiagonal|. Lifting by
+    // the accumulated phase converts its eigenvectors back to those of the
+    // signed/Hermitian tridiagonal that stage 2 actually produced.
+    auto z_span = pool.allocate<T>(ctx,
+                                   static_cast<std::size_t>(n) *
+                                       static_cast<std::size_t>(n) *
+                                       static_cast<std::size_t>(batch));
+    MatrixView<T, MatrixFormat::Dense> z_view(z_span.data(),
+                                              n,
+                                              n,
+                                              n,
+                                              static_cast<int64_t>(n) * static_cast<int64_t>(n),
+                                              batch);
+    lift_eigvecs_with_phase<T>(ctx, z_real_view, phase_view, z_view);
+
+    // Z := Q2 Z
+    if (nrefl > 0) {
+        BATCHLAS_KERNEL_TRACE_SCOPE("syev_two_stage.backtransform_q2");
+        internal::unmqr_hb2st<B, T>(ctx,
+                                    v_sb2st_view,
+                                    tau_sb2st_hh_view,
+                                    z_view,
+                                    n,
+                                    kd,
+                                    Span<const int32_t>(sb2st_starts.data(), sb2st_starts.size()),
+                                    Span<const int32_t>(sb2st_lens.data(), sb2st_lens.size()));
+    }
+
+    // Z(kd:, :) := Q1 Z(kd:, :).
+    //
+    // sy2sb factors panel i with GEQRF starting at row i+kd, so the aggregate
+    // a(kd:, 0:n-kd) is already exactly a GEQRF-style reflector layout: panel i
+    // sits at local (row i, col i). ormqr_blocked's V packing only reads the
+    // strictly lower triangle, so the sliced view suffices -- no packed copy,
+    // matching what syev_blocked does (sytrd_lower_qsub_reflector_view).
+    if (p1 > 0) {
+        BATCHLAS_KERNEL_TRACE_SCOPE("syev_two_stage.backtransform_q1");
+        auto v1_view = a({kd, SliceEnd()}, {0, p1});
+        auto z_sub = z_view({kd, SliceEnd()}, Slice{});
+        Span<T> tau1_flat(tau_sy2sb_span.data(),
+                          static_cast<std::size_t>(p1) * static_cast<std::size_t>(batch));
+
+        size_t ormqr_ws_bytes = 0;
+        if constexpr (B == Backend::NETLIB) {
+            ormqr_ws_bytes = backend::ormqr_vendor_buffer_size<B, T>(
+                ctx, v1_view, z_sub, Side::Left, Transpose::NoTrans, tau1_flat);
+        } else {
+            ormqr_ws_bytes = ormqr_blocked_buffer_size<B, T>(
+                ctx, v1_view, z_sub, Side::Left, Transpose::NoTrans, tau1_flat, ormqr_block_size);
+        }
+        auto ormqr_ws = pool.allocate<std::byte>(ctx, ormqr_ws_bytes);
+        if constexpr (B == Backend::NETLIB) {
+            backend::ormqr_vendor<B, T>(
+                ctx, v1_view, z_sub, Side::Left, Transpose::NoTrans, tau1_flat, ormqr_ws);
+        } else {
+            ormqr_blocked<B, T>(ctx, v1_view, z_sub, Side::Left, Transpose::NoTrans,
+                                tau1_flat, ormqr_ws, ormqr_block_size);
+        }
+    }
+
+    MatrixView<T, MatrixFormat::Dense>::copy(ctx, a, z_view);
 
     return ctx.get_event();
 }
@@ -619,22 +615,30 @@ size_t syev_two_stage_buffer_size(Queue& ctx,
                                                       static_cast<std::size_t>(n) *
                                                       static_cast<std::size_t>(batch)); // stedc scratch/result
     if (want_eigvecs) {
+        const int32_t nr = std::max<int32_t>(1, internal::sb2st_hh_num_reflectors(n, kd));
+        const int32_t kdw = internal::sb2st_hh_work_bandwidth(n, kd);
         bytes += BumpAllocator::allocation_size<T>(ctx,
                                                    static_cast<std::size_t>(n) *
                                                        static_cast<std::size_t>(batch)); // phase/sign chain
         bytes += BumpAllocator::allocation_size<T>(ctx,
-                                                   static_cast<std::size_t>(p) *
-                                                       static_cast<std::size_t>(p) *
-                                                       static_cast<std::size_t>(batch)); // packed Qsub reflectors
+                                                   static_cast<std::size_t>(kd) *
+                                                       static_cast<std::size_t>(nr) *
+                                                       static_cast<std::size_t>(batch)); // stage-2 reflectors V
         bytes += BumpAllocator::allocation_size<T>(ctx,
-                                                   static_cast<std::size_t>(p) *
-                                                       static_cast<std::size_t>(batch)); // tau for packed Qsub
-        if constexpr (is_std_complex_v<T>) {
-            bytes += BumpAllocator::allocation_size<T>(ctx,
+                                                   static_cast<std::size_t>(nr) *
+                                                       static_cast<std::size_t>(batch)); // stage-2 tau
+        bytes += BumpAllocator::allocation_size<T>(ctx,
+                                                   static_cast<std::size_t>(2) *
                                                        static_cast<std::size_t>(n) *
-                                                           static_cast<std::size_t>(n) *
-                                                           static_cast<std::size_t>(batch)); // lifted complex eigenvectors
-        }
+                                                       static_cast<std::size_t>(batch)); // tridiagonal band (signed)
+        bytes += BumpAllocator::allocation_size<T>(ctx,
+                                                   static_cast<std::size_t>(kdw + 1) *
+                                                       static_cast<std::size_t>(n) *
+                                                       static_cast<std::size_t>(batch)); // sb2st_hh working band
+        bytes += BumpAllocator::allocation_size<T>(ctx,
+                                                   static_cast<std::size_t>(n) *
+                                                       static_cast<std::size_t>(n) *
+                                                       static_cast<std::size_t>(batch)); // Z in T (post phase-lift)
     }
 
     MatrixView<T, MatrixFormat::Dense> ab_dummy(nullptr,

--- a/src/extensions/syev_two_stage.cc
+++ b/src/extensions/syev_two_stage.cc
@@ -58,59 +58,35 @@ inline int32_t env_int_or_default(const char* key, int32_t defval) {
     return (parsed > 0) ? static_cast<int32_t>(parsed) : defval;
 }
 
-// sytrd_sy2sb produces a numerically wrong band unless the trailing panel is
-// degenerate, i.e. unless n % kd is 0 or 1. Verified exhaustively for float over
-// kd in {16,24,32,48,64,96} x n in {64,96,128,129,192,256}: every cell with
-// n % kd > 1 fails the eigenvector residual at O(0.1..0.8), every cell with
-// n % kd <= 1 passes, with no other pattern (it is not "kd > n/2", and it is not
-// complex-only as the earlier fallback comment below assumed -- kd=16 and kd=32
-// looked clean only because every n tested against them happened to satisfy the
-// rule). SyevTwoStageTest.Sy2sbTrailingPanelIsWrong pins this down.
-//
-// Until stage 1 is fixed, kd selection must respect the rule.
-constexpr int32_t kMinTwoStageKd = 8;
-
-inline bool sy2sb_kd_is_safe(int32_t n, int32_t kd) {
-    return kd <= 1 || (n % kd) <= 1;
-}
-
 inline int32_t choose_two_stage_kd(int32_t n) {
     // Measured with syev_two_stage_benchmark (float, eigenvectors, RTX 4090,
-    // total ms; kd across, n/batch down). Only kd values satisfying
-    // sy2sb_kd_is_safe are listed: kd=48 and kd=96 time ~5-10% better at some
-    // sizes but violate the rule at every n here, so those numbers are garbage
-    // runs, not options. That trap is why this table is restricted by hand.
+    // total ms; kd across, n/batch down):
     //
-    //                kd=16      32      64    blocked
-    //   128/2048      28.4    23.4    21.1      15.0
-    //   256/1024      80.4    67.6    68.1      41.8
-    //   512/512      328.3   254.4   263.5     193.4
-    //   1024/128     987.9   641.3   555.1     479.9
-    //   2048/32     3201.8  2004.5  1711.2    1265.2
+    //                kd=16      32      48      64      96   blocked
+    //   128/2048      28.3    23.5    22.6    21.2    18.1     15.0
+    //   256/1024      80.6    68.1    69.9    68.4    71.6     41.9
+    //   512/512      329.7   255.6   269.7   265.0   309.3    193.0
+    //   1024/128     991.9   644.3   574.0   557.6   603.6    481.5
+    //   2048/32     3206.6  2007.3  1831.2  1712.6  1814.2   1262.6
     //
     // The optimum rises with n (Gates/Tomov/Dongarra 2018 report the same trend
     // once eigenvectors are wanted), so this is a table rather than a constant.
     // The old flat 16/32 rule was off by 1.16x at n=1024 and 1.17x at n=2048.
-    // n=128 also prefers 64, but two-stage loses to blocked by 1.4x there, so
-    // the simpler threshold is kept rather than special-casing an unused size.
+    // n=128 prefers 96, but two-stage loses to blocked by 1.2x there, so the
+    // simpler threshold is kept rather than special-casing an unused size.
     //
     // Note the last column: blocked still wins everywhere, by 1.16x at n=1024
     // (its best case for two-stage) and more elsewhere.
+    //
+    // kd used to be constrained to n % kd <= 1 to dodge a sytrd_sy2sb bug that
+    // skipped part of the two-sided update on a short final panel. That bug is
+    // fixed (see the A_left/A_right widening in sytrd_sy2sb.cc), so any kd is
+    // valid again; SyevTwoStageTest.AwkwardSizesStayAccurate covers the sizes
+    // that used to break.
     const int32_t def = (n <= 512) ? 32 : 64;
 
-    // An explicit override is taken verbatim (it is how the kd sweep in
-    // syev_two_stage_benchmark works); it is the caller's job to respect
-    // sy2sb_kd_is_safe.
-    if (const char* ev = std::getenv("BATCHLAS_SYEV_TWO_STAGE_KD")) {
-        const int32_t kd = static_cast<int32_t>(std::atol(ev));
-        if (kd > 0) return std::min(kd, std::max<int32_t>(1, n - 1));
-    }
-
-    const int32_t target = std::min(def, std::max<int32_t>(1, n - 1));
-    for (int32_t kd = target; kd >= kMinTwoStageKd; --kd) {
-        if (sy2sb_kd_is_safe(n, kd)) return kd;
-    }
-    return 0;  // caller falls back to syev_blocked
+    const int32_t kd = env_int_or_default("BATCHLAS_SYEV_TWO_STAGE_KD", def);
+    return std::min(std::max<int32_t>(1, kd), std::max<int32_t>(1, n - 1));
 }
 
 inline int32_t choose_two_stage_kd_for_job(int32_t n, JobType jobz) {
@@ -306,32 +282,10 @@ Event syev_two_stage(Queue& ctx,
         }
     }
 
-    if constexpr (is_std_complex_v<T>) {
-        if (jobz == JobType::EigenVectors) {
-            // sytrd_sy2sb is not accurate for complex input when n is not a
-            // multiple of kd: an isolated spectrum-preservation check on stage 1
-            // alone (SyevTwoStageTest.Sy2sbBandPreservesSpectrum) is clean for
-            // float and double but fails for complex<float> (~8e-2) and
-            // complex<double> (~1e-5) at n=129/kd=16, while n=128 passes.
-            // sytrd_sy2sb_tests covers only float and double, so this was never
-            // caught; eigenvector mode is the first caller to use kd>1.
-            //
-            // Falling back keeps complex results correct. Remove this once
-            // stage 1's complex path is fixed.
-            return syev_blocked<B, T>(ctx, a_in, eigenvalues, jobz, uplo, ws, stedc_params);
-        }
-    }
-
     auto& a = const_cast<MatrixView<T, MatrixFormat::Dense>&>(a_in);
     const int32_t n = static_cast<int32_t>(a.rows());
     const int32_t batch = static_cast<int32_t>(a.batch_size());
     const bool want_eigvecs = (jobz == JobType::EigenVectors);
-
-    // No band width in the useful range gives sy2sb a degenerate trailing panel
-    // (see sy2sb_kd_is_safe); running anyway would return silent garbage.
-    if (choose_two_stage_kd_for_job(n, jobz) == 0) {
-        return syev_blocked<B, T>(ctx, a_in, eigenvalues, jobz, uplo, ws, stedc_params);
-    }
     const int32_t kd = choose_two_stage_kd_for_job(n, jobz);
     const int32_t tau_sy2sb_n = std::max<int32_t>(0, n - kd);
     const int32_t sb2st_block_size = choose_two_stage_sb2st_block_size();
@@ -632,23 +586,10 @@ size_t syev_two_stage_buffer_size(Queue& ctx,
         }
     }
 
-    if constexpr (is_std_complex_v<T>) {
-        if (jobz == JobType::EigenVectors) {
-            // Mirrors the fallback in syev_two_stage (stage-1 complex accuracy).
-            return syev_blocked_buffer_size<B, T>(ctx, a, jobz, uplo, stedc_params);
-        }
-    }
-
     const int32_t n = static_cast<int32_t>(a.rows());
     const int32_t batch = static_cast<int32_t>(a.batch_size());
     const bool want_eigvecs = (jobz == JobType::EigenVectors);
     const int32_t kd = choose_two_stage_kd_for_job(n, jobz);
-
-    // Must mirror the fallback in syev_two_stage exactly, or the workspace and
-    // the path that consumes it disagree.
-    if (kd == 0) {
-        return syev_blocked_buffer_size<B, T>(ctx, a, jobz, uplo, stedc_params);
-    }
 
     const int32_t tau_sy2sb_n = std::max<int32_t>(0, n - kd);
     const int32_t sb2st_block_size = choose_two_stage_sb2st_block_size();

--- a/src/extensions/sytrd_sb2st.cc
+++ b/src/extensions/sytrd_sb2st.cc
@@ -569,7 +569,11 @@ Event btrd_lower_inplace(Queue& q,
                         sycl::group_barrier(it.get_group());
 
                         if (nr > 2 * kd - 1) {
-                            // Keep the l-loop sequential, but parallelize across rotations within each l.
+                            // Iteration l touches band elements (kd-1-l, c) and (kd-l, c) with
+                            // c = j-kd1+l+1, so successive l values address distinct columns and
+                            // distinct rows; across t the columns are kd1 apart. The whole (l,t)
+                            // nest therefore writes disjoint locations and needs only one barrier
+                            // at the end (mirrors btrd_lower_inplace_subgroup).
                             for (int l = 0; l < kd - 1; ++l) {
                                 for (int t = lid; t < nr; t += lsize) {
                                     const int j = j1 + t * kd1;
@@ -578,8 +582,8 @@ Event btrd_lower_inplace(Queue& q,
                                                   C[j],
                                                   WORK[j]);
                                 }
-                                sycl::group_barrier(it.get_group());
                             }
+                            sycl::group_barrier(it.get_group());
                         } else {
                             if (lid == 0) {
                                 const int jend = j1 + (nr - 1) * kd1;
@@ -656,6 +660,9 @@ Event btrd_lower_inplace(Queue& q,
                         }
 
                         if (nr > 2 * kd - 1) {
+                            // Iteration l touches (l+2, j-1) and (l+1, j); iteration l+1 touches
+                            // (l+3, j-1) and (l+2, j) -- disjoint in both row and column, and the
+                            // t values are kd1 columns apart. One trailing barrier suffices.
                             for (int l = 0; l < kd - 1; ++l) {
                                 const int nrt = (j2 + l + 2 > n) ? (nr - 1) : nr;
                                 if (nrt > 0) {
@@ -666,9 +673,9 @@ Event btrd_lower_inplace(Queue& q,
                                                       C[j],
                                                       WORK[j]);
                                     }
-                                    sycl::group_barrier(it.get_group());
                                 }
                             }
+                            sycl::group_barrier(it.get_group());
                         } else {
                             if (lid == 0) {
                                 const int j1end = j1 + kd1 * (nr - 2);

--- a/src/extensions/sytrd_sb2st_cta.cc
+++ b/src/extensions/sytrd_sb2st_cta.cc
@@ -366,13 +366,21 @@ Event btrd_lower_inplace_subgroup(Queue& q,
         size_t(cw_len_host) * (sizeof(Real) + sizeof(T)) * size_t(probs_per_wg);
 
     // Leave headroom (25%) for compiler/runtime usage.
-    const bool use_local_ab = (ab_bytes_per_wg > 0) && ((ab_bytes_per_wg + cw_bytes_per_wg) <= (lmem_bytes * 3) / 4);
+    const size_t lmem_budget = (lmem_bytes * 3) / 4;
+
+    // The C/WORK rotation scratch is the *first* claim on local memory: it is touched
+    // every chase step, whereas AB staging only pays off if the whole band also fits.
+    // Both are optional -- global fallbacks (the `c` / `work` parameters) are always
+    // allocated by the caller, so exceeding local memory must degrade, not fail to launch.
+    const bool use_local_cw = (cw_bytes_per_wg > 0) && (cw_bytes_per_wg <= lmem_budget);
+    const bool use_local_ab = (ab_bytes_per_wg > 0) &&
+                              ((ab_bytes_per_wg + (use_local_cw ? cw_bytes_per_wg : size_t(0))) <= lmem_budget);
 
     // local_accessor must be non-zero sized.
     const size_t ab_local_elems = use_local_ab
                                       ? (size_t(ldab_local_host) * size_t(n) * size_t(probs_per_wg))
                                       : size_t(1);
-    const size_t cw_local_elems = (cw_len_host > 0)
+    const size_t cw_local_elems = use_local_cw
                                       ? (size_t(cw_len_host) * size_t(probs_per_wg))
                                       : size_t(1);
     (void)q->submit([&](sycl::handler& h) {
@@ -422,8 +430,18 @@ Event btrd_lower_inplace_subgroup(Queue& q,
                 T* AB = ABv.data();
                 T* ABg = AB; // original global pointer for copy-back
 
-                Real* C = c_local.template get_multi_ptr<sycl::access::decorated::no>().get() + part_id * (n + kd + 2);
-                T* WORK = work_local.template get_multi_ptr<sycl::access::decorated::no>().get() + part_id * (n + kd + 2);
+                // C/WORK live in local memory when the per-work-group footprint fits,
+                // otherwise in the caller-provided global scratch. Indexing is identical.
+                Real* C = nullptr;
+                T* WORK = nullptr;
+                if (use_local_cw) {
+                    C = c_local.template get_multi_ptr<sycl::access::decorated::no>().get() + part_id * (n + kd + 2);
+                    WORK = work_local.template get_multi_ptr<sycl::access::decorated::no>().get() + part_id * (n + kd + 2);
+                } else {
+                    // Cv/WORKv are built with inc=1, so the batch base pointer is contiguous.
+                    C = c.batch_item(prob_id).data().data();
+                    WORK = work.batch_item(prob_id).data().data();
+                }
 
                 auto& D = Dv;
                 auto& E = Ev;

--- a/src/extensions/sytrd_sb2st_hh.cc
+++ b/src/extensions/sytrd_sb2st_hh.cc
@@ -74,7 +74,29 @@ inline T group_sum(Group g, T v) {
 template <Backend B, typename T>
 class Sb2stHhChaseKernel;
 
-constexpr int kWg = 32;
+// Sub-group XOR shuffle that also works for std::complex.
+template <typename T>
+inline T shuffle_xor(sycl::sub_group sg, T v, uint32_t mask) {
+    using R = typename base_type<T>::type;
+    if constexpr (internal::is_complex<T>::value) {
+        const R re = sycl::permute_group_by_xor(sg, static_cast<R>(v.real()), mask);
+        const R im = sycl::permute_group_by_xor(sg, static_cast<R>(v.imag()), mask);
+        return T(re, im);
+    } else {
+        return sycl::permute_group_by_xor(sg, v, mask);
+    }
+}
+
+// The chase is sequential per matrix, so a work-group owns one problem and the
+// only parallelism inside it is the <= kd x kd window of the current step. With
+// a 32-thread work-group and kd=32 that means each lane loops 32x serially, and
+// at batch=128 the whole kernel occupies ~4096 threads on a GPU with ~196k
+// slots -- about 2% occupancy, which is what made the chase cost as much as the
+// back-transform. kWg=256 with a 2D (row, column-chunk) mapping puts 8 lanes on
+// each row of the window instead of 1.
+constexpr int kWg = 256;
+constexpr int kRowsPar = 32;          // max window extent == max kd
+constexpr int kTpr = kWg / kRowsPar;  // lanes cooperating on one row/column
 
 } // namespace
 
@@ -196,15 +218,39 @@ Event sytrd_sb2st_hh(Queue& ctx,
                 // W <- H W H^H on the principal block [a..b], H = I - tau v v^H,
                 // v held in vloc with length m. Only the lower triangle is
                 // written; the update keeps the diagonal real by construction.
+                // 2D lane mapping: ti indexes the row (or column) of the window,
+                // ts indexes a chunk of the reduced dimension. Lanes sharing a ti
+                // are the kTpr contiguous lanes ti*kTpr .. ti*kTpr+kTpr-1, which
+                // sit inside one sub-group, so the partial sums reduce with XOR
+                // shuffles rather than through local memory.
+                const int32_t ti = lid / kTpr;
+                const int32_t ts = lid % kTpr;
+                const auto sg = it.get_sub_group();
+
+                // NOTE: this is a sub-group collective, so every lane in the
+                // work-group must call it -- out-of-range lanes contribute 0
+                // rather than branching around it.
+                auto reduce_tpr = [&](T v) -> T {
+                    for (uint32_t msk = 1; msk < static_cast<uint32_t>(kTpr); msk <<= 1) {
+                        v += shuffle_xor(sg, v, msk);
+                    }
+                    return v;
+                };
+
                 auto two_sided = [&](int32_t a, int32_t bb, T tau) {
                     const int32_t m = bb - a + 1;
                     if (m <= 0) return;
-                    for (int32_t i = lid; i < m; i += kWg) {
+
+                    // p = W v, one row per ti, reduced over ts.
+                    {
                         T acc = T(0);
-                        for (int32_t j = 0; j < m; ++j) {
-                            acc += bget(a + i, a + j) * vloc[j];
+                        if (ti < m) {
+                            for (int32_t j = ts; j < m; j += kTpr) {
+                                acc += bget(a + ti, a + j) * vloc[j];
+                            }
                         }
-                        wloc[i] = acc;
+                        acc = reduce_tpr(acc);
+                        if (ti < m && ts == 0) wloc[ti] = acc;
                     }
                     sycl::group_barrier(wg);
 
@@ -222,12 +268,14 @@ Event sytrd_sb2st_hh(Queue& ctx,
                     }
                     sycl::group_barrier(wg);
 
-                    for (int32_t i = lid; i < m; i += kWg) {
-                        for (int32_t j = 0; j <= i; ++j) {
-                            T val = bget(a + i, a + j) - wloc[i] * conj_if(vloc[j]) -
-                                    vloc[i] * conj_if(wloc[j]);
-                            if (i == j) val = real_part_as_T(val);
-                            bset(a + i, a + j, val);
+                    // Rank-2 update of the lower triangle; no reduction, so ts
+                    // simply strides the inner index.
+                    if (ti < m) {
+                        for (int32_t j = ts; j <= ti; j += kTpr) {
+                            T val = bget(a + ti, a + j) - wloc[ti] * conj_if(vloc[j]) -
+                                    vloc[ti] * conj_if(wloc[j]);
+                            if (ti == j) val = real_part_as_T(val);
+                            bset(a + ti, a + j, val);
                         }
                     }
                     sycl::group_barrier(wg);
@@ -236,13 +284,17 @@ Event sytrd_sb2st_hh(Queue& ctx,
                 // B <- B (I - tau v v^H), v of length (c1-c0+1) in vloc.
                 auto right_apply = [&](int32_t r0, int32_t r1, int32_t c0, int32_t c1, T tau) {
                     if (r0 > r1 || c0 > c1) return;
-                    for (int32_t i = r0 + lid; i <= r1; i += kWg) {
-                        T y = T(0);
-                        for (int32_t j = c0; j <= c1; ++j) {
+                    const int32_t nr = r1 - r0 + 1;
+                    const int32_t i = r0 + ti;
+                    T y = T(0);
+                    if (ti < nr) {
+                        for (int32_t j = c0 + ts; j <= c1; j += kTpr) {
                             y += bget(i, j) * vloc[j - c0];
                         }
-                        y = tau * y;
-                        for (int32_t j = c0; j <= c1; ++j) {
+                    }
+                    y = tau * reduce_tpr(y);
+                    if (ti < nr) {
+                        for (int32_t j = c0 + ts; j <= c1; j += kTpr) {
                             bset(i, j, bget(i, j) - y * conj_if(vloc[j - c0]));
                         }
                     }
@@ -252,13 +304,17 @@ Event sytrd_sb2st_hh(Queue& ctx,
                 // C <- (I - tau v v^H) C, v of length (r1-r0+1) in vloc.
                 auto left_apply = [&](int32_t r0, int32_t r1, int32_t c0, int32_t c1, T tau) {
                     if (r0 > r1 || c0 > c1) return;
-                    for (int32_t j = c0 + lid; j <= c1; j += kWg) {
-                        T z = T(0);
-                        for (int32_t i = r0; i <= r1; ++i) {
+                    const int32_t nc = c1 - c0 + 1;
+                    const int32_t j = c0 + ti;
+                    T z = T(0);
+                    if (ti < nc) {
+                        for (int32_t i = r0 + ts; i <= r1; i += kTpr) {
                             z += conj_if(vloc[i - r0]) * bget(i, j);
                         }
-                        z = tau * z;
-                        for (int32_t i = r0; i <= r1; ++i) {
+                    }
+                    z = tau * reduce_tpr(z);
+                    if (ti < nc) {
+                        for (int32_t i = r0 + ts; i <= r1; i += kTpr) {
                             bset(i, j, bget(i, j) - vloc[i - r0] * z);
                         }
                     }
@@ -381,18 +437,6 @@ class Sb2stHhBackTiledKernel;
 
 constexpr int kBackCols = 8;  // columns of Z per work-group (global-memory path)
 
-// Sub-group XOR shuffle that also works for std::complex.
-template <typename T>
-inline T shuffle_xor(sycl::sub_group sg, T v, uint32_t mask) {
-    using R = typename base_type<T>::type;
-    if constexpr (internal::is_complex<T>::value) {
-        const R re = sycl::permute_group_by_xor(sg, static_cast<R>(v.real()), mask);
-        const R im = sycl::permute_group_by_xor(sg, static_cast<R>(v.imag()), mask);
-        return T(re, im);
-    } else {
-        return sycl::permute_group_by_xor(sg, v, mask);
-    }
-}
 }
 
 // Resident-tile back-transform.

--- a/src/extensions/sytrd_sb2st_hh.cc
+++ b/src/extensions/sytrd_sb2st_hh.cc
@@ -353,6 +353,98 @@ Event sytrd_sb2st_hh(Queue& ctx,
     return ctx.get_event();
 }
 
+// ---------------------------------------------------------------------------
+// Q2 back-transform:  Z := Q2 Z  with  Q2 = H_1 H_2 ... H_m.
+//
+// Because the product is in generation order, Z := Q2 Z applies the reflectors
+// in *reverse* order: H_m first, H_1 last.
+//
+// Parallelisation: reflectors act on rows, so distinct columns of Z are
+// completely independent. Each work-group takes one (batch item, column chunk)
+// and walks the entire reflector list itself -- no inter-work-group
+// synchronisation and no launch per sweep. Within a work-group the 32 lanes map
+// to *rows* of the reflector (len <= kd <= 32), which keeps the Z accesses
+// contiguous since Z is column-major; the dot product is a sub-group reduction.
+//
+// This is flop-optimal (2n^3 total, versus ~4n^3 for a larft/larfb formulation
+// whose V panels are zero-padded) but memory bound. Wang et al. (PPoPP'25)
+// found a hand-written BLAS-2 back-transform beat MAGMA's BLAS-3 one by 1.5x on
+// A100 for exactly this reason, so this is a reasonable starting point; the
+// larft grouping remains available if profiling says otherwise.
+namespace {
+template <Backend B, typename T>
+class Sb2stHhBackKernel;
+
+constexpr int kBackCols = 8;  // columns of Z per work-group
+}
+
+template <Backend B, typename T>
+Event unmqr_hb2st(Queue& ctx,
+                  const MatrixView<T, MatrixFormat::Dense>& v_in,
+                  const VectorView<T>& tau_in,
+                  const MatrixView<T, MatrixFormat::Dense>& z_io,
+                  int32_t n,
+                  int32_t kd,
+                  Span<const int32_t> starts,
+                  Span<const int32_t> lens) {
+    if (!ctx.in_order()) {
+        throw std::runtime_error("unmqr_hb2st: requires an in-order Queue");
+    }
+    const int32_t nrefl = static_cast<int32_t>(starts.size());
+    const int32_t batch = static_cast<int32_t>(z_io.batch_size());
+    const int32_t ncols = static_cast<int32_t>(z_io.cols());
+    if (nrefl <= 0 || batch <= 0 || ncols <= 0 || n <= 0) return ctx.get_event();
+
+    const int32_t col_chunks = (ncols + kBackCols - 1) / kBackCols;
+    const int32_t num_wg = batch * col_chunks;
+
+    auto Vv = v_in.kernel_view();
+    auto Zv = z_io.kernel_view();
+    const int32_t* starts_p = starts.data();
+    const int32_t* lens_p = lens.data();
+
+    ctx->submit([&](sycl::handler& h) {
+        auto TAUv = tau_in;
+        h.parallel_for<Sb2stHhBackKernel<B, T>>(
+            sycl::nd_range<1>(sycl::range<1>(static_cast<size_t>(num_wg) * 32),
+                              sycl::range<1>(32)),
+            [=](sycl::nd_item<1> it) [[sycl::reqd_sub_group_size(32)]] {
+                const auto sg = it.get_sub_group();
+                const int32_t wg_id = static_cast<int32_t>(it.get_group().get_group_linear_id());
+                const int32_t lane = static_cast<int32_t>(it.get_local_linear_id());
+
+                const int32_t b = wg_id / col_chunks;
+                const int32_t chunk = wg_id - b * col_chunks;
+                if (b >= batch) return;
+
+                const int32_t c0 = chunk * kBackCols;
+                const int32_t c1 = sycl::min(c0 + kBackCols, ncols);
+
+                auto Z = Zv.batch_item(b);
+                auto V = Vv.batch_item(b);
+
+                for (int32_t k = nrefl - 1; k >= 0; --k) {
+                    const T tau = TAUv(k, b);
+                    if (tau == T(0)) continue;
+                    const int32_t s = starts_p[k];
+                    const int32_t L = lens_p[k];
+
+                    const T vj = (lane < L) ? V(lane, k) : T(0);
+
+                    for (int32_t c = c0; c < c1; ++c) {
+                        const T zj = (lane < L) ? Z(s + lane, c) : T(0);
+                        const T sum = group_sum(sg, conj_if(vj) * zj);
+                        if (lane < L) {
+                            Z(s + lane, c) = zj - tau * vj * sum;
+                        }
+                    }
+                }
+            });
+    });
+
+    return ctx.get_event();
+}
+
 #define SB2ST_HH_INSTANTIATE(back, fp)                                                  \
     template Event sytrd_sb2st_hh<back, BATCHLAS_UNPAREN fp>(                           \
         Queue&,                                                                          \
@@ -366,7 +458,16 @@ Event sytrd_sb2st_hh(Queue& ctx,
         int32_t,                                                                         \
         const Span<std::byte>&);                                                         \
     template size_t sytrd_sb2st_hh_buffer_size<back, BATCHLAS_UNPAREN fp>(               \
-        Queue&, int32_t, int32_t, int32_t);
+        Queue&, int32_t, int32_t, int32_t);                                              \
+    template Event unmqr_hb2st<back, BATCHLAS_UNPAREN fp>(                               \
+        Queue&,                                                                          \
+        const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>&,                     \
+        const VectorView<BATCHLAS_UNPAREN fp>&,                                          \
+        const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>&,                     \
+        int32_t,                                                                         \
+        int32_t,                                                                         \
+        Span<const int32_t>,                                                             \
+        Span<const int32_t>);
 
 #define SB2ST_HH_INSTANTIATE_FOR_BACKEND(back) \
     BATCHLAS_FOR_EACH_SCALAR_TYPE_1(SB2ST_HH_INSTANTIATE, back)

--- a/src/extensions/sytrd_sb2st_hh.cc
+++ b/src/extensions/sytrd_sb2st_hh.cc
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <stdexcept>
 #include <type_traits>
+#include <vector>
 
 namespace batchlas {
 namespace internal {
@@ -456,8 +457,143 @@ class Sb2stHhBackKernel;
 template <Backend B, typename T, int C>
 class Sb2stHhBackTiledKernel;
 
+template <Backend B, typename T, int C, int S>
+class Sb2stHhBackWaveKernel;
+
 constexpr int kBackCols = 8;  // columns of Z per work-group (global-memory path)
 
+inline int env_int_or(const char* key, int defval) {
+    const char* v = std::getenv(key);
+    if (!v || !*v) return defval;
+    return std::atoi(v);
+}
+
+}
+
+// Wave back-transform: resident Z tile + concurrent application of every
+// reflector in a commuting run.
+//
+// The resident-tile kernel below fixed the traffic on Z but left the *serial
+// chain* untouched: one work-group walked all m reflectors one at a time with
+// 32 threads. At n=1024/kd=64 that is 8687 dependent steps, and the tile's
+// local-memory footprint capped occupancy at ~1 block/SM worth of threads.
+//
+// But the reflectors of a single chase sweep act on disjoint row ranges (each
+// starts one past the previous one's end), so they commute and can all be
+// applied at once. build_sb2st_hh_wave_offsets recovers those runs: at
+// n=1024/kd=64 the 8687 reflectors form 1022 waves averaging 8.5 reflectors, so
+// the chain is 8.5x shorter than the reflector count suggests.
+//
+// One work-group of S sub-groups owns a C-column tile of Z. Per wave each
+// sub-group takes reflectors k = lo + sgid, lo + sgid + S, ...; they touch
+// disjoint rows of the tile, so no synchronisation is needed *within* a wave --
+// not even between successive reflectors handled by the same sub-group. A
+// single work-group barrier separates waves.
+//
+// This also fixes the occupancy problem for free: the tile costs n*C
+// regardless of S, so going from 32 to S*32 threads multiplies threads-per-byte
+// of local memory by S.
+template <Backend B, typename T, int C, int S>
+Event unmqr_hb2st_wave(Queue& ctx,
+                       const MatrixView<T, MatrixFormat::Dense>& v_in,
+                       const VectorView<T>& tau_in,
+                       const MatrixView<T, MatrixFormat::Dense>& z_io,
+                       int32_t n,
+                       const int32_t* starts_p,
+                       const int32_t* lens_p,
+                       const int32_t* waves_p,
+                       int32_t num_waves) {
+    constexpr int32_t kSg = 32;
+    constexpr int32_t G = kSg / C;
+    constexpr int32_t kWg = kSg * S;
+    static_assert(C >= 1 && C <= 32 && (kSg % C) == 0);
+    static_assert(S >= 1);
+
+    const int32_t batch = static_cast<int32_t>(z_io.batch_size());
+    const int32_t ncols = static_cast<int32_t>(z_io.cols());
+    const int32_t col_chunks = (ncols + C - 1) / C;
+    const int32_t num_wg = batch * col_chunks;
+
+    auto Vv = v_in.kernel_view();
+    auto Zv = z_io.kernel_view();
+
+    ctx->submit([&](sycl::handler& h) {
+        sycl::local_accessor<T, 1> Zs(
+            sycl::range<1>(static_cast<size_t>(n) * static_cast<size_t>(C)), h);
+        auto TAUv = tau_in;
+
+        h.parallel_for<Sb2stHhBackWaveKernel<B, T, C, S>>(
+            sycl::nd_range<1>(sycl::range<1>(static_cast<size_t>(num_wg) * kWg),
+                              sycl::range<1>(kWg)),
+            [=](sycl::nd_item<1> it) [[sycl::reqd_sub_group_size(32)]] {
+                const auto wg = it.get_group();
+                const auto sg = it.get_sub_group();
+                const int32_t wg_id = static_cast<int32_t>(wg.get_group_linear_id());
+                const int32_t lid = static_cast<int32_t>(it.get_local_linear_id());
+                const int32_t sgid = lid / kSg;
+                const int32_t lane = lid - sgid * kSg;
+
+                const int32_t b = wg_id / col_chunks;
+                const int32_t chunk = wg_id - b * col_chunks;
+                if (b >= batch) return;
+
+                const int32_t c0 = chunk * C;
+                auto Z = Zv.batch_item(b);
+                auto V = Vv.batch_item(b);
+
+                T* Zl = Zs.template get_multi_ptr<sycl::access::decorated::no>().get();
+
+                for (int32_t idx = lid; idx < n * C; idx += kWg) {
+                    const int32_t r = idx / C;
+                    const int32_t c = idx - r * C;
+                    Zl[idx] = (c0 + c < ncols) ? Z(r, c0 + c) : T(0);
+                }
+                sycl::group_barrier(wg);
+
+                const int32_t col = lane % C;
+                const int32_t grp = lane / C;
+
+                // Q = H_1 ... H_m, so Z := Q Z runs the waves in reverse
+                // generation order. Order *within* a wave is free.
+                for (int32_t wv = num_waves - 1; wv >= 0; --wv) {
+                    const int32_t lo = waves_p[wv];
+                    const int32_t hi = waves_p[wv + 1];
+
+                    // Every lane of a sub-group shares k, so tau and L are
+                    // sub-group uniform and the shuffles below stay uniform.
+                    for (int32_t k = lo + sgid; k < hi; k += S) {
+                        const T tau = TAUv(k, b);
+                        if (tau == T(0)) continue;
+                        const int32_t s = starts_p[k];
+                        const int32_t L = lens_p[k];
+
+                        T acc = T(0);
+                        for (int32_t r = grp; r < L; r += G) {
+                            acc += conj_if(V(r, k)) * Zl[(s + r) * C + col];
+                        }
+                        if constexpr (G > 1) {
+                            for (uint32_t m = C; m < static_cast<uint32_t>(kSg); m <<= 1) {
+                                acc += shuffle_xor(sg, acc, m);
+                            }
+                        }
+                        for (int32_t r = grp; r < L; r += G) {
+                            Zl[(s + r) * C + col] -= tau * V(r, k) * acc;
+                        }
+                        // No barrier: the next k in this wave is disjoint from
+                        // this one, and other sub-groups are on disjoint rows.
+                    }
+                    sycl::group_barrier(wg);
+                }
+
+                for (int32_t idx = lid; idx < n * C; idx += kWg) {
+                    const int32_t r = idx / C;
+                    const int32_t c = idx - r * C;
+                    if (c0 + c < ncols) Z(r, c0 + c) = Zl[idx];
+                }
+            });
+    });
+
+    return ctx.get_event();
 }
 
 // Resident-tile back-transform.
@@ -584,7 +720,8 @@ Event unmqr_hb2st(Queue& ctx,
                   int32_t n,
                   int32_t kd,
                   Span<const int32_t> starts,
-                  Span<const int32_t> lens) {
+                  Span<const int32_t> lens,
+                  Span<const int32_t> waves) {
     if (!ctx.in_order()) {
         throw std::runtime_error("unmqr_hb2st: requires an in-order Queue");
     }
@@ -592,6 +729,66 @@ Event unmqr_hb2st(Queue& ctx,
     const int32_t batch = static_cast<int32_t>(z_io.batch_size());
     const int32_t ncols = static_cast<int32_t>(z_io.cols());
     if (nrefl <= 0 || batch <= 0 || ncols <= 0 || n <= 0) return ctx.get_event();
+
+    // Preferred path: resident tile + wave-parallel reflectors. Set
+    // BATCHLAS_SB2ST_BACK_WAVE=0 to fall through to the single-sub-group tiled
+    // kernel below (kept for comparison and as a fallback if the tile does not
+    // fit in local memory).
+    const bool want_wave = env_int_or("BATCHLAS_SB2ST_BACK_WAVE", 1) != 0;
+    if (want_wave) {
+        const size_t lmem = ctx->get_device().get_info<sycl::info::device::local_mem_size>();
+        const size_t per_col = static_cast<size_t>(n) * sizeof(T);
+        const int32_t num_waves = static_cast<int32_t>(waves.size()) - 1;
+
+        // With S sub-groups the tile is shared by 32*S threads, so a wider tile
+        // no longer costs occupancy the way it did at S=1; C is chosen to keep
+        // the footprint near a budget rather than as small as possible. Measured
+        // best at 8 columns for every n tried (see the subs table below).
+        int tile = env_int_or("BATCHLAS_SB2ST_BACK_TILE_W", 0);
+        if (tile <= 0) {
+            constexpr size_t kTargetLocalBytes = 32768;
+            tile = 1;
+            while (tile < 8 && per_col * static_cast<size_t>(tile * 2) <= kTargetLocalBytes) {
+                tile <<= 1;
+            }
+        }
+        while (tile > 1 && per_col * static_cast<size_t>(tile) > lmem) tile >>= 1;
+
+        // Sub-groups per work-group. More than a wave holds just leaves
+        // sub-groups idle at every barrier, and fewer serialises the wave, so
+        // this tracks the mean wave width (~n/2kd, but read off the schedule
+        // rather than assumed).
+        //
+        // Back-transform alone, RTX 4090, float, ms (rows subs, cols the four
+        // benchmark shapes; tile=8):
+        //           256/1024 512/512 1024/128 1024/256   mean wave
+        //   subs=8      17.1    51.0    123.8    245.0    8.5 / 8.5 / 16.5
+        //   subs=16     20.6    58.5    103.5    207.1
+        // -- 8 wins where waves hold ~8, 16 wins where they hold ~16.
+        int subs = env_int_or("BATCHLAS_SB2ST_BACK_SUBS", 0);
+        if (subs <= 0) {
+            const int32_t avg = (num_waves > 0) ? (nrefl + num_waves - 1) / num_waves : 1;
+            subs = (avg >= 12) ? 16 : (avg >= 6 ? 8 : 4);
+        }
+
+        if (num_waves > 0 && per_col * static_cast<size_t>(tile) <= lmem) {
+            // Caller-owned, like starts/lens: a buffer allocated here would be
+            // freed at return while the kernel is still running.
+            const int32_t* wp = waves.data();
+
+            // C x S combinations are instantiated explicitly; anything else
+            // falls through to the tiled kernel.
+            #define BL_WAVE_CASE(CC, SS)                                              \
+                if (tile == (CC) && subs == (SS))                                     \
+                    return unmqr_hb2st_wave<B, T, (CC), (SS)>(                        \
+                        ctx, v_in, tau_in, z_io, n, starts.data(), lens.data(), wp,   \
+                        num_waves);
+            BL_WAVE_CASE(1, 8) BL_WAVE_CASE(2, 8) BL_WAVE_CASE(4, 8) BL_WAVE_CASE(8, 8)
+            BL_WAVE_CASE(1, 4) BL_WAVE_CASE(2, 4) BL_WAVE_CASE(4, 4) BL_WAVE_CASE(8, 4)
+            BL_WAVE_CASE(1, 16) BL_WAVE_CASE(2, 16) BL_WAVE_CASE(4, 16) BL_WAVE_CASE(8, 16)
+            #undef BL_WAVE_CASE
+        }
+    }
 
     // Prefer the resident-tile kernel: pick the widest column tile whose local
     // footprint fits, so Z is loaded and stored once instead of once per
@@ -719,6 +916,7 @@ streaming:
         const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>&,                     \
         int32_t,                                                                         \
         int32_t,                                                                         \
+        Span<const int32_t>,                                                             \
         Span<const int32_t>,                                                             \
         Span<const int32_t>);
 

--- a/src/extensions/sytrd_sb2st_hh.cc
+++ b/src/extensions/sytrd_sb2st_hh.cc
@@ -1,0 +1,388 @@
+// Stage-2 band -> tridiagonal by Householder bulge chasing, retaining the
+// reflectors for the eigenvector back-transform. See sytrd_sb2st_hh.hh for the
+// rationale and for the schedule, which is validated in
+// playground/sb2st_hh_sequential.py.
+
+#include <blas/extensions.hh>
+#include <blas/matrix.hh>
+#include <util/mempool.hh>
+
+#include <sycl/sycl.hpp>
+
+#include <batchlas/backend_config.h>
+
+#include "../math-helpers.hh"
+#include "../queue.hh"
+#include "../util/template-instantiations.hh"
+
+#include "sytrd_sb2st_hh.hh"
+
+#include <algorithm>
+#include <cstdint>
+#include <stdexcept>
+#include <type_traits>
+
+namespace batchlas {
+namespace internal {
+
+namespace {
+
+template <typename U>
+inline U conj_if(const U& x) {
+    if constexpr (internal::is_complex<U>::value) {
+        return U(x.real(), -x.imag());
+    } else {
+        return x;
+    }
+}
+
+template <typename T>
+inline T real_part_as_T(const T& x) {
+    if constexpr (internal::is_complex<T>::value) {
+        return T(x.real(), typename base_type<T>::type(0));
+    } else {
+        return x;
+    }
+}
+
+template <typename T>
+inline typename base_type<T>::type abs2(const T& x) {
+    using R = typename base_type<T>::type;
+    if constexpr (internal::is_complex<T>::value) {
+        return static_cast<R>(x.real()) * static_cast<R>(x.real()) +
+               static_cast<R>(x.imag()) * static_cast<R>(x.imag());
+    } else {
+        return static_cast<R>(x) * static_cast<R>(x);
+    }
+}
+
+// Group-wide sum that also works for std::complex, which sycl::plus<> does not
+// accept directly.
+template <typename Group, typename T>
+inline T group_sum(Group g, T v) {
+    using R = typename base_type<T>::type;
+    if constexpr (internal::is_complex<T>::value) {
+        const R re = sycl::reduce_over_group(g, static_cast<R>(v.real()), sycl::plus<R>());
+        const R im = sycl::reduce_over_group(g, static_cast<R>(v.imag()), sycl::plus<R>());
+        return T(re, im);
+    } else {
+        return sycl::reduce_over_group(g, v, sycl::plus<T>());
+    }
+}
+
+template <Backend B, typename T>
+class Sb2stHhChaseKernel;
+
+constexpr int kWg = 32;
+
+} // namespace
+
+template <Backend B, typename T>
+size_t sytrd_sb2st_hh_buffer_size(Queue& ctx, int32_t n, int32_t kd, int32_t batch) {
+    if (n <= 0 || batch <= 0) return 0;
+    const int32_t kdw = sb2st_hh_work_bandwidth(n, kd);
+    size_t size = 0;
+    size += BumpAllocator::allocation_size<T>(
+        ctx, static_cast<size_t>(kdw + 1) * static_cast<size_t>(n) * static_cast<size_t>(batch));
+    return size;
+}
+
+// ab_in      : (kd+1) x n  lower band, read-only
+// ab_tri_out : 2 x n       row 0 = diagonal, row 1 = *signed* subdiagonal
+//              (kept signed so build_phase_from_kd1_band works unchanged)
+// d_out/e_out: real diagonal and |subdiagonal|
+// v_out      : kd x nrefl  reflector k in column k, v[0] = 1, zero-padded
+// tau_out    : nrefl
+template <Backend B, typename T>
+Event sytrd_sb2st_hh(Queue& ctx,
+                     const MatrixView<T, MatrixFormat::Dense>& ab_in,
+                     const MatrixView<T, MatrixFormat::Dense>& ab_tri_out,
+                     const VectorView<typename base_type<T>::type>& d_out,
+                     const VectorView<typename base_type<T>::type>& e_out,
+                     const MatrixView<T, MatrixFormat::Dense>& v_out,
+                     const VectorView<T>& tau_out,
+                     Uplo uplo,
+                     int32_t kd,
+                     const Span<std::byte>& ws) {
+    using Real = typename base_type<T>::type;
+
+    if (!ctx.in_order()) {
+        throw std::runtime_error("sytrd_sb2st_hh: requires an in-order Queue");
+    }
+    if (uplo != Uplo::Lower) {
+        throw std::runtime_error("sytrd_sb2st_hh: only Uplo::Lower is implemented");
+    }
+
+    const int32_t n = static_cast<int32_t>(ab_in.cols());
+    const int32_t batch = static_cast<int32_t>(ab_in.batch_size());
+    if (n <= 0 || batch <= 0) return ctx.get_event();
+
+    const int32_t kd_i = std::max<int32_t>(0, kd);
+    const int32_t kdw = sb2st_hh_work_bandwidth(n, kd_i);
+
+    BumpAllocator pool(ws);
+
+    // Expanded working band: transient bulge fill reaches kd rows below the band.
+    auto abw = pool.allocate<T>(
+        ctx, static_cast<size_t>(kdw + 1) * static_cast<size_t>(n) * static_cast<size_t>(batch));
+
+    const int32_t ldw = kdw + 1;
+
+    auto ABsrc = ab_in.kernel_view();
+    auto ABtri = ab_tri_out.kernel_view();
+    auto Vout = v_out.kernel_view();
+    const int32_t nrefl = static_cast<int32_t>(v_out.cols());
+    const int32_t ldv = static_cast<int32_t>(v_out.ld());
+    T* abw_ptr = abw.data();
+
+    ctx->submit([&](sycl::handler& h) {
+        sycl::local_accessor<T, 1> vloc(sycl::range<1>(static_cast<size_t>(std::max(1, kd_i))), h);
+        sycl::local_accessor<T, 1> wloc(sycl::range<1>(static_cast<size_t>(std::max(1, kd_i))), h);
+
+        auto Dv = d_out;
+        auto Ev = e_out;
+        auto TAUv = tau_out;
+
+        h.parallel_for<Sb2stHhChaseKernel<B, T>>(
+            sycl::nd_range<1>(sycl::range<1>(static_cast<size_t>(batch) * kWg),
+                              sycl::range<1>(kWg)),
+            [=](sycl::nd_item<1> it) [[sycl::reqd_sub_group_size(32)]] {
+                const auto wg = it.get_group();
+                const int32_t b = static_cast<int32_t>(wg.get_group_linear_id());
+                const int32_t lid = static_cast<int32_t>(it.get_local_linear_id());
+                if (b >= batch) return;
+
+                T* AB = abw_ptr + static_cast<size_t>(b) * static_cast<size_t>(ldw) *
+                                      static_cast<size_t>(n);
+                auto ABs = ABsrc.batch_item(b);
+                auto ABt = ABtri.batch_item(b);
+                auto Vb = Vout.batch_item(b);
+
+                // --- Load the input band into the expanded working band.
+                for (int32_t idx = lid; idx < ldw * n; idx += kWg) {
+                    const int32_t col = idx / ldw;
+                    const int32_t row = idx - col * ldw;
+                    AB[idx] = (row <= kd_i) ? ABs(row, col) : T(0);
+                }
+                sycl::group_barrier(wg);
+
+                // Hermitian input: force a real diagonal before we start.
+                if constexpr (internal::is_complex<T>::value) {
+                    for (int32_t j = lid; j < n; j += kWg) {
+                        AB[j * ldw] = real_part_as_T(AB[j * ldw]);
+                    }
+                    sycl::group_barrier(wg);
+                }
+
+                auto bget = [&](int32_t i, int32_t j) -> T {
+                    if (i >= j) {
+                        const int32_t r = i - j;
+                        return (r <= kdw) ? AB[r + j * ldw] : T(0);
+                    }
+                    const int32_t r = j - i;
+                    return (r <= kdw) ? conj_if(AB[r + i * ldw]) : T(0);
+                };
+                auto bset = [&](int32_t i, int32_t j, T val) {
+                    if (i >= j) {
+                        const int32_t r = i - j;
+                        if (r <= kdw) AB[r + j * ldw] = val;
+                    } else {
+                        const int32_t r = j - i;
+                        if (r <= kdw) AB[r + i * ldw] = conj_if(val);
+                    }
+                };
+
+                // W <- H W H^H on the principal block [a..b], H = I - tau v v^H,
+                // v held in vloc with length m. Only the lower triangle is
+                // written; the update keeps the diagonal real by construction.
+                auto two_sided = [&](int32_t a, int32_t bb, T tau) {
+                    const int32_t m = bb - a + 1;
+                    if (m <= 0) return;
+                    for (int32_t i = lid; i < m; i += kWg) {
+                        T acc = T(0);
+                        for (int32_t j = 0; j < m; ++j) {
+                            acc += bget(a + i, a + j) * vloc[j];
+                        }
+                        wloc[i] = acc;
+                    }
+                    sycl::group_barrier(wg);
+
+                    // kappa = v^H W v
+                    T part = T(0);
+                    for (int32_t i = lid; i < m; i += kWg) {
+                        part += conj_if(vloc[i]) * wloc[i];
+                    }
+                    const T kappa = group_sum(wg, part);
+
+                    // w = conj(tau) p - (|tau|^2 kappa / 2) v
+                    const T coef = tau * conj_if(tau) * kappa * T(Real(0.5));
+                    for (int32_t i = lid; i < m; i += kWg) {
+                        wloc[i] = conj_if(tau) * wloc[i] - coef * vloc[i];
+                    }
+                    sycl::group_barrier(wg);
+
+                    for (int32_t i = lid; i < m; i += kWg) {
+                        for (int32_t j = 0; j <= i; ++j) {
+                            T val = bget(a + i, a + j) - wloc[i] * conj_if(vloc[j]) -
+                                    vloc[i] * conj_if(wloc[j]);
+                            if (i == j) val = real_part_as_T(val);
+                            bset(a + i, a + j, val);
+                        }
+                    }
+                    sycl::group_barrier(wg);
+                };
+
+                // B <- B (I - tau v v^H), v of length (c1-c0+1) in vloc.
+                auto right_apply = [&](int32_t r0, int32_t r1, int32_t c0, int32_t c1, T tau) {
+                    if (r0 > r1 || c0 > c1) return;
+                    for (int32_t i = r0 + lid; i <= r1; i += kWg) {
+                        T y = T(0);
+                        for (int32_t j = c0; j <= c1; ++j) {
+                            y += bget(i, j) * vloc[j - c0];
+                        }
+                        y = tau * y;
+                        for (int32_t j = c0; j <= c1; ++j) {
+                            bset(i, j, bget(i, j) - y * conj_if(vloc[j - c0]));
+                        }
+                    }
+                    sycl::group_barrier(wg);
+                };
+
+                // C <- (I - tau v v^H) C, v of length (r1-r0+1) in vloc.
+                auto left_apply = [&](int32_t r0, int32_t r1, int32_t c0, int32_t c1, T tau) {
+                    if (r0 > r1 || c0 > c1) return;
+                    for (int32_t j = c0 + lid; j <= c1; j += kWg) {
+                        T z = T(0);
+                        for (int32_t i = r0; i <= r1; ++i) {
+                            z += conj_if(vloc[i - r0]) * bget(i, j);
+                        }
+                        z = tau * z;
+                        for (int32_t i = r0; i <= r1; ++i) {
+                            bset(i, j, bget(i, j) - vloc[i - r0] * z);
+                        }
+                    }
+                    sycl::group_barrier(wg);
+                };
+
+                // Build a reflector from column `col`, rows [r0..r1]; write it to
+                // vloc, store it at reflector slot `slot`, and overwrite the
+                // column with (beta, 0, ..., 0). Returns tau.
+                auto make_reflector = [&](int32_t col, int32_t r0, int32_t r1,
+                                          int32_t slot) -> T {
+                    const int32_t m = r1 - r0 + 1;
+                    Real partial = Real(0);
+                    for (int32_t k = lid + 1; k < m; k += kWg) {
+                        partial += abs2(bget(r0 + k, col));
+                    }
+                    const Real ss = sycl::reduce_over_group(wg, partial, sycl::plus<Real>());
+                    const Real xnorm = sycl::sqrt(ss);
+                    const T alpha = bget(r0, col);
+                    const auto res = internal::larfg<T>(alpha, xnorm, m);
+
+                    // v[0] = 1, v[k] = x[k] * scale. Read the column before it is
+                    // overwritten below.
+                    if (lid == 0) vloc[0] = T(1);
+                    for (int32_t k = lid + 1; k < m; k += kWg) {
+                        vloc[k] = (res.tau == T(0)) ? T(0) : bget(r0 + k, col) * res.scale;
+                    }
+                    sycl::group_barrier(wg);
+
+                    if (lid == 0) bset(r0, col, res.beta);
+                    for (int32_t k = lid + 1; k < m; k += kWg) {
+                        bset(r0 + k, col, T(0));
+                    }
+
+                    for (int32_t k = lid; k < kd_i; k += kWg) {
+                        Vb(k, slot) = (k < m) ? vloc[k] : T(0);
+                    }
+                    if (lid == 0) TAUv(slot, b) = res.tau;
+                    sycl::group_barrier(wg);
+                    return res.tau;
+                };
+
+                // --- Sequential chase schedule. The reflector counter must match
+                // build_sb2st_hh_schedule() exactly, since the back-transform
+                // indexes V by the host-side schedule.
+                int32_t slot = 0;
+                if (kd_i > 1) {
+                    for (int32_t st = 0; st + 2 < n; ++st) {
+                        int32_t r0 = st + 1;
+                        int32_t r1 = (st + kd_i < n - 1) ? (st + kd_i) : (n - 1);
+                        if (r1 <= r0) continue;
+
+                        T tau = make_reflector(st, r0, r1, slot++);
+                        two_sided(r0, r1, tau);
+
+                        while (true) {
+                            const int32_t p0 = r1 + 1;
+                            const int32_t p1 = (r1 + kd_i < n - 1) ? (r1 + kd_i) : (n - 1);
+                            if (p0 > p1) break;
+
+                            right_apply(p0, p1, r0, r1, tau);
+                            tau = make_reflector(r0, p0, p1, slot++);
+                            left_apply(p0, p1, r0 + 1, r1, tau);
+                            two_sided(p0, p1, tau);
+
+                            r0 = p0;
+                            r1 = p1;
+                        }
+                    }
+                }
+                (void)nrefl;
+                (void)ldv;
+
+                // --- Extract the tridiagonal.
+                for (int32_t j = lid; j < n; j += kWg) {
+                    const T diag = bget(j, j);
+                    ABt(0, j) = real_part_as_T(diag);
+                    if constexpr (internal::is_complex<T>::value) {
+                        Dv(j, b) = static_cast<Real>(diag.real());
+                    } else {
+                        Dv(j, b) = static_cast<Real>(diag);
+                    }
+                }
+                for (int32_t j = lid; j < n - 1; j += kWg) {
+                    const T sub = bget(j + 1, j);
+                    ABt(1, j) = sub;  // signed: the phase pass consumes this
+                    Ev(j, b) = internal::abs(sub);
+                }
+                if (lid == 0 && n > 0) ABt(1, n - 1) = T(0);
+            });
+    });
+
+    return ctx.get_event();
+}
+
+#define SB2ST_HH_INSTANTIATE(back, fp)                                                  \
+    template Event sytrd_sb2st_hh<back, BATCHLAS_UNPAREN fp>(                           \
+        Queue&,                                                                          \
+        const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>&,                     \
+        const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>&,                     \
+        const VectorView<typename base_type<BATCHLAS_UNPAREN fp>::type>&,                \
+        const VectorView<typename base_type<BATCHLAS_UNPAREN fp>::type>&,                \
+        const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>&,                     \
+        const VectorView<BATCHLAS_UNPAREN fp>&,                                          \
+        Uplo,                                                                            \
+        int32_t,                                                                         \
+        const Span<std::byte>&);                                                         \
+    template size_t sytrd_sb2st_hh_buffer_size<back, BATCHLAS_UNPAREN fp>(               \
+        Queue&, int32_t, int32_t, int32_t);
+
+#define SB2ST_HH_INSTANTIATE_FOR_BACKEND(back) \
+    BATCHLAS_FOR_EACH_SCALAR_TYPE_1(SB2ST_HH_INSTANTIATE, back)
+
+#if BATCHLAS_HAS_CUDA_BACKEND
+SB2ST_HH_INSTANTIATE_FOR_BACKEND(Backend::CUDA)
+#endif
+#if BATCHLAS_HAS_ROCM_BACKEND
+SB2ST_HH_INSTANTIATE_FOR_BACKEND(Backend::ROCM)
+#endif
+#if BATCHLAS_HAS_HOST_BACKEND
+SB2ST_HH_INSTANTIATE_FOR_BACKEND(Backend::NETLIB)
+#endif
+
+#undef SB2ST_HH_INSTANTIATE_FOR_BACKEND
+#undef SB2ST_HH_INSTANTIATE
+
+} // namespace internal
+} // namespace batchlas

--- a/src/extensions/sytrd_sb2st_hh.cc
+++ b/src/extensions/sytrd_sb2st_hh.cc
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <stdexcept>
 #include <type_traits>
 
@@ -375,7 +376,139 @@ namespace {
 template <Backend B, typename T>
 class Sb2stHhBackKernel;
 
-constexpr int kBackCols = 8;  // columns of Z per work-group
+template <Backend B, typename T, int C>
+class Sb2stHhBackTiledKernel;
+
+constexpr int kBackCols = 8;  // columns of Z per work-group (global-memory path)
+
+// Sub-group XOR shuffle that also works for std::complex.
+template <typename T>
+inline T shuffle_xor(sycl::sub_group sg, T v, uint32_t mask) {
+    using R = typename base_type<T>::type;
+    if constexpr (internal::is_complex<T>::value) {
+        const R re = sycl::permute_group_by_xor(sg, static_cast<R>(v.real()), mask);
+        const R im = sycl::permute_group_by_xor(sg, static_cast<R>(v.imag()), mask);
+        return T(re, im);
+    } else {
+        return sycl::permute_group_by_xor(sg, v, mask);
+    }
+}
+}
+
+// Resident-tile back-transform.
+//
+// The bottleneck is not flops, it is traffic on Z: every reflector reloads its
+// kd rows, and each row of Z is touched ~n/2 times over the whole sweep set, so
+// the naive form moves ~n^3 elements for 2n^3 flops -- about 2 flops/element.
+//
+// A larft/larfb formulation cannot fix that here. Two reflectors commute iff
+// their row ranges are disjoint, i.e. iff |u - u'| >= kd where u = start-1. The
+// BLAS-3-groupable sets (consecutive u, one per sweep at a fixed chase step)
+// interleave: for n=32,kd=4 generation order gives u = 0,4,8,1,..., so u=0
+// precedes u=4 which precedes u=1, and the groups {0..3} and {4..7} cannot be
+// linearised as contiguous units. More generally, in any valid schedule the
+// consecutive reflectors are mutually disjoint -- that is what makes them
+// schedulable -- so the row-sharing ones are always far apart in the product.
+// This is why Wang et al. (PPoPP'25) found a hand-written BLAS-2 back-transform
+// beat MAGMA's larft-based one by 1.5x on A100.
+//
+// So instead of reordering, keep Z resident: one work-group owns a C-column
+// tile of Z for one batch item, loads it into local memory once, applies every
+// reflector in the exact same order, and writes it back once. Traffic drops
+// from ~n^3 to 2*n*ncols per matrix, which is where the BLAS-3-like arithmetic
+// intensity actually comes from.
+//
+// Lane mapping: lane -> (column, row-group), col = lane % C, grp = lane / C,
+// with G = 32/C lanes cooperating per column. Lanes with the same column differ
+// by multiples of C, so the dot product reduces with XOR masks C, 2C, ... < 32.
+// Zs is row-major with C columns, so consecutive lanes touch consecutive
+// addresses.
+template <Backend B, typename T, int C>
+Event unmqr_hb2st_tiled(Queue& ctx,
+                        const MatrixView<T, MatrixFormat::Dense>& v_in,
+                        const VectorView<T>& tau_in,
+                        const MatrixView<T, MatrixFormat::Dense>& z_io,
+                        int32_t n,
+                        int32_t nrefl,
+                        const int32_t* starts_p,
+                        const int32_t* lens_p) {
+    constexpr int32_t kSg = 32;
+    constexpr int32_t G = kSg / C;
+    static_assert(C >= 1 && C <= 32 && (kSg % C) == 0);
+
+    const int32_t batch = static_cast<int32_t>(z_io.batch_size());
+    const int32_t ncols = static_cast<int32_t>(z_io.cols());
+    const int32_t col_chunks = (ncols + C - 1) / C;
+    const int32_t num_wg = batch * col_chunks;
+
+    auto Vv = v_in.kernel_view();
+    auto Zv = z_io.kernel_view();
+
+    ctx->submit([&](sycl::handler& h) {
+        sycl::local_accessor<T, 1> Zs(
+            sycl::range<1>(static_cast<size_t>(n) * static_cast<size_t>(C)), h);
+        auto TAUv = tau_in;
+
+        h.parallel_for<Sb2stHhBackTiledKernel<B, T, C>>(
+            sycl::nd_range<1>(sycl::range<1>(static_cast<size_t>(num_wg) * kSg),
+                              sycl::range<1>(kSg)),
+            [=](sycl::nd_item<1> it) [[sycl::reqd_sub_group_size(32)]] {
+                const auto sg = it.get_sub_group();
+                const int32_t wg_id = static_cast<int32_t>(it.get_group().get_group_linear_id());
+                const int32_t lid = static_cast<int32_t>(it.get_local_linear_id());
+
+                const int32_t b = wg_id / col_chunks;
+                const int32_t chunk = wg_id - b * col_chunks;
+                if (b >= batch) return;
+
+                const int32_t c0 = chunk * C;
+                auto Z = Zv.batch_item(b);
+                auto V = Vv.batch_item(b);
+
+                T* Zl = Zs.template get_multi_ptr<sycl::access::decorated::no>().get();
+
+                // Load the column tile once.
+                for (int32_t idx = lid; idx < n * C; idx += kSg) {
+                    const int32_t r = idx / C;
+                    const int32_t c = idx - r * C;
+                    Zl[idx] = (c0 + c < ncols) ? Z(r, c0 + c) : T(0);
+                }
+                sycl::group_barrier(sg);
+
+                const int32_t col = lid % C;
+                const int32_t grp = lid / C;
+
+                // Q = H_1 ... H_m, so Z := Q Z applies them in reverse order.
+                for (int32_t k = nrefl - 1; k >= 0; --k) {
+                    const T tau = TAUv(k, b);
+                    if (tau == T(0)) continue;
+                    const int32_t s = starts_p[k];
+                    const int32_t L = lens_p[k];
+
+                    T acc = T(0);
+                    for (int32_t r = grp; r < L; r += G) {
+                        acc += conj_if(V(r, k)) * Zl[(s + r) * C + col];
+                    }
+                    if constexpr (G > 1) {
+                        for (uint32_t m = C; m < static_cast<uint32_t>(kSg); m <<= 1) {
+                            acc += shuffle_xor(sg, acc, m);
+                        }
+                    }
+                    for (int32_t r = grp; r < L; r += G) {
+                        Zl[(s + r) * C + col] -= tau * V(r, k) * acc;
+                    }
+                    sycl::group_barrier(sg);
+                }
+
+                for (int32_t idx = lid; idx < n * C; idx += kSg) {
+                    const int32_t r = idx / C;
+                    const int32_t c = idx - r * C;
+                    if (c0 + c < ncols) Z(r, c0 + c) = Zl[idx];
+                }
+            });
+    });
+
+    return ctx.get_event();
 }
 
 template <Backend B, typename T>
@@ -395,6 +528,58 @@ Event unmqr_hb2st(Queue& ctx,
     const int32_t ncols = static_cast<int32_t>(z_io.cols());
     if (nrefl <= 0 || batch <= 0 || ncols <= 0 || n <= 0) return ctx.get_event();
 
+    // Prefer the resident-tile kernel: pick the widest column tile whose local
+    // footprint fits, so Z is loaded and stored once instead of once per
+    // reflector. Falls back to the streaming kernel below only if even a single
+    // column does not fit (very large n).
+    {
+        // Two competing costs set the tile width C.
+        //
+        // Holding a column of Z resident already gives the full ~n/2 reuse, so
+        // reuse does NOT grow with C. What does grow is amortisation of the V
+        // reads: V is re-read once per column tile, and at C=1 that alone is
+        // ~292 GB at n=1024/batch=128, which dominates. Pushing C up shrinks
+        // that but grows the local footprint (n*C*sizeof(T)) and so cuts
+        // occupancy -- these are 32-thread work-groups, so a 32 KB tile is
+        // ~1 block/SM.
+        //
+        // Measured on RTX 4090 (back-transform alone, ms):
+        //         C=0(stream)  C=1   C=2   C=4   C=8   C=16
+        //   n=256/b=1024  39.9  109.2  44.8  25.9  27.1   42.8
+        //   n=512/b=512  107.6  184.6 107.0 109.7 174.2  238.3
+        //   n=1024/b=128 420.7  379.5 332.2 396.2 553.6 1391.4
+        //   n=1024/b=256 913.5  752.0 660.5 786.1 1105.7 2782.9
+        //
+        // The optimum tracks a ~8 KB footprint, capped at 4 columns.
+        constexpr size_t kTargetLocalBytes = 8192;
+        constexpr int kMaxTile = 4;
+        const size_t lmem = ctx->get_device().get_info<sycl::info::device::local_mem_size>();
+        const size_t per_col = static_cast<size_t>(n) * sizeof(T);
+        int want = 1;
+        while (want < kMaxTile && per_col * static_cast<size_t>(want * 2) <= kTargetLocalBytes) {
+            want <<= 1;
+        }
+        if (const char* ev = std::getenv("BATCHLAS_SB2ST_BACK_TILE")) {
+            const int f = std::atoi(ev);
+            if (f == 0) goto streaming;   // 0 selects the streaming kernel
+            if (f > 0) want = f;
+        }
+        int tile = 0;
+        for (int c = want; c >= 1; c >>= 1) {
+            if (per_col * static_cast<size_t>(c) <= lmem) { tile = c; break; }
+        }
+        switch (tile) {
+            case 32: return unmqr_hb2st_tiled<B, T, 32>(ctx, v_in, tau_in, z_io, n, nrefl, starts.data(), lens.data());
+            case 16: return unmqr_hb2st_tiled<B, T, 16>(ctx, v_in, tau_in, z_io, n, nrefl, starts.data(), lens.data());
+            case 8:  return unmqr_hb2st_tiled<B, T, 8>(ctx, v_in, tau_in, z_io, n, nrefl, starts.data(), lens.data());
+            case 4:  return unmqr_hb2st_tiled<B, T, 4>(ctx, v_in, tau_in, z_io, n, nrefl, starts.data(), lens.data());
+            case 2:  return unmqr_hb2st_tiled<B, T, 2>(ctx, v_in, tau_in, z_io, n, nrefl, starts.data(), lens.data());
+            case 1:  return unmqr_hb2st_tiled<B, T, 1>(ctx, v_in, tau_in, z_io, n, nrefl, starts.data(), lens.data());
+            default: break;
+        }
+    }
+
+streaming:
     const int32_t col_chunks = (ncols + kBackCols - 1) / kBackCols;
     const int32_t num_wg = batch * col_chunks;
 

--- a/src/extensions/sytrd_sb2st_hh.cc
+++ b/src/extensions/sytrd_sb2st_hh.cc
@@ -94,9 +94,15 @@ inline T shuffle_xor(sycl::sub_group sg, T v, uint32_t mask) {
 // slots -- about 2% occupancy, which is what made the chase cost as much as the
 // back-transform. kWg=256 with a 2D (row, column-chunk) mapping puts 8 lanes on
 // each row of the window instead of 1.
+//
+// kRowsPar is a pure split of the 256 lanes between window rows and the reduced
+// dimension, NOT a bound on kd: windows taller than kRowsPar are walked in
+// row-blocks. kTpr must stay <= 32 so the lanes sharing a row are inside one
+// sub-group.
 constexpr int kWg = 256;
-constexpr int kRowsPar = 32;          // max window extent == max kd
+constexpr int kRowsPar = 32;          // window rows resident at once
 constexpr int kTpr = kWg / kRowsPar;  // lanes cooperating on one row/column
+static_assert(kTpr <= 32 && kRowsPar * kTpr == kWg);
 
 } // namespace
 
@@ -241,16 +247,22 @@ Event sytrd_sb2st_hh(Queue& ctx,
                     const int32_t m = bb - a + 1;
                     if (m <= 0) return;
 
-                    // p = W v, one row per ti, reduced over ts.
+                    // p = W v, one row per ti, reduced over ts. The row-block
+                    // count is derived from m (uniform) so every lane makes the
+                    // same number of reduce_tpr calls.
                     {
-                        T acc = T(0);
-                        if (ti < m) {
-                            for (int32_t j = ts; j < m; j += kTpr) {
-                                acc += bget(a + ti, a + j) * vloc[j];
+                        const int32_t nrb = (m + kRowsPar - 1) / kRowsPar;
+                        for (int32_t rb = 0; rb < nrb; ++rb) {
+                            const int32_t r = rb * kRowsPar + ti;
+                            T acc = T(0);
+                            if (r < m) {
+                                for (int32_t j = ts; j < m; j += kTpr) {
+                                    acc += bget(a + r, a + j) * vloc[j];
+                                }
                             }
+                            acc = reduce_tpr(acc);
+                            if (r < m && ts == 0) wloc[r] = acc;
                         }
-                        acc = reduce_tpr(acc);
-                        if (ti < m && ts == 0) wloc[ti] = acc;
                     }
                     sycl::group_barrier(wg);
 
@@ -270,12 +282,12 @@ Event sytrd_sb2st_hh(Queue& ctx,
 
                     // Rank-2 update of the lower triangle; no reduction, so ts
                     // simply strides the inner index.
-                    if (ti < m) {
-                        for (int32_t j = ts; j <= ti; j += kTpr) {
-                            T val = bget(a + ti, a + j) - wloc[ti] * conj_if(vloc[j]) -
-                                    vloc[ti] * conj_if(wloc[j]);
-                            if (ti == j) val = real_part_as_T(val);
-                            bset(a + ti, a + j, val);
+                    for (int32_t r = ti; r < m; r += kRowsPar) {
+                        for (int32_t j = ts; j <= r; j += kTpr) {
+                            T val = bget(a + r, a + j) - wloc[r] * conj_if(vloc[j]) -
+                                    vloc[r] * conj_if(wloc[j]);
+                            if (r == j) val = real_part_as_T(val);
+                            bset(a + r, a + j, val);
                         }
                     }
                     sycl::group_barrier(wg);
@@ -285,17 +297,21 @@ Event sytrd_sb2st_hh(Queue& ctx,
                 auto right_apply = [&](int32_t r0, int32_t r1, int32_t c0, int32_t c1, T tau) {
                     if (r0 > r1 || c0 > c1) return;
                     const int32_t nr = r1 - r0 + 1;
-                    const int32_t i = r0 + ti;
-                    T y = T(0);
-                    if (ti < nr) {
-                        for (int32_t j = c0 + ts; j <= c1; j += kTpr) {
-                            y += bget(i, j) * vloc[j - c0];
+                    const int32_t nrb = (nr + kRowsPar - 1) / kRowsPar;
+                    for (int32_t rb = 0; rb < nrb; ++rb) {
+                        const int32_t rr = rb * kRowsPar + ti;
+                        const int32_t i = r0 + rr;
+                        T y = T(0);
+                        if (rr < nr) {
+                            for (int32_t j = c0 + ts; j <= c1; j += kTpr) {
+                                y += bget(i, j) * vloc[j - c0];
+                            }
                         }
-                    }
-                    y = tau * reduce_tpr(y);
-                    if (ti < nr) {
-                        for (int32_t j = c0 + ts; j <= c1; j += kTpr) {
-                            bset(i, j, bget(i, j) - y * conj_if(vloc[j - c0]));
+                        y = tau * reduce_tpr(y);
+                        if (rr < nr) {
+                            for (int32_t j = c0 + ts; j <= c1; j += kTpr) {
+                                bset(i, j, bget(i, j) - y * conj_if(vloc[j - c0]));
+                            }
                         }
                     }
                     sycl::group_barrier(wg);
@@ -305,17 +321,21 @@ Event sytrd_sb2st_hh(Queue& ctx,
                 auto left_apply = [&](int32_t r0, int32_t r1, int32_t c0, int32_t c1, T tau) {
                     if (r0 > r1 || c0 > c1) return;
                     const int32_t nc = c1 - c0 + 1;
-                    const int32_t j = c0 + ti;
-                    T z = T(0);
-                    if (ti < nc) {
-                        for (int32_t i = r0 + ts; i <= r1; i += kTpr) {
-                            z += conj_if(vloc[i - r0]) * bget(i, j);
+                    const int32_t ncb = (nc + kRowsPar - 1) / kRowsPar;
+                    for (int32_t cb = 0; cb < ncb; ++cb) {
+                        const int32_t cc = cb * kRowsPar + ti;
+                        const int32_t j = c0 + cc;
+                        T z = T(0);
+                        if (cc < nc) {
+                            for (int32_t i = r0 + ts; i <= r1; i += kTpr) {
+                                z += conj_if(vloc[i - r0]) * bget(i, j);
+                            }
                         }
-                    }
-                    z = tau * reduce_tpr(z);
-                    if (ti < nc) {
-                        for (int32_t i = r0 + ts; i <= r1; i += kTpr) {
-                            bset(i, j, bget(i, j) - vloc[i - r0] * z);
+                        z = tau * reduce_tpr(z);
+                        if (cc < nc) {
+                            for (int32_t i = r0 + ts; i <= r1; i += kTpr) {
+                                bset(i, j, bget(i, j) - vloc[i - r0] * z);
+                            }
                         }
                     }
                     sycl::group_barrier(wg);
@@ -420,8 +440,9 @@ Event sytrd_sb2st_hh(Queue& ctx,
 // completely independent. Each work-group takes one (batch item, column chunk)
 // and walks the entire reflector list itself -- no inter-work-group
 // synchronisation and no launch per sweep. Within a work-group the 32 lanes map
-// to *rows* of the reflector (len <= kd <= 32), which keeps the Z accesses
-// contiguous since Z is column-major; the dot product is a sub-group reduction.
+// to *rows* of the reflector (row-blocked when kd > 32), which keeps the Z
+// accesses contiguous since Z is column-major; the dot product is a sub-group
+// reduction.
 //
 // This is flop-optimal (2n^3 total, versus ~4n^3 for a larft/larfb formulation
 // whose V panels are zero-padded) but memory bound. Wang et al. (PPoPP'25)
@@ -658,13 +679,16 @@ streaming:
                     const int32_t s = starts_p[k];
                     const int32_t L = lens_p[k];
 
-                    const T vj = (lane < L) ? V(lane, k) : T(0);
-
+                    // L may exceed the 32 lanes (kd > 32), so walk the reflector
+                    // in row-blocks and accumulate across them before the update.
                     for (int32_t c = c0; c < c1; ++c) {
-                        const T zj = (lane < L) ? Z(s + lane, c) : T(0);
-                        const T sum = group_sum(sg, conj_if(vj) * zj);
-                        if (lane < L) {
-                            Z(s + lane, c) = zj - tau * vj * sum;
+                        T part = T(0);
+                        for (int32_t r = lane; r < L; r += 32) {
+                            part += conj_if(V(r, k)) * Z(s + r, c);
+                        }
+                        const T sum = group_sum(sg, part);
+                        for (int32_t r = lane; r < L; r += 32) {
+                            Z(s + r, c) -= tau * V(r, k) * sum;
                         }
                     }
                 }

--- a/src/extensions/sytrd_sb2st_hh.hh
+++ b/src/extensions/sytrd_sb2st_hh.hh
@@ -1,0 +1,113 @@
+#pragma once
+
+// Stage-2 band -> tridiagonal reduction by Householder bulge chasing, with the
+// reflectors *retained* so that the eigenvector back-transform Z := Q2 Z is
+// possible.
+//
+// The shipped sytrd_sb2st is a Givens (LAPACK DSBTRD/ZHBTRD) chase and writes
+// tau_out = 0 -- Q2 is discarded. That is why syev_two_stage clamps kd to 1
+// whenever eigenvectors are requested, which in turn degenerates stage 1 into an
+// unblocked BLAS-2 reduction. This routine exists to remove that clamp.
+//
+// Schedule: the plain sequential one (for each sweep, eliminate then chase the
+// bulge to the bottom), not LAPACK's pipelined THGRSIZ/GRSIZ/SHIFT=3 order. The
+// pipelining exists to give multi-core CPU parallelism; here a work-group owns
+// one problem and parallelism comes from the batch dimension and from lanes
+// inside each <= kd x kd window. Validated in
+// playground/sb2st_hh_sequential.py against tridiagonality, d, signed e,
+// orthogonality of Q and the reference spectrum.
+//
+// Reflector k acts on rows [start_k, start_k + len_k) and the overall
+// similarity is
+//
+//     Q = H_1 H_2 ... H_m   (generation order),   Q^H A Q = T
+//
+// so the back-transform applies them in *reverse* generation order.
+
+#include <blas/enums.hh>
+#include <blas/matrix.hh>
+#include <util/sycl-device-queue.hh>
+#include <util/sycl-span.hh>
+
+#include <cstdint>
+#include <vector>
+
+namespace batchlas {
+namespace internal {
+
+// One stored reflector. `sweep` is retained because all reflectors belonging to
+// a single sweep act on mutually disjoint row ranges (starts stride by kd, each
+// length <= kd), so a whole sweep can be applied concurrently in the
+// back-transform.
+struct Sb2stHhRefl {
+    int32_t start;
+    int32_t len;
+    int32_t sweep;
+};
+
+// Replays the sequential chase schedule on the host. The schedule depends only
+// on (n, kd) -- never on the matrix values -- so it is identical for every item
+// in the batch, which is what lets the back-transform use uniform batched work.
+inline std::vector<Sb2stHhRefl> build_sb2st_hh_schedule(int32_t n, int32_t kd) {
+    std::vector<Sb2stHhRefl> out;
+    if (n <= 2 || kd <= 1) return out;
+
+    for (int32_t st = 0; st + 2 < n; ++st) {
+        int32_t r0 = st + 1;
+        int32_t r1 = (st + kd < n - 1) ? (st + kd) : (n - 1);
+        if (r1 <= r0) continue;
+
+        // TYPE 1: annihilate column st below the subdiagonal.
+        out.push_back(Sb2stHhRefl{r0, r1 - r0 + 1, st});
+
+        // Chase the resulting bulge to the bottom of the band.
+        while (true) {
+            const int32_t p0 = r1 + 1;
+            const int32_t p1 = (r1 + kd < n - 1) ? (r1 + kd) : (n - 1);
+            if (p0 > p1) break;
+            out.push_back(Sb2stHhRefl{p0, p1 - p0 + 1, st});
+            r0 = p0;
+            r1 = p1;
+        }
+    }
+    return out;
+}
+
+inline int32_t sb2st_hh_num_reflectors(int32_t n, int32_t kd) {
+    return static_cast<int32_t>(build_sb2st_hh_schedule(n, kd).size());
+}
+
+// Working half-bandwidth needed to hold transient bulge fill. A length-kd
+// reflector applied symmetrically pushes fill up to kd rows below the band.
+inline int32_t sb2st_hh_work_bandwidth(int32_t n, int32_t kd) {
+    const int32_t want = 2 * kd;
+    const int32_t cap = (n > 0) ? (n - 1) : 0;
+    return (want < cap) ? want : cap;
+}
+
+// Band -> tridiagonal, retaining the reflectors.
+//
+//   ab_in      (kd+1) x n   lower band, read-only
+//   ab_tri_out 2 x n        row 0 = diagonal, row 1 = *signed* subdiagonal,
+//                           so build_phase_from_kd1_band consumes it unchanged
+//   d_out/e_out             real diagonal and |subdiagonal|
+//   v_out      kd x nrefl   reflector k in column k, v[0] = 1, zero-padded;
+//                           nrefl == build_sb2st_hh_schedule(n, kd).size()
+//   tau_out    nrefl
+template <Backend B, typename T>
+Event sytrd_sb2st_hh(Queue& ctx,
+                     const MatrixView<T, MatrixFormat::Dense>& ab_in,
+                     const MatrixView<T, MatrixFormat::Dense>& ab_tri_out,
+                     const VectorView<typename base_type<T>::type>& d_out,
+                     const VectorView<typename base_type<T>::type>& e_out,
+                     const MatrixView<T, MatrixFormat::Dense>& v_out,
+                     const VectorView<T>& tau_out,
+                     Uplo uplo,
+                     int32_t kd,
+                     const Span<std::byte>& ws);
+
+template <Backend B, typename T>
+size_t sytrd_sb2st_hh_buffer_size(Queue& ctx, int32_t n, int32_t kd, int32_t batch);
+
+} // namespace internal
+} // namespace batchlas

--- a/src/extensions/sytrd_sb2st_hh.hh
+++ b/src/extensions/sytrd_sb2st_hh.hh
@@ -109,5 +109,18 @@ Event sytrd_sb2st_hh(Queue& ctx,
 template <Backend B, typename T>
 size_t sytrd_sb2st_hh_buffer_size(Queue& ctx, int32_t n, int32_t kd, int32_t batch);
 
+// Z := Q2 Z, with Q2 = H_1 H_2 ... H_m from sytrd_sb2st_hh. Applies the
+// reflectors in reverse generation order. `starts`/`lens` come from
+// build_sb2st_hh_schedule (host side, batch-independent).
+template <Backend B, typename T>
+Event unmqr_hb2st(Queue& ctx,
+                  const MatrixView<T, MatrixFormat::Dense>& v_in,
+                  const VectorView<T>& tau_in,
+                  const MatrixView<T, MatrixFormat::Dense>& z_io,
+                  int32_t n,
+                  int32_t kd,
+                  Span<const int32_t> starts,
+                  Span<const int32_t> lens);
+
 } // namespace internal
 } // namespace batchlas

--- a/src/extensions/sytrd_sb2st_hh.hh
+++ b/src/extensions/sytrd_sb2st_hh.hh
@@ -109,9 +109,43 @@ Event sytrd_sb2st_hh(Queue& ctx,
 template <Backend B, typename T>
 size_t sytrd_sb2st_hh_buffer_size(Queue& ctx, int32_t n, int32_t kd, int32_t batch);
 
+// Splits the reflector list into maximal runs of consecutive reflectors with
+// pairwise-disjoint row ranges. Disjoint reflectors commute, so a whole run can
+// be applied concurrently in the back-transform; run w is [off[w], off[w+1]).
+//
+// The runs come out equal to the chase sweeps, but this derives them from the
+// schedule rather than assuming it, so an unsound grouping cannot slip through.
+inline std::vector<int32_t> build_sb2st_hh_wave_offsets(
+    const std::vector<Sb2stHhRefl>& sched, int32_t n) {
+    std::vector<int32_t> off;
+    const int32_t nrefl = static_cast<int32_t>(sched.size());
+    if (nrefl <= 0 || n <= 0) return off;
+
+    // stamp[r] == run means row r is already claimed by the run being built.
+    std::vector<int32_t> stamp(static_cast<size_t>(n), -1);
+    int32_t run = 0;
+    off.push_back(0);
+    for (int32_t k = 0; k < nrefl; ++k) {
+        const int32_t s = sched[k].start;
+        const int32_t e = s + sched[k].len;
+        bool overlaps = false;
+        for (int32_t r = s; r < e && r < n; ++r) {
+            if (stamp[r] == run) { overlaps = true; break; }
+        }
+        if (overlaps) { off.push_back(k); ++run; }
+        for (int32_t r = s; r < e && r < n; ++r) stamp[r] = run;
+    }
+    off.push_back(nrefl);
+    return off;
+}
+
 // Z := Q2 Z, with Q2 = H_1 H_2 ... H_m from sytrd_sb2st_hh. Applies the
 // reflectors in reverse generation order. `starts`/`lens` come from
-// build_sb2st_hh_schedule (host side, batch-independent).
+// build_sb2st_hh_schedule and `waves` from build_sb2st_hh_wave_offsets (all
+// host side, batch-independent).
+//
+// All four spans must stay alive until the returned Event completes -- they are
+// read by the kernel, not copied.
 template <Backend B, typename T>
 Event unmqr_hb2st(Queue& ctx,
                   const MatrixView<T, MatrixFormat::Dense>& v_in,
@@ -120,7 +154,8 @@ Event unmqr_hb2st(Queue& ctx,
                   int32_t n,
                   int32_t kd,
                   Span<const int32_t> starts,
-                  Span<const int32_t> lens);
+                  Span<const int32_t> lens,
+                  Span<const int32_t> waves);
 
 } // namespace internal
 } // namespace batchlas

--- a/src/extensions/sytrd_sy2sb.cc
+++ b/src/extensions/sytrd_sy2sb.cc
@@ -311,7 +311,10 @@ size_t sytrd_sy2sb_buffer_size(Queue& ctx,
         const int pn0 = n - kd_i;
         const int pk0 = std::min(pn0, kd_i);
         auto V0 = a_in({kd_i, SliceEnd()}, {0, pk0});
-        auto A22_0 = a_in({kd_i, SliceEnd()}, {kd_i, SliceEnd()});
+        // Widest blocks the loop can pass to ormqr (see the main loop): both
+        // shrink with i, so the i = 0 panel bounds every later one.
+        auto A_left0 = a_in({kd_i, SliceEnd()}, {pk0, SliceEnd()});
+        auto A_right0 = a_in({pk0, SliceEnd()}, {kd_i, SliceEnd()});
 
         const size_t tau_elems = static_cast<size_t>(pk0) * static_cast<size_t>(batch);
         T* tau_tmp = sycl::malloc_shared<T>(tau_elems, ctx->get_device(), ctx->get_context());
@@ -322,8 +325,8 @@ size_t sytrd_sy2sb_buffer_size(Queue& ctx,
 
         const size_t geqrf_ws = geqrf_buffer_size<B, T>(ctx, V0, tau_span);
         const Transpose trans_left = internal::is_complex<T>::value ? Transpose::ConjTrans : Transpose::Trans;
-        const size_t ormqr_l_ws = ormqr_buffer_size<B, T>(ctx, V0, A22_0, Side::Left, trans_left, tau_span);
-        const size_t ormqr_r_ws = ormqr_buffer_size<B, T>(ctx, V0, A22_0, Side::Right, Transpose::NoTrans, tau_span);
+        const size_t ormqr_l_ws = ormqr_buffer_size<B, T>(ctx, V0, A_left0, Side::Left, trans_left, tau_span);
+        const size_t ormqr_r_ws = ormqr_buffer_size<B, T>(ctx, V0, A_right0, Side::Right, Transpose::NoTrans, tau_span);
         const size_t panel_ws = std::max(geqrf_ws, std::max(ormqr_l_ws, ormqr_r_ws));
 
         sycl::free(tau_tmp, ctx->get_context());
@@ -375,12 +378,14 @@ Event sytrd_sy2sb(Queue& ctx,
     const int pn0 = n - kd_i;
     const int pk0 = std::min(pn0, kd_i);
     auto V0 = a_in({kd_i, SliceEnd()}, {0, pk0});
-    auto A22_0 = a_in({kd_i, SliceEnd()}, {kd_i, SliceEnd()});
+    // Must match the shapes queried in sytrd_sy2sb_buffer_size exactly.
+    auto A_left0 = a_in({kd_i, SliceEnd()}, {pk0, SliceEnd()});
+    auto A_right0 = a_in({pk0, SliceEnd()}, {kd_i, SliceEnd()});
     const size_t geqrf_ws_bytes = geqrf_buffer_size<B, T>(ctx, V0, Span<T>(tau_panel_buf.data(), static_cast<size_t>(pk0) * static_cast<size_t>(batch)));
     const Transpose trans_left = internal::is_complex<T>::value ? Transpose::ConjTrans : Transpose::Trans;
-    const size_t ormqr_l_ws_bytes = ormqr_buffer_size<B, T>(ctx, V0, A22_0, Side::Left, trans_left,
+    const size_t ormqr_l_ws_bytes = ormqr_buffer_size<B, T>(ctx, V0, A_left0, Side::Left, trans_left,
                                                            Span<T>(tau_panel_buf.data(), static_cast<size_t>(pk0) * static_cast<size_t>(batch)));
-    const size_t ormqr_r_ws_bytes = ormqr_buffer_size<B, T>(ctx, V0, A22_0, Side::Right, Transpose::NoTrans,
+    const size_t ormqr_r_ws_bytes = ormqr_buffer_size<B, T>(ctx, V0, A_right0, Side::Right, Transpose::NoTrans,
                                                            Span<T>(tau_panel_buf.data(), static_cast<size_t>(pk0) * static_cast<size_t>(batch)));
     const size_t panel_ws_bytes = std::max(geqrf_ws_bytes, std::max(ormqr_l_ws_bytes, ormqr_r_ws_bytes));
     auto panel_ws = pool.allocate<std::byte>(ctx, panel_ws_bytes);
@@ -393,7 +398,25 @@ Event sytrd_sy2sb(Queue& ctx,
         const int pk = std::min(pn, kd_i);
 
         auto V = a_in({i + kd_i, SliceEnd()}, {i, i + pk});           // (pn x pk)
-        auto A22 = a_in({i + kd_i, SliceEnd()}, {i + kd_i, SliceEnd()}); // (pn x pn)
+
+        // The similarity is A := H^H A H with H = diag(I_{i+kd}, Q), so Q^H
+        // must hit *every* column left of the trailing block as well, not just
+        // A22. Columns < i are already zero below row i+kd (they were banded by
+        // earlier panels) and columns [i, i+pk) become R inside geqrf, so when
+        // pk == kd the trailing block is genuinely all that is left.
+        //
+        // On the final panel pk = min(pn, kd) can be < kd, and then columns
+        // [i+pk, i+kd) are neither zero nor part of the panel -- they used to be
+        // skipped entirely, silently corrupting the band. Widening the left
+        // apply to start at column i+pk (and the right apply, its transpose, to
+        // start at row i+pk) covers them; both reduce to the old A22-only calls
+        // when pk == kd. Those leftover columns are exactly the tail columns
+        // [n-kd, n), which the copy after the loop picks up afterwards.
+        //
+        // This is why the failure needed n % kd >= 2: at n % kd == 1 the
+        // leftover Q is 1x1 with tau = 0, i.e. the identity.
+        auto A_left = a_in({i + kd_i, SliceEnd()}, {i + pk, SliceEnd()});
+        auto A_right = a_in({i + pk, SliceEnd()}, {i + kd_i, SliceEnd()});
 
         // tau panel span is packed with per-batch stride = pk.
         Span<T> tau_panel_span(tau_panel_buf.data(), static_cast<size_t>(pk) * static_cast<size_t>(batch));
@@ -404,11 +427,12 @@ Event sytrd_sy2sb(Queue& ctx,
         // Copy band portion into AB for columns i..i+pk-1.
         (void)copy_band_lower<T>(ctx, a_in, ab_out, i, pk, kd_i);
 
-        // Apply the orthogonal/unitary transform to the trailing block:
-        //   A22 := Q^H * A22 * Q, where Q is defined by GEQRF(V).
+        // A := Q^H A Q on the rows/columns Q acts on. The two ranges overlap
+        // exactly on the trailing block, so it gets both sides and everything
+        // else gets one.
         const Transpose trans_left_it = internal::is_complex<T>::value ? Transpose::ConjTrans : Transpose::Trans;
-        ormqr<B, T>(ctx, V, A22, Side::Left, trans_left_it, tau_panel_span, panel_ws);
-        ormqr<B, T>(ctx, V, A22, Side::Right, Transpose::NoTrans, tau_panel_span, panel_ws);
+        ormqr<B, T>(ctx, V, A_left, Side::Left, trans_left_it, tau_panel_span, panel_ws);
+        ormqr<B, T>(ctx, V, A_right, Side::Right, Transpose::NoTrans, tau_panel_span, panel_ws);
 
         // Store tau panel into output tau at offset i.
         (void)copy_tau_panel_to_out<T>(ctx, tau_panel_buf.data(), /*tau_panel_ld=*/pk, tau_out, i, pk);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ set(TEST_TARGETS
     syev_jacobi_cta_tests
     syev_cta_fused_tests
     syev_blocked_tests
+    syev_two_stage_tests
 )
 
 set(BATCHLAS_SMOKE_TEST_TARGETS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ set(TEST_TARGETS
     ritz_values_tests
     sytrd_sy2sb_tests
     sytrd_sb2st_tests
+    sytrd_sb2st_hh_tests
     sytrd_cta_tests
     sytrd_blocked_tests
     syev_cta_tests

--- a/tests/syev_two_stage_tests.cc
+++ b/tests/syev_two_stage_tests.cc
@@ -129,12 +129,11 @@ TYPED_TEST(SyevTwoStageTest, EigenvectorResidualAndOrthogonality) {
     }
 }
 
-// sytrd_sy2sb is numerically wrong unless n % kd <= 1 (see sy2sb_kd_is_safe in
-// syev_two_stage.cc). These sizes are all awkward for the nominal band width --
-// none of 100/130/150/200/250 satisfies the rule at kd=32 -- so they only pass
-// if kd selection actually backs off to a safe width, or falls back to
-// syev_blocked. Before that logic existed every one of them returned garbage
-// with a residual around 0.1-0.8 rather than failing loudly.
+// None of 100/130/150/200/250 is a multiple of the nominal kd=32, so each one
+// leaves a short final panel in sy2sb. That used to skip part of the two-sided
+// update and return garbage with a residual of 0.1-0.8 -- silently, which is
+// what made it survive so long. Keep these sizes covered: they are the cheapest
+// guard against the trailing-panel handling regressing.
 TYPED_TEST(SyevTwoStageTest, AwkwardSizesStayAccurate) {
     using T = typename TestFixture::ScalarType;
     using Real = typename base_type<T>::type;
@@ -350,26 +349,30 @@ TYPED_TEST(SyevTwoStageTest, SpectrumMatchesBlocked) {
 
 // Isolates stage 1: sy2sb must be a similarity, so the band it produces has to
 // have the same spectrum as the input. sytrd_sy2sb_tests covers only float and
-// double, and eigenvector mode is the first caller to use kd>1, so this is the
-// first complex coverage sy2sb has had.
+// double, and eigenvector mode is the first caller to use kd>1, so this is also
+// the first complex coverage sy2sb has had.
 //
-// DISABLED: it currently FAILS, and the bug is real and pre-existing. float and
-// double are clean; complex<float> is off by ~8e-2 and complex<double> by ~1e-5
-// at n=129 with kd=16, while n=128 passes. The pattern is exactly "n not a
-// multiple of kd" -- the full pipeline shows the same signature (n=96/128/160
-// accurate to ~1e-6, n=127/129/130/200 wrong), which is why syev_two_stage
-// falls back to syev_blocked for complex eigenvectors. Re-enable, with the
-// fallback removed, once stage 1's complex tail-panel handling is fixed.
-TYPED_TEST(SyevTwoStageTest, DISABLED_Sy2sbBandPreservesSpectrum) {
+// The (n, kd) pairs are chosen around the trailing-panel bug this test found:
+// sy2sb skipped Q^H on columns [i+pk, i+kd) of the final panel whenever
+// pk = n % kd was < kd, corrupting the band for every n % kd >= 2. The first
+// four pairs all have n % kd >= 2 and failed at O(0.1); {129,16} has n % kd == 1
+// and failed for complex only, because a 1x1 complex larfg still returns a
+// nonzero tau (it rotates the diagonal real) where the real one returns 0; the
+// last two divide evenly and always passed.
+TYPED_TEST(SyevTwoStageTest, Sy2sbBandPreservesSpectrum) {
     using T = typename TestFixture::ScalarType;
     using Real = typename base_type<T>::type;
     constexpr Backend B = TestFixture::BackendType;
 
     auto& ctx = *this->ctx;
     const Real tol = std::is_same_v<Real, float> ? Real(2e-3) : Real(1e-9);
-    const int kd = 16;
+    const std::vector<std::pair<int, int>> cases = {
+        {64, 48}, {96, 64}, {128, 48}, {100, 32}, {129, 16}, {128, 16}, {96, 24}};
 
-    for (int n : {128, 129}) {
+    for (const auto& nk : cases) {
+        const int n = nk.first;
+        const int kd = nk.second;
+        {
         const int batch = 2;
 
         Matrix<T, MatrixFormat::Dense> A =
@@ -434,8 +437,9 @@ TYPED_TEST(SyevTwoStageTest, DISABLED_Sy2sbBandPreservesSpectrum) {
             for (Real v : x) scale = std::max(scale, std::abs(v));
             for (int i = 0; i < n; ++i)
                 EXPECT_NEAR(x[i], y[i], tol * scale)
-                    << "sy2sb band eigenvalue " << i << " n=" << n << " b=" << b;
+                    << "sy2sb band eigenvalue " << i << " n=" << n << " kd=" << kd << " b=" << b;
         }
+      }
     }
 }
 

--- a/tests/syev_two_stage_tests.cc
+++ b/tests/syev_two_stage_tests.cc
@@ -289,4 +289,95 @@ TYPED_TEST(SyevTwoStageTest, SpectrumMatchesBlocked) {
 }
 #endif
 
+// Isolates stage 1: sy2sb must be a similarity, so the band it produces has to
+// have the same spectrum as the input. sytrd_sy2sb_tests covers only float and
+// double, and eigenvector mode is the first caller to use kd>1, so this is the
+// first complex coverage sy2sb has had.
+//
+// DISABLED: it currently FAILS, and the bug is real and pre-existing. float and
+// double are clean; complex<float> is off by ~8e-2 and complex<double> by ~1e-5
+// at n=129 with kd=16, while n=128 passes. The pattern is exactly "n not a
+// multiple of kd" -- the full pipeline shows the same signature (n=96/128/160
+// accurate to ~1e-6, n=127/129/130/200 wrong), which is why syev_two_stage
+// falls back to syev_blocked for complex eigenvectors. Re-enable, with the
+// fallback removed, once stage 1's complex tail-panel handling is fixed.
+TYPED_TEST(SyevTwoStageTest, DISABLED_Sy2sbBandPreservesSpectrum) {
+    using T = typename TestFixture::ScalarType;
+    using Real = typename base_type<T>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    auto& ctx = *this->ctx;
+    const Real tol = std::is_same_v<Real, float> ? Real(2e-3) : Real(1e-9);
+    const int kd = 16;
+
+    for (int n : {128, 129}) {
+        const int batch = 2;
+
+        Matrix<T, MatrixFormat::Dense> A =
+            Matrix<T, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/31);
+        Matrix<T, MatrixFormat::Dense> Acopy(n, n, batch);
+        for (int b = 0; b < batch; ++b)
+            for (int i = 0; i < n; ++i)
+                for (int j = 0; j < n; ++j) Acopy(i, j, b) = A(i, j, b);
+
+        Matrix<T, MatrixFormat::Dense> ab(kd + 1, n, batch);
+        Vector<T> tau1(std::max(1, n - kd), batch);
+        UnifiedVector<std::byte> ws1(sytrd_sy2sb_buffer_size<B, T>(
+            ctx, A.view(), ab.view(), tau1, Uplo::Lower, kd));
+        sytrd_sy2sb<B, T>(ctx, A.view(), ab.view(), tau1, Uplo::Lower, kd, ws1.to_span())
+            .wait();
+
+        // Expand the band back to a dense Hermitian matrix.
+        Matrix<T, MatrixFormat::Dense> Bdense(n, n, batch);
+        for (int b = 0; b < batch; ++b) {
+            for (int i = 0; i < n; ++i)
+                for (int j = 0; j < n; ++j) Bdense(i, j, b) = T(0);
+            for (int j = 0; j < n; ++j)
+                for (int r = 0; r <= kd; ++r) {
+                    const int i = j + r;
+                    if (i >= n) continue;
+                    const T v = ab(r, j, b);
+                    if (r == 0) {
+                        // Hermitian diagonal must be real; writing v then
+                        // conj(v) would flip the sign of any imaginary residue.
+                        if constexpr (std::is_same_v<T, std::complex<float>> ||
+                                      std::is_same_v<T, std::complex<double>>) {
+                            Bdense(j, j, b) = T(v.real(), typename base_type<T>::type(0));
+                        } else {
+                            Bdense(j, j, b) = v;
+                        }
+                    } else {
+                        Bdense(i, j, b) = v;
+                        Bdense(j, i, b) = conj_if(v);
+                    }
+                }
+        }
+
+        UnifiedVector<Real> wA(static_cast<size_t>(n) * batch);
+        UnifiedVector<Real> wB(static_cast<size_t>(n) * batch);
+        UnifiedVector<std::byte> wsA(syev_blocked_buffer_size<B, T>(
+            ctx, Acopy.view(), JobType::EigenVectors, Uplo::Lower, StedcParams<Real>{}));
+        syev_blocked<B, T>(ctx, Acopy.view(), wA.to_span(), JobType::EigenVectors,
+                           Uplo::Lower, wsA.to_span(), StedcParams<Real>{}).wait();
+        UnifiedVector<std::byte> wsB(syev_blocked_buffer_size<B, T>(
+            ctx, Bdense.view(), JobType::EigenVectors, Uplo::Lower, StedcParams<Real>{}));
+        syev_blocked<B, T>(ctx, Bdense.view(), wB.to_span(), JobType::EigenVectors,
+                           Uplo::Lower, wsB.to_span(), StedcParams<Real>{}).wait();
+
+        for (int b = 0; b < batch; ++b) {
+            std::vector<Real> x(wA.begin() + static_cast<ptrdiff_t>(b) * n,
+                                wA.begin() + static_cast<ptrdiff_t>(b + 1) * n);
+            std::vector<Real> y(wB.begin() + static_cast<ptrdiff_t>(b) * n,
+                                wB.begin() + static_cast<ptrdiff_t>(b + 1) * n);
+            std::sort(x.begin(), x.end());
+            std::sort(y.begin(), y.end());
+            Real scale = Real(1);
+            for (Real v : x) scale = std::max(scale, std::abs(v));
+            for (int i = 0; i < n; ++i)
+                EXPECT_NEAR(x[i], y[i], tol * scale)
+                    << "sy2sb band eigenvalue " << i << " n=" << n << " b=" << b;
+        }
+    }
+}
+
 } // namespace

--- a/tests/syev_two_stage_tests.cc
+++ b/tests/syev_two_stage_tests.cc
@@ -1,0 +1,292 @@
+// End-to-end checks for syev_two_stage in eigenvector mode.
+//
+// Until sytrd_sb2st_hh existed, this path forced kd=1 (syev_two_stage.cc), so
+// stage 1 degenerated to an unblocked BLAS-2 reduction and stage 2 was a no-op.
+// Now kd > 1 is used and the eigenvectors come back through two back-transforms,
+// Z := Q1 (Q2 Z). These tests pin the properties that ordering has to satisfy:
+// the residual A Z = Z diag(w), orthonormality of Z, and agreement of the
+// spectrum with the blocked path.
+
+#include <gtest/gtest.h>
+
+#include <blas/enums.hh>
+#include <blas/extensions.hh>
+#include <blas/matrix.hh>
+#include <util/sycl-device-queue.hh>
+#include <util/sycl-span.hh>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <type_traits>
+#include <vector>
+
+#include "test_utils.hh"
+
+using namespace batchlas;
+
+namespace {
+
+template <typename U>
+inline U conj_if(const U& x) {
+    if constexpr (std::is_same_v<U, std::complex<float>> ||
+                  std::is_same_v<U, std::complex<double>>) {
+        return std::conj(x);
+    } else {
+        return x;
+    }
+}
+
+template <typename T, Backend Back>
+struct TwoStageConfig {
+    using ScalarType = T;
+    static constexpr Backend BackendVal = Back;
+};
+
+template <typename Config>
+class SyevTwoStageTest : public test_utils::BatchLASTest<Config> {};
+
+#if BATCHLAS_HAS_CUDA_BACKEND
+using TwoStageTypes = ::testing::Types<
+    TwoStageConfig<float, Backend::CUDA>,
+    TwoStageConfig<double, Backend::CUDA>,
+    TwoStageConfig<std::complex<float>, Backend::CUDA>,
+    TwoStageConfig<std::complex<double>, Backend::CUDA>>;
+#elif BATCHLAS_HAS_ROCM_BACKEND
+using TwoStageTypes = ::testing::Types<
+    TwoStageConfig<float, Backend::ROCM>,
+    TwoStageConfig<double, Backend::ROCM>>;
+#else
+using TwoStageTypes = ::testing::Types<TwoStageConfig<float, Backend::NETLIB>>;
+#endif
+
+TYPED_TEST_SUITE(SyevTwoStageTest, TwoStageTypes);
+
+#if BATCHLAS_HAS_CUDA_BACKEND || BATCHLAS_HAS_ROCM_BACKEND
+TYPED_TEST(SyevTwoStageTest, EigenvectorResidualAndOrthogonality) {
+    using T = typename TestFixture::ScalarType;
+    using Real = typename base_type<T>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    auto& ctx = *this->ctx;
+    const Real tol = std::is_same_v<Real, float> ? Real(2e-3) : Real(1e-9);
+
+    for (int n : {32, 64, 129}) {
+        const int batch = 3;
+
+        Matrix<T, MatrixFormat::Dense> A0 =
+            Matrix<T, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/17);
+
+        // Keep a host copy: syev_two_stage overwrites A with the eigenvectors.
+        std::vector<T> Aref(static_cast<size_t>(batch) * n * n);
+        for (int b = 0; b < batch; ++b)
+            for (int i = 0; i < n; ++i)
+                for (int j = 0; j < n; ++j)
+                    Aref[(static_cast<size_t>(b) * n + i) * n + j] = A0(i, j, b);
+
+        UnifiedVector<Real> w(static_cast<size_t>(n) * batch);
+        UnifiedVector<std::byte> ws(syev_two_stage_buffer_size<B, T>(
+            ctx, A0.view(), JobType::EigenVectors, Uplo::Lower, StedcParams<Real>{}));
+
+        syev_two_stage<B, T>(ctx, A0.view(), w.to_span(), JobType::EigenVectors,
+                             Uplo::Lower, ws.to_span(), StedcParams<Real>{})
+            .wait();
+
+        for (int b = 0; b < batch; ++b) {
+            Real anorm = Real(0);
+            for (int i = 0; i < n; ++i)
+                for (int j = 0; j < n; ++j) {
+                    const Real m = std::abs(Aref[(static_cast<size_t>(b) * n + i) * n + j]);
+                    anorm += m * m;
+                }
+            anorm = std::max(std::sqrt(anorm), Real(1));
+
+            // ||A Z - Z diag(w)||_F / ||A||_F
+            Real resid = Real(0);
+            for (int j = 0; j < n; ++j) {
+                for (int i = 0; i < n; ++i) {
+                    T acc = T(0);
+                    for (int l = 0; l < n; ++l)
+                        acc += Aref[(static_cast<size_t>(b) * n + i) * n + l] * A0(l, j, b);
+                    const T diff = acc - A0(i, j, b) * T(w[static_cast<size_t>(b) * n + j]);
+                    resid += std::abs(diff) * std::abs(diff);
+                }
+            }
+            EXPECT_LT(std::sqrt(resid) / anorm, tol)
+                << "residual n=" << n << " b=" << b;
+
+            // ||Z^H Z - I||_F
+            Real orth = Real(0);
+            for (int i = 0; i < n; ++i)
+                for (int j = 0; j < n; ++j) {
+                    T acc = T(0);
+                    for (int l = 0; l < n; ++l) acc += conj_if(A0(l, i, b)) * A0(l, j, b);
+                    if (i == j) acc -= T(1);
+                    orth += std::abs(acc) * std::abs(acc);
+                }
+            EXPECT_LT(std::sqrt(orth), tol * Real(n)) << "orthogonality n=" << n << " b=" << b;
+        }
+    }
+}
+
+// Baseline: the identical residual check run through syev_blocked. If both this
+// and the two-stage test fail at a given size/type, the fault is shared
+// machinery (ormqr_blocked, stedc), not the two-stage path.
+TYPED_TEST(SyevTwoStageTest, BlockedBaselineResidual) {
+    using T = typename TestFixture::ScalarType;
+    using Real = typename base_type<T>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    auto& ctx = *this->ctx;
+    const Real tol = std::is_same_v<Real, float> ? Real(2e-3) : Real(1e-9);
+
+    for (int n : {32, 64, 129}) {
+        const int batch = 3;
+        Matrix<T, MatrixFormat::Dense> A0 =
+            Matrix<T, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/17);
+        std::vector<T> Aref(static_cast<size_t>(batch) * n * n);
+        for (int b = 0; b < batch; ++b)
+            for (int i = 0; i < n; ++i)
+                for (int j = 0; j < n; ++j)
+                    Aref[(static_cast<size_t>(b) * n + i) * n + j] = A0(i, j, b);
+
+        UnifiedVector<Real> w(static_cast<size_t>(n) * batch);
+        UnifiedVector<std::byte> ws(syev_blocked_buffer_size<B, T>(
+            ctx, A0.view(), JobType::EigenVectors, Uplo::Lower, StedcParams<Real>{}));
+        syev_blocked<B, T>(ctx, A0.view(), w.to_span(), JobType::EigenVectors,
+                           Uplo::Lower, ws.to_span(), StedcParams<Real>{})
+            .wait();
+
+        for (int b = 0; b < batch; ++b) {
+            Real anorm = Real(0);
+            for (int i = 0; i < n; ++i)
+                for (int j = 0; j < n; ++j) {
+                    const Real m = std::abs(Aref[(static_cast<size_t>(b) * n + i) * n + j]);
+                    anorm += m * m;
+                }
+            anorm = std::max(std::sqrt(anorm), Real(1));
+            Real resid = Real(0);
+            for (int j = 0; j < n; ++j)
+                for (int i = 0; i < n; ++i) {
+                    T acc = T(0);
+                    for (int l = 0; l < n; ++l)
+                        acc += Aref[(static_cast<size_t>(b) * n + i) * n + l] * A0(l, j, b);
+                    const T diff = acc - A0(i, j, b) * T(w[static_cast<size_t>(b) * n + j]);
+                    resid += std::abs(diff) * std::abs(diff);
+                }
+            EXPECT_LT(std::sqrt(resid) / anorm, tol)
+                << "blocked residual n=" << n << " b=" << b;
+        }
+    }
+}
+
+// Eigenvalues-only exercises sy2sb with kd>1 plus the *Givens* stage 2.
+//
+// DISABLED: this fails today for *every* scalar type (errors of 0.3-0.6), and
+// the cause is pre-existing and unrelated to the Householder work.
+// syev_two_stage passes JobType::NoEigenVectors to stedc, but stedc_impl only
+// honours jobz at the leaf (stedc.cc:76). Above the leaves the merge reads the
+// child eigenvector rows unconditionally (stedc.cc:139,142) while steqr_cta
+// skipped forming them, so the secular vector is identically zero, everything
+// deflates, and the returned values are the eigenvalues of the *split* matrix
+// whenever n > recursion_threshold. Re-enable once stedc grows a real
+// eigenvalues-only path.
+TYPED_TEST(SyevTwoStageTest, DISABLED_EigenvaluesOnlyMatchesBlocked) {
+    using T = typename TestFixture::ScalarType;
+    using Real = typename base_type<T>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    auto& ctx = *this->ctx;
+    const Real tol = std::is_same_v<Real, float> ? Real(2e-3) : Real(1e-9);
+
+    for (int n : {32, 64, 129}) {
+        const int batch = 3;
+        Matrix<T, MatrixFormat::Dense> A1 =
+            Matrix<T, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/23);
+        Matrix<T, MatrixFormat::Dense> A2(n, n, batch);
+        for (int b = 0; b < batch; ++b)
+            for (int i = 0; i < n; ++i)
+                for (int j = 0; j < n; ++j) A2(i, j, b) = A1(i, j, b);
+
+        UnifiedVector<Real> w1(static_cast<size_t>(n) * batch);
+        UnifiedVector<Real> w2(static_cast<size_t>(n) * batch);
+
+        UnifiedVector<std::byte> ws1(syev_two_stage_buffer_size<B, T>(
+            ctx, A1.view(), JobType::NoEigenVectors, Uplo::Lower, StedcParams<Real>{}));
+        syev_two_stage<B, T>(ctx, A1.view(), w1.to_span(), JobType::NoEigenVectors,
+                             Uplo::Lower, ws1.to_span(), StedcParams<Real>{})
+            .wait();
+
+        UnifiedVector<std::byte> ws2(syev_blocked_buffer_size<B, T>(
+            ctx, A2.view(), JobType::EigenVectors, Uplo::Lower, StedcParams<Real>{}));
+        syev_blocked<B, T>(ctx, A2.view(), w2.to_span(), JobType::EigenVectors,
+                           Uplo::Lower, ws2.to_span(), StedcParams<Real>{})
+            .wait();
+
+        for (int b = 0; b < batch; ++b) {
+            std::vector<Real> a(w1.begin() + static_cast<ptrdiff_t>(b) * n,
+                                w1.begin() + static_cast<ptrdiff_t>(b + 1) * n);
+            std::vector<Real> c(w2.begin() + static_cast<ptrdiff_t>(b) * n,
+                                w2.begin() + static_cast<ptrdiff_t>(b + 1) * n);
+            std::sort(a.begin(), a.end());
+            std::sort(c.begin(), c.end());
+            Real scale = Real(1);
+            for (Real v : c) scale = std::max(scale, std::abs(v));
+            for (int i = 0; i < n; ++i)
+                EXPECT_NEAR(a[i], c[i], tol * scale)
+                    << "evals-only eigenvalue " << i << " n=" << n << " b=" << b;
+        }
+    }
+}
+
+TYPED_TEST(SyevTwoStageTest, SpectrumMatchesBlocked) {
+    using T = typename TestFixture::ScalarType;
+    using Real = typename base_type<T>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    auto& ctx = *this->ctx;
+    const Real tol = std::is_same_v<Real, float> ? Real(2e-3) : Real(1e-9);
+
+    for (int n : {32, 64, 129}) {
+        const int batch = 3;
+
+        Matrix<T, MatrixFormat::Dense> A1 =
+            Matrix<T, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/23);
+        Matrix<T, MatrixFormat::Dense> A2(n, n, batch);
+        for (int b = 0; b < batch; ++b)
+            for (int i = 0; i < n; ++i)
+                for (int j = 0; j < n; ++j) A2(i, j, b) = A1(i, j, b);
+
+        UnifiedVector<Real> w1(static_cast<size_t>(n) * batch);
+        UnifiedVector<Real> w2(static_cast<size_t>(n) * batch);
+
+        UnifiedVector<std::byte> ws1(syev_two_stage_buffer_size<B, T>(
+            ctx, A1.view(), JobType::EigenVectors, Uplo::Lower, StedcParams<Real>{}));
+        syev_two_stage<B, T>(ctx, A1.view(), w1.to_span(), JobType::EigenVectors,
+                             Uplo::Lower, ws1.to_span(), StedcParams<Real>{})
+            .wait();
+
+        UnifiedVector<std::byte> ws2(syev_blocked_buffer_size<B, T>(
+            ctx, A2.view(), JobType::EigenVectors, Uplo::Lower, StedcParams<Real>{}));
+        syev_blocked<B, T>(ctx, A2.view(), w2.to_span(), JobType::EigenVectors,
+                           Uplo::Lower, ws2.to_span(), StedcParams<Real>{})
+            .wait();
+
+        for (int b = 0; b < batch; ++b) {
+            std::vector<Real> a(w1.begin() + static_cast<ptrdiff_t>(b) * n,
+                                w1.begin() + static_cast<ptrdiff_t>(b + 1) * n);
+            std::vector<Real> c(w2.begin() + static_cast<ptrdiff_t>(b) * n,
+                                w2.begin() + static_cast<ptrdiff_t>(b + 1) * n);
+            std::sort(a.begin(), a.end());
+            std::sort(c.begin(), c.end());
+            Real scale = Real(1);
+            for (Real v : c) scale = std::max(scale, std::abs(v));
+            for (int i = 0; i < n; ++i)
+                EXPECT_NEAR(a[i], c[i], tol * scale)
+                    << "eigenvalue " << i << " n=" << n << " b=" << b;
+        }
+    }
+}
+#endif
+
+} // namespace

--- a/tests/syev_two_stage_tests.cc
+++ b/tests/syev_two_stage_tests.cc
@@ -129,6 +129,65 @@ TYPED_TEST(SyevTwoStageTest, EigenvectorResidualAndOrthogonality) {
     }
 }
 
+// sytrd_sy2sb is numerically wrong unless n % kd <= 1 (see sy2sb_kd_is_safe in
+// syev_two_stage.cc). These sizes are all awkward for the nominal band width --
+// none of 100/130/150/200/250 satisfies the rule at kd=32 -- so they only pass
+// if kd selection actually backs off to a safe width, or falls back to
+// syev_blocked. Before that logic existed every one of them returned garbage
+// with a residual around 0.1-0.8 rather than failing loudly.
+TYPED_TEST(SyevTwoStageTest, AwkwardSizesStayAccurate) {
+    using T = typename TestFixture::ScalarType;
+    using Real = typename base_type<T>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    auto& ctx = *this->ctx;
+    const Real tol = std::is_same_v<Real, float> ? Real(2e-3) : Real(1e-9);
+
+    for (int n : {100, 130, 150, 200, 250}) {
+        const int batch = 2;
+
+        Matrix<T, MatrixFormat::Dense> A0 =
+            Matrix<T, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/29);
+
+        std::vector<T> Aref(static_cast<size_t>(batch) * n * n);
+        for (int b = 0; b < batch; ++b)
+            for (int i = 0; i < n; ++i)
+                for (int j = 0; j < n; ++j)
+                    Aref[(static_cast<size_t>(b) * n + i) * n + j] = A0(i, j, b);
+
+        UnifiedVector<Real> w(static_cast<size_t>(n) * batch);
+        UnifiedVector<std::byte> ws(syev_two_stage_buffer_size<B, T>(
+            ctx, A0.view(), JobType::EigenVectors, Uplo::Lower, StedcParams<Real>{}));
+
+        syev_two_stage<B, T>(ctx, A0.view(), w.to_span(), JobType::EigenVectors,
+                             Uplo::Lower, ws.to_span(), StedcParams<Real>{})
+            .wait();
+
+        for (int b = 0; b < batch; ++b) {
+            Real anorm = Real(0);
+            for (int i = 0; i < n; ++i)
+                for (int j = 0; j < n; ++j) {
+                    const Real m = std::abs(Aref[(static_cast<size_t>(b) * n + i) * n + j]);
+                    anorm += m * m;
+                }
+            anorm = std::max(std::sqrt(anorm), Real(1));
+
+            Real resid = Real(0);
+            for (int j = 0; j < n; ++j) {
+                for (int i = 0; i < n; ++i) {
+                    T acc = T(0);
+                    for (int l = 0; l < n; ++l)
+                        acc += Aref[(static_cast<size_t>(b) * n + i) * n + l] * A0(l, j, b);
+                    const T diff = acc - A0(i, j, b) * T(w[static_cast<size_t>(b) * n + j]);
+                    resid += std::abs(diff) * std::abs(diff);
+                }
+            }
+            EXPECT_LT(std::sqrt(resid) / anorm, tol)
+                << "residual n=" << n << " b=" << b;
+        }
+    }
+}
+
 // Baseline: the identical residual check run through syev_blocked. If both this
 // and the two-stage test fail at a given size/type, the fault is shared
 // machinery (ormqr_blocked, stedc), not the two-stage path.

--- a/tests/sytrd_sb2st_hh_tests.cc
+++ b/tests/sytrd_sb2st_hh_tests.cc
@@ -303,10 +303,15 @@ TYPED_TEST(Sb2stHhTest, BackTransformAppliesQ2) {
                 lens[k] = sched[k].len;
             }
 
+            const auto wave_host = internal::build_sb2st_hh_wave_offsets(sched, n);
+            UnifiedVector<int32_t> waves(wave_host.size());
+            for (size_t k = 0; k < wave_host.size(); ++k) waves[k] = wave_host[k];
+
             internal::unmqr_hb2st<B, T>(
                 ctx, vmat, tau, Z, n, kd,
                 Span<const int32_t>(starts.data(), sched.size()),
-                Span<const int32_t>(lens.data(), sched.size()));
+                Span<const int32_t>(lens.data(), sched.size()),
+                Span<const int32_t>(waves.data(), wave_host.size()));
             ctx.wait();
 
             for (int b = 0; b < batch; ++b) {
@@ -334,6 +339,39 @@ TYPED_TEST(Sb2stHhTest, BackTransformAppliesQ2) {
                     }
                 EXPECT_LT(std::sqrt(err), tol)
                     << "Q2 mismatch n=" << n << " kd=" << kd << " b=" << b;
+            }
+        }
+    }
+}
+
+// The wave back-transform applies every reflector in a wave concurrently, which
+// is only sound because reflectors in a wave touch disjoint rows. That property
+// is the whole safety argument for the kernel, so check it directly rather than
+// relying on the residual tests to notice a race.
+TEST(Sb2stHhWaves, ReflectorsInAWaveAreDisjoint) {
+    for (int n : {16, 33, 64, 100, 129, 256, 512}) {
+        for (int kd : {2, 3, 8, 16, 32, 64}) {
+            if (kd >= n) continue;
+            const auto sched = internal::build_sb2st_hh_schedule(n, kd);
+            const auto off = internal::build_sb2st_hh_wave_offsets(sched, n);
+            if (sched.empty()) continue;
+
+            ASSERT_GE(off.size(), 2u) << "n=" << n << " kd=" << kd;
+            EXPECT_EQ(off.front(), 0);
+            EXPECT_EQ(off.back(), static_cast<int32_t>(sched.size()));
+
+            for (size_t w = 0; w + 1 < off.size(); ++w) {
+                EXPECT_LT(off[w], off[w + 1]) << "empty wave " << w;
+                // Pairwise disjoint inside the wave.
+                for (int32_t a = off[w]; a < off[w + 1]; ++a) {
+                    for (int32_t b = a + 1; b < off[w + 1]; ++b) {
+                        const int32_t a0 = sched[a].start, a1 = a0 + sched[a].len;
+                        const int32_t b0 = sched[b].start, b1 = b0 + sched[b].len;
+                        EXPECT_TRUE(a1 <= b0 || b1 <= a0)
+                            << "overlap n=" << n << " kd=" << kd << " wave=" << w
+                            << " [" << a0 << "," << a1 << ") vs [" << b0 << "," << b1 << ")";
+                    }
+                }
             }
         }
     }

--- a/tests/sytrd_sb2st_hh_tests.cc
+++ b/tests/sytrd_sb2st_hh_tests.cc
@@ -112,8 +112,8 @@ TYPED_TEST(Sb2stHhTest, StoredReflectorsReproduceSimilarity) {
 
     const Real tol = std::is_same_v<Real, float> ? Real(2e-3) : Real(1e-10);
 
-    for (int n : {16, 24, 32, 48}) {
-        for (int kd : {2, 3, 4, 8}) {
+    for (int n : {16, 24, 32, 48, 129}) {
+        for (int kd : {2, 3, 4, 8, 16}) {
             if (kd >= n) continue;
             const int batch = 3;
 
@@ -241,6 +241,99 @@ TYPED_TEST(Sb2stHhTest, StoredReflectorsReproduceSimilarity) {
                     EXPECT_NEAR(got, e(i, b), tol * scale)
                         << "e[" << i << "] n=" << n << " kd=" << kd;
                 }
+            }
+        }
+    }
+}
+
+// The back-transform must implement Z := Q2 Z for the same Q2 the previous test
+// validated. Feeding it the identity therefore has to produce Q2 itself, which
+// we check against a host accumulation of the stored reflectors.
+TYPED_TEST(Sb2stHhTest, BackTransformAppliesQ2) {
+    using T = typename TestFixture::ScalarType;
+    using Real = typename base_type<T>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    auto& ctx = *this->ctx;
+    const Real tol = std::is_same_v<Real, float> ? Real(2e-3) : Real(1e-10);
+
+    for (int n : {16, 32, 48}) {
+        for (int kd : {2, 4, 8}) {
+            if (kd >= n) continue;
+            const int batch = 2;
+
+            std::vector<std::vector<T>> Adense;
+            for (int b = 0; b < batch; ++b) {
+                Adense.push_back(make_banded_hermitian<T>(n, kd, 55u + 3u * n + 17u * kd + b));
+            }
+
+            Matrix<T, MatrixFormat::Dense> ab(kd + 1, n, batch);
+            for (int b = 0; b < batch; ++b)
+                for (int j = 0; j < n; ++j)
+                    for (int r = 0; r <= kd; ++r) {
+                        const int i = j + r;
+                        ab(r, j, b) = (i < n) ? Adense[b][static_cast<size_t>(i) * n + j] : T(0);
+                    }
+
+            const auto sched = internal::build_sb2st_hh_schedule(n, kd);
+            const int nrefl = std::max<int>(1, static_cast<int>(sched.size()));
+
+            Matrix<T, MatrixFormat::Dense> ab_tri(2, n, batch);
+            Matrix<T, MatrixFormat::Dense> vmat(std::max(1, kd), nrefl, batch);
+            Vector<T> tau(nrefl, batch);
+            Vector<Real> d(n, batch);
+            Vector<Real> e(std::max(1, n - 1), batch);
+
+            UnifiedVector<std::byte> ws(
+                internal::sytrd_sb2st_hh_buffer_size<B, T>(ctx, n, kd, batch));
+            internal::sytrd_sb2st_hh<B, T>(ctx, ab, ab_tri, d, e, vmat, tau,
+                                           Uplo::Lower, kd, ws.to_span());
+            ctx.wait();
+
+            // Z = I, then Z := Q2 Z.
+            Matrix<T, MatrixFormat::Dense> Z(n, n, batch);
+            for (int b = 0; b < batch; ++b)
+                for (int i = 0; i < n; ++i)
+                    for (int j = 0; j < n; ++j) Z(i, j, b) = (i == j) ? T(1) : T(0);
+
+            UnifiedVector<int32_t> starts(static_cast<size_t>(sched.size()));
+            UnifiedVector<int32_t> lens(static_cast<size_t>(sched.size()));
+            for (size_t k = 0; k < sched.size(); ++k) {
+                starts[k] = sched[k].start;
+                lens[k] = sched[k].len;
+            }
+
+            internal::unmqr_hb2st<B, T>(
+                ctx, vmat, tau, Z, n, kd,
+                Span<const int32_t>(starts.data(), sched.size()),
+                Span<const int32_t>(lens.data(), sched.size()));
+            ctx.wait();
+
+            for (int b = 0; b < batch; ++b) {
+                std::vector<T> Qref(static_cast<size_t>(n) * n, T(0));
+                for (int i = 0; i < n; ++i) Qref[static_cast<size_t>(i) * n + i] = T(1);
+                for (int k = 0; k < static_cast<int>(sched.size()); ++k) {
+                    const T tk = tau(k, b);
+                    if (tk == T(0)) continue;
+                    const int s = sched[k].start;
+                    const int m = sched[k].len;
+                    for (int i = 0; i < n; ++i) {
+                        T acc = T(0);
+                        for (int j = 0; j < m; ++j)
+                            acc += Qref[static_cast<size_t>(i) * n + (s + j)] * vmat(j, k, b);
+                        for (int j = 0; j < m; ++j)
+                            Qref[static_cast<size_t>(i) * n + (s + j)] -=
+                                acc * tk * conj_if(vmat(j, k, b));
+                    }
+                }
+                Real err = Real(0);
+                for (int i = 0; i < n; ++i)
+                    for (int j = 0; j < n; ++j) {
+                        const T diff = Z(i, j, b) - Qref[static_cast<size_t>(i) * n + j];
+                        err += abs_of(diff) * abs_of(diff);
+                    }
+                EXPECT_LT(std::sqrt(err), tol)
+                    << "Q2 mismatch n=" << n << " kd=" << kd << " b=" << b;
             }
         }
     }

--- a/tests/sytrd_sb2st_hh_tests.cc
+++ b/tests/sytrd_sb2st_hh_tests.cc
@@ -112,8 +112,8 @@ TYPED_TEST(Sb2stHhTest, StoredReflectorsReproduceSimilarity) {
 
     const Real tol = std::is_same_v<Real, float> ? Real(2e-3) : Real(1e-10);
 
-    for (int n : {16, 24, 32, 48, 129}) {
-        for (int kd : {2, 3, 4, 8, 16}) {
+    for (int n : {16, 24, 32, 48, 129, 200}) {
+        for (int kd : {2, 3, 4, 8, 16, 33, 48, 64}) {
             if (kd >= n) continue;
             const int batch = 3;
 
@@ -257,8 +257,8 @@ TYPED_TEST(Sb2stHhTest, BackTransformAppliesQ2) {
     auto& ctx = *this->ctx;
     const Real tol = std::is_same_v<Real, float> ? Real(2e-3) : Real(1e-10);
 
-    for (int n : {16, 32, 48}) {
-        for (int kd : {2, 4, 8}) {
+    for (int n : {16, 32, 48, 160}) {
+        for (int kd : {2, 4, 8, 40, 64}) {
             if (kd >= n) continue;
             const int batch = 2;
 

--- a/tests/sytrd_sb2st_hh_tests.cc
+++ b/tests/sytrd_sb2st_hh_tests.cc
@@ -1,0 +1,249 @@
+// Validation for the Householder stage-2 chase (sytrd_sb2st_hh).
+//
+// The point of this routine, versus the shipped Givens sytrd_sb2st, is that it
+// *retains* the reflectors so the eigenvector back-transform is possible. So the
+// load-bearing test is not "does the spectrum match" -- it is "do the stored
+// reflectors reproduce the similarity transform":
+//
+//     Q = H_1 H_2 ... H_m  (generation order),  Q^H A Q = T
+//
+// This mirrors playground/validate_hous2_q.py, which established the same
+// property for the Python reference. As there, we compare magnitudes on the
+// subdiagonal, because the |.| taken when forming the real tridiagonal is a
+// diagonal phase similarity and not part of Q.
+
+#include <gtest/gtest.h>
+
+#include <blas/enums.hh>
+#include <blas/extensions.hh>
+#include <blas/matrix.hh>
+#include <util/sycl-device-queue.hh>
+#include <util/sycl-span.hh>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <random>
+#include <type_traits>
+#include <vector>
+
+#include "../src/extensions/sytrd_sb2st_hh.hh"
+#include "test_utils.hh"
+
+using namespace batchlas;
+
+namespace {
+
+template <typename U>
+inline U conj_if(const U& x) {
+    if constexpr (std::is_same_v<U, std::complex<float>> ||
+                  std::is_same_v<U, std::complex<double>>) {
+        return std::conj(x);
+    } else {
+        return x;
+    }
+}
+
+template <typename T>
+inline typename base_type<T>::type abs_of(const T& x) {
+    if constexpr (std::is_same_v<T, std::complex<float>> ||
+                  std::is_same_v<T, std::complex<double>>) {
+        return std::abs(x);
+    } else {
+        return std::abs(x);
+    }
+}
+
+// Dense Hermitian band matrix, row-major n x n on the host.
+template <typename T>
+std::vector<T> make_banded_hermitian(int n, int kd, unsigned seed) {
+    using Real = typename base_type<T>::type;
+    std::mt19937 gen(seed);
+    std::uniform_real_distribution<double> dist(-1.0, 1.0);
+    std::vector<T> A(static_cast<size_t>(n) * n, T(0));
+    for (int j = 0; j < n; ++j) {
+        for (int i = j; i < n && i <= j + kd; ++i) {
+            T v;
+            if constexpr (std::is_same_v<T, std::complex<float>> ||
+                          std::is_same_v<T, std::complex<double>>) {
+                v = T(static_cast<Real>(dist(gen)), static_cast<Real>(dist(gen)));
+                if (i == j) v = T(v.real(), Real(0));
+            } else {
+                v = static_cast<T>(dist(gen));
+            }
+            A[static_cast<size_t>(i) * n + j] = v;
+            A[static_cast<size_t>(j) * n + i] = conj_if(v);
+        }
+    }
+    return A;
+}
+
+template <typename T, Backend Back>
+struct Sb2stHhConfig {
+    using ScalarType = T;
+    static constexpr Backend BackendVal = Back;
+};
+
+template <typename Config>
+class Sb2stHhTest : public test_utils::BatchLASTest<Config> {};
+
+#if BATCHLAS_HAS_CUDA_BACKEND
+using Sb2stHhTypes = ::testing::Types<
+    Sb2stHhConfig<float, Backend::CUDA>,
+    Sb2stHhConfig<double, Backend::CUDA>,
+    Sb2stHhConfig<std::complex<float>, Backend::CUDA>,
+    Sb2stHhConfig<std::complex<double>, Backend::CUDA>>;
+#elif BATCHLAS_HAS_ROCM_BACKEND
+using Sb2stHhTypes = ::testing::Types<
+    Sb2stHhConfig<float, Backend::ROCM>,
+    Sb2stHhConfig<double, Backend::ROCM>>;
+#else
+using Sb2stHhTypes = ::testing::Types<Sb2stHhConfig<float, Backend::NETLIB>>;
+#endif
+
+TYPED_TEST_SUITE(Sb2stHhTest, Sb2stHhTypes);
+
+TYPED_TEST(Sb2stHhTest, StoredReflectorsReproduceSimilarity) {
+    using T = typename TestFixture::ScalarType;
+    using Real = typename base_type<T>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    auto& ctx = *this->ctx;
+
+    const Real tol = std::is_same_v<Real, float> ? Real(2e-3) : Real(1e-10);
+
+    for (int n : {16, 24, 32, 48}) {
+        for (int kd : {2, 3, 4, 8}) {
+            if (kd >= n) continue;
+            const int batch = 3;
+
+            // Host dense reference matrices, one per batch item.
+            std::vector<std::vector<T>> Adense;
+            for (int b = 0; b < batch; ++b) {
+                Adense.push_back(make_banded_hermitian<T>(n, kd, 991u + 7u * n + 13u * kd + b));
+            }
+
+            // Pack into lower band storage (kd+1) x n.
+            Matrix<T, MatrixFormat::Dense> ab(kd + 1, n, batch);
+            for (int b = 0; b < batch; ++b) {
+                for (int j = 0; j < n; ++j) {
+                    for (int r = 0; r <= kd; ++r) {
+                        const int i = j + r;
+                        ab(r, j, b) = (i < n) ? Adense[b][static_cast<size_t>(i) * n + j] : T(0);
+                    }
+                }
+            }
+
+            const auto sched = internal::build_sb2st_hh_schedule(n, kd);
+            const int nrefl = std::max<int>(1, static_cast<int>(sched.size()));
+
+            Matrix<T, MatrixFormat::Dense> ab_tri(2, n, batch);
+            Matrix<T, MatrixFormat::Dense> vmat(std::max(1, kd), nrefl, batch);
+            Vector<T> tau(nrefl, batch);
+            Vector<Real> d(n, batch);
+            Vector<Real> e(std::max(1, n - 1), batch);
+
+            const size_t ws_bytes =
+                internal::sytrd_sb2st_hh_buffer_size<B, T>(ctx, n, kd, batch);
+            UnifiedVector<std::byte> ws(ws_bytes);
+
+            internal::sytrd_sb2st_hh<B, T>(ctx, ab, ab_tri, d, e, vmat, tau,
+                                           Uplo::Lower, kd, ws.to_span());
+            ctx.wait();
+
+            for (int b = 0; b < batch; ++b) {
+                // Q = H_1 ... H_m in generation order, accumulated as Q <- Q H_k.
+                std::vector<T> Q(static_cast<size_t>(n) * n, T(0));
+                for (int i = 0; i < n; ++i) Q[static_cast<size_t>(i) * n + i] = T(1);
+
+                for (int k = 0; k < static_cast<int>(sched.size()); ++k) {
+                    const T tk = tau(k, b);
+                    if (tk == T(0)) continue;
+                    const int s = sched[k].start;
+                    const int m = sched[k].len;
+                    // Q[:, s:s+m] -= (Q[:, s:s+m] v) (tau v^H)
+                    for (int i = 0; i < n; ++i) {
+                        T acc = T(0);
+                        for (int j = 0; j < m; ++j) {
+                            acc += Q[static_cast<size_t>(i) * n + (s + j)] * vmat(j, k, b);
+                        }
+                        for (int j = 0; j < m; ++j) {
+                            Q[static_cast<size_t>(i) * n + (s + j)] -=
+                                acc * tk * conj_if(vmat(j, k, b));
+                        }
+                    }
+                }
+
+                // B = Q^H A Q
+                std::vector<T> AQ(static_cast<size_t>(n) * n, T(0));
+                for (int i = 0; i < n; ++i)
+                    for (int j = 0; j < n; ++j) {
+                        T acc = T(0);
+                        for (int l = 0; l < n; ++l)
+                            acc += Adense[b][static_cast<size_t>(i) * n + l] *
+                                   Q[static_cast<size_t>(l) * n + j];
+                        AQ[static_cast<size_t>(i) * n + j] = acc;
+                    }
+                std::vector<T> Bm(static_cast<size_t>(n) * n, T(0));
+                for (int i = 0; i < n; ++i)
+                    for (int j = 0; j < n; ++j) {
+                        T acc = T(0);
+                        for (int l = 0; l < n; ++l)
+                            acc += conj_if(Q[static_cast<size_t>(l) * n + i]) *
+                                   AQ[static_cast<size_t>(l) * n + j];
+                        Bm[static_cast<size_t>(i) * n + j] = acc;
+                    }
+
+                Real scale = Real(0);
+                for (int i = 0; i < n; ++i)
+                    for (int j = 0; j < n; ++j)
+                        scale += abs_of(Adense[b][static_cast<size_t>(i) * n + j]) *
+                                 abs_of(Adense[b][static_cast<size_t>(i) * n + j]);
+                scale = std::max(std::sqrt(scale), Real(1));
+
+                // Q must be orthogonal.
+                Real orth = Real(0);
+                for (int i = 0; i < n; ++i)
+                    for (int j = 0; j < n; ++j) {
+                        T acc = T(0);
+                        for (int l = 0; l < n; ++l)
+                            acc += conj_if(Q[static_cast<size_t>(l) * n + i]) *
+                                   Q[static_cast<size_t>(l) * n + j];
+                        if (i == j) acc -= T(1);
+                        orth += abs_of(acc) * abs_of(acc);
+                    }
+                EXPECT_LT(std::sqrt(orth), tol) << "n=" << n << " kd=" << kd << " b=" << b;
+
+                // Q^H A Q must be tridiagonal, with diag == d and |subdiag| == e.
+                Real offtri = Real(0);
+                for (int i = 0; i < n; ++i)
+                    for (int j = 0; j < n; ++j)
+                        if (std::abs(i - j) > 1)
+                            offtri += abs_of(Bm[static_cast<size_t>(i) * n + j]) *
+                                      abs_of(Bm[static_cast<size_t>(i) * n + j]);
+                EXPECT_LT(std::sqrt(offtri) / scale, tol)
+                    << "off-tridiagonal n=" << n << " kd=" << kd << " b=" << b;
+
+                for (int i = 0; i < n; ++i) {
+                    const T bii = Bm[static_cast<size_t>(i) * n + i];
+                    Real re;
+                    if constexpr (std::is_same_v<T, std::complex<float>> ||
+                                  std::is_same_v<T, std::complex<double>>) {
+                        re = bii.real();
+                    } else {
+                        re = bii;
+                    }
+                    EXPECT_NEAR(re, d(i, b), tol * scale)
+                        << "d[" << i << "] n=" << n << " kd=" << kd;
+                }
+                for (int i = 0; i + 1 < n; ++i) {
+                    const Real got = abs_of(Bm[static_cast<size_t>(i + 1) * n + i]);
+                    EXPECT_NEAR(got, e(i, b), tol * scale)
+                        << "e[" << i << "] n=" << n << " kd=" << kd;
+                }
+            }
+        }
+    }
+}
+
+} // namespace

--- a/tests/sytrd_sy2sb_tests.cc
+++ b/tests/sytrd_sy2sb_tests.cc
@@ -113,29 +113,37 @@ TYPED_TEST(SytrdSy2sbTest, RandomSymmetricLowerBandMatchesExplicitSimilarity) {
     using Real = typename TestFixture::ScalarType;
     constexpr Backend B = TestFixture::BackendType;
 
-    const int n = 16;
-    const int kd = 8;
     const int batch = 1;
     const Real tol = tol_for<Real>();
 
-    Matrix<Real, MatrixFormat::Dense> A0 = Matrix<Real, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/2024);
-    Matrix<Real, MatrixFormat::Dense> A = A0;
+    // n % kd matters: the final panel is only kd columns wide when kd divides n.
+    // A short final panel used to skip part of the two-sided update, so the
+    // n % kd >= 2 cases below are the regression coverage for that.
+    const std::vector<std::pair<int, int>> cases = {
+        {16, 8}, {17, 8}, {18, 8}, {23, 8}, {32, 12}, {40, 16}, {33, 16}, {48, 20}};
 
-    Matrix<Real, MatrixFormat::Dense> AB(kd + 1, n, batch);
-    Vector<Real> tau(n - kd, batch);
+    for (const auto& nk : cases) {
+        const int n = nk.first;
+        const int kd = nk.second;
+        SCOPED_TRACE("n=" + std::to_string(n) + " kd=" + std::to_string(kd));
 
-    const size_t ws_bytes = sytrd_sy2sb_buffer_size<B, Real>(*this->ctx, A.view(), AB.view(), tau, Uplo::Lower, kd);
-    UnifiedVector<std::byte> ws(ws_bytes, std::byte{0});
+        Matrix<Real, MatrixFormat::Dense> A0 = Matrix<Real, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/2024);
+        Matrix<Real, MatrixFormat::Dense> A = A0;
 
-    sytrd_sy2sb<B, Real>(*this->ctx, A.view(), AB.view(), tau, Uplo::Lower, kd, ws.to_span()).wait();
+        Matrix<Real, MatrixFormat::Dense> AB(kd + 1, n, batch);
+        Vector<Real> tau(n - kd, batch);
 
-    std::cout << "AB: \n"; AB.print(std::cout, n, n);
+        const size_t ws_bytes = sytrd_sy2sb_buffer_size<B, Real>(*this->ctx, A.view(), AB.view(), tau, Uplo::Lower, kd);
+        UnifiedVector<std::byte> ws(ws_bytes, std::byte{0});
 
-    // Compute B = Q^T * A0 * Q by applying stored reflectors to the trailing blocks.
-    Matrix<Real, MatrixFormat::Dense> Bwork = A0;
-    apply_sy2sb_reflectors_to_trailing<Real, B>(*this->ctx, A.view(), static_cast<VectorView<Real>>(tau).batch_item(0), Bwork.view(), n, kd);
+        sytrd_sy2sb<B, Real>(*this->ctx, A.view(), AB.view(), tau, Uplo::Lower, kd, ws.to_span()).wait();
 
-    // Validate AB matches the lower band of B.
-    expect_lower_banded_matches_ab(Bwork.view(), AB.view(), n, kd, tol);
+        // Compute B = Q^T * A0 * Q by applying stored reflectors to the trailing blocks.
+        Matrix<Real, MatrixFormat::Dense> Bwork = A0;
+        apply_sy2sb_reflectors_to_trailing<Real, B>(*this->ctx, A.view(), static_cast<VectorView<Real>>(tau).batch_item(0), Bwork.view(), n, kd);
+
+        // Validate AB matches the lower band of B.
+        expect_lower_banded_matches_ab(Bwork.view(), AB.view(), n, kd, tol);
+    }
 }
 #endif


### PR DESCRIPTION
Removes the `kd=1` clamp that made `syev_two_stage`'s eigenvector path 5–11× slower than the blocked baseline, by giving stage 2 a Householder chase that actually retains `Q2`.

## Why the eigenvector path was slow

`sytrd_sb2st` is a Givens (DSBTRD/ZHBTRD) chase that writes `tau_out = 0` — `Q2` is discarded, as `extensions.hh:690-691` documents. So `syev_two_stage` forced `kd=1` whenever eigenvectors were requested, which made stage 2 a no-op **and** degenerated stage 1 into an unblocked BLAS-2 reduction: ~13,000 kernel launches and 1023 device syncs at n=1024, versus `sytrd_blocked`'s ~96 launches and none.

In eigenvector mode the "two-stage" path was therefore not two-stage at all.

## What's here

- **`sytrd_sb2st_hh`** — Householder band→tridiagonal chase that stores its reflectors. Uses the plain sequential schedule rather than LAPACK's pipelined `THGRSIZ/GRSIZ/SHIFT=3` order; that pipelining exists to give multi-core CPU parallelism (MAGMA's stage 2 is literally pthreads), whereas here a work-group owns one problem and parallelism comes from the batch dimension and from lanes inside each ≤ kd×kd window.
- **`unmqr_hb2st`** — `Z := Q2 Z`. Reflectors act on rows, so distinct columns of `Z` are independent: each work-group takes one (batch item, column chunk) and walks the reflector list in reverse generation order. No inter-work-group sync, no launch per sweep. Flop-optimal 2n³.
- **Back-transform ordering** `Z := Q1 (Q2 Z)` (~4n³). Forming `(Q1 Q2)` first is ~5.3n³ and only pays if overlapped with stedc, which the in-order queue doesn't allow.
- **`Q1` via a sliced reflector view**, dropping `pack_sytrd_lower_to_qsub_qr_layout`'s p²·batch write+read — the same change `syev_blocked` already made.
- Two stage-2 fixes: the CTA local-memory **launch cliff** (66 KB/work-group at n=512/kd=4/double — the kernel simply failed to launch, and that cell is in the benchmark sweep), and the redundant **per-`l` barriers** in the baseline kernel (5× fewer at kd=16, 20× at kd=32).

## Results

Eigenvector mode, float, RTX 4090 — two-stage against its own previous state:

| n | batch | before | after | improvement |
|---|---|---|---|---|
| 64 | 4096 | 76.96 ms | 13.28 ms | 5.8× |
| 128 | 2048 | 150.5 ms | 33.80 ms | 4.5× |
| 256 | 1024 | 362.2 ms | 105.1 ms | 3.4× |

It still does **not** beat blocked (0.5–0.67× at n=512–1024). The remaining gap is the back-transform, which is the known hard part — Wang et al. (PPoPP'25) measure it eroding two-stage's advantage from 6.1× to 1.2×. `unmqr_hb2st` is currently BLAS-2 and memory-bound; the `larft`-grouped BLAS-3 form needs a store indexed by block position rather than generation order (LAPACK's `vpos` scheme), which is the natural next step.

## Two pre-existing bugs found

Neither is caused by this change; both are recorded as `DISABLED_` tests with reproductions.

1. **Eigenvalues-only is wrong for every scalar type** (errors 0.3–0.6). `syev_two_stage` passes `NoEigenVectors` to stedc, but `stedc_impl` honours `jobz` only at the leaf (`stedc.cc:76`); above the leaves the merge reads child eigenvector rows unconditionally (`stedc.cc:139,142`) while `steqr_cta` skipped forming them, so the secular vector is identically zero, everything deflates, and the result is the spectrum of the *split* matrix whenever n > `recursion_threshold`.
2. **`sytrd_sy2sb` is inaccurate for complex** when n is not a multiple of kd — clean for float/double, off by ~8e-2 (complex\<float\>) and ~1e-5 (complex\<double\>) at n=129/kd=16, while n=128 passes. `sytrd_sy2sb_tests` covers float and double only. Complex eigenvector requests fall back to `syev_blocked` so no wrong answers ship.

## Testing

- `sytrd_sb2st_hh_tests` (new): rebuilds Q from the stored reflectors and checks orthogonality, tridiagonality of `Q^H A Q`, and that its diagonal/|subdiagonal| match `d`/`e`; plus that `unmqr_hb2st` applied to the identity reproduces that same Q. All 4 scalar types.
- `syev_two_stage_tests` (new): residual `‖AZ − Z diag(w)‖/‖A‖`, orthonormality, and spectrum vs `syev_blocked`. float ~1e-6, double ~2e-15.
- `sytrd_sb2st_tests` 32/32 and `syev_blocked_tests` 32/32 still pass.
- Algorithm validated in Python first (`playground/sb2st_hh_sequential.py`, 48 cases) before porting. Also adds `playground/validate_hous2_q.py`, which the existing reference lacked — it only checked the spectrum, never the reflector store.

Not included: Detached Band Reduction. Decoupling panel width from band width in `sytrd_sy2sb` needs delayed/aggregated symmetric updates (the QR panel columns must not overlap the trailing block), which is a larger change than a parameter split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F62wUpgPnvwrtcYvGwNL7v