### PR TITLE
Fix ILU(k), gate it on smallest eigenpairs, and make it pay for itself in LOBPCG

### DIFF
--- a/benchmarks/iluk_convergence_stats.cc
+++ b/benchmarks/iluk_convergence_stats.cc
@@ -263,7 +263,8 @@ void run_case(Queue& queue,
     SyevxParams<float> params;
     params.iterations = max_iters;
     params.extra_directions = extra_dirs;
-    params.find_largest = true;
+    // ILU(k) approximates A^{-1}; it only preconditions the smallest eigenpairs.
+    params.find_largest = false;
     params.absolute_tolerance = 1e-6f;
     params.relative_tolerance = 1e-6f;
     params.preconditioner = precond_ptr;

--- a/benchmarks/syevx_iluk_acc.cc
+++ b/benchmarks/syevx_iluk_acc.cc
@@ -440,7 +440,8 @@ std::vector<MatrixMetrics<Real>> run_sparse_syevx_once(Queue& q,
     params.algorithm = OrthoAlgorithm::ShiftChol3;
     params.iterations = static_cast<std::size_t>(max_iters);
     params.extra_directions = static_cast<std::size_t>(extra_dirs);
-    params.find_largest = true;
+    // ILU(k) approximates A^{-1}; it only preconditions the smallest eigenpairs.
+    params.find_largest = false;
     params.absolute_tolerance = tolerance;
     params.relative_tolerance = tolerance;
     params.preconditioner = preconditioner;

--- a/include/blas/extensions.hh
+++ b/include/blas/extensions.hh
@@ -5,6 +5,7 @@
 #include <batchlas/tuning_params.hh>
 #include <blas/enums.hh>
 #include <blas/matrix.hh>
+#include <blas/functions/iluk.hh>
 #include <numeric>
 #include <limits>
 #include <cstddef>
@@ -14,9 +15,6 @@
 
 namespace batchlas {
     // Forward declarations for interface compatibility
-
-    template <typename T>
-    struct ILUKPreconditioner;
 
     template <typename T>
     struct SyevxInstrumentation;
@@ -47,6 +45,12 @@ namespace batchlas {
         // components being sought and amplifies the rest, so syevx rejects that
         // combination rather than silently converging more slowly.
         const ILUKPreconditioner<T>* preconditioner = nullptr;
+        // Build the ILU(k) factor inside syevx instead of supplying one. The factor
+        // is carved out of the same workspace the caller passes to syevx, so an
+        // end-to-end timing covers formation as well as application. Requires a CSR
+        // A and find_largest = false, and is mutually exclusive with the pointer above.
+        bool build_preconditioner = false;
+        ILUKParams<T> iluk_params{};
         const SyevxInstrumentation<T>* instrumentation = nullptr;               // Optional convergence instrumentation sink
     };
 

--- a/include/blas/extensions.hh
+++ b/include/blas/extensions.hh
@@ -41,7 +41,12 @@ namespace batchlas {
         bool find_largest = true;                          // Whether to find largest eigenvalues
         T absolute_tolerance = T(std::numeric_limits<float_type>::epsilon());  // Absolute tolerance
         T relative_tolerance = T(std::numeric_limits<float_type>::epsilon());  // Relative tolerance
-        const ILUKPreconditioner<T>* preconditioner = nullptr;                 // Optional ILU(k) preconditioner
+        // Optional ILU(k) preconditioner. An ILU(k) factorization of A approximates
+        // A^{-1}, which is the correct LOBPCG preconditioner only when searching for
+        // the *smallest* eigenpairs. With find_largest = true it damps exactly the
+        // components being sought and amplifies the rest, so syevx rejects that
+        // combination rather than silently converging more slowly.
+        const ILUKPreconditioner<T>* preconditioner = nullptr;
         const SyevxInstrumentation<T>* instrumentation = nullptr;               // Optional convergence instrumentation sink
     };
 

--- a/include/blas/functions/iluk.hh
+++ b/include/blas/functions/iluk.hh
@@ -23,6 +23,29 @@ struct ILUKParams {
     bool validate_batch_sparsity = true;
 };
 
+// Non-owning description of a factored ILU(k) preconditioner. This is what the
+// apply kernel actually consumes, so a factor can live either in storage owned by
+// an ILUKPreconditioner or in a caller-supplied workspace (see the Span overload
+// of iluk_factorize). The view is valid only while that storage is.
+template <typename T>
+struct ILUKView {
+    MatrixView<T, MatrixFormat::CSR> lu;
+    Span<int> diag_positions;  // size = n * batch_size, absolute indices into lu's values
+
+    Span<int> l_rows;
+    Span<int> l_level_ptr;
+    Span<int> u_rows;
+    Span<int> u_level_ptr;
+    int l_levels = 0;
+    int u_levels = 0;
+
+    bool u_diagonals_usable = false;
+
+    int n = 0;
+    int batch_size = 0;
+    T diagonal_shift = T(1e-8);
+};
+
 template <typename T>
 struct ILUKPreconditioner {
     ILUKPreconditioner() : lu(1, 1, 1, 1) {}
@@ -57,6 +80,23 @@ struct ILUKPreconditioner {
     typename base_type<T>::type fill_factor = typename base_type<T>::type(10);
     typename base_type<T>::type diag_pivot_threshold = typename base_type<T>::type(0.1);
     bool modified_ilu = true;
+
+    ILUKView<T> view() const {
+        ILUKView<T> v;
+        v.lu = lu.view();
+        v.diag_positions = diag_positions;
+        v.l_rows = l_rows;
+        v.l_level_ptr = l_level_ptr;
+        v.u_rows = u_rows;
+        v.u_level_ptr = u_level_ptr;
+        v.l_levels = l_levels;
+        v.u_levels = u_levels;
+        v.u_diagonals_usable = u_diagonals_usable;
+        v.n = n;
+        v.batch_size = batch_size;
+        v.diagonal_shift = diagonal_shift;
+        return v;
+    }
 };
 
 // Populate the triangular-solve level schedule from M.lu's sparsity pattern.
@@ -70,17 +110,58 @@ ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
                                      const MatrixView<T, MatrixFormat::CSR>& A,
                                      const ILUKParams<T>& params = ILUKParams<T>());
 
+// Bytes of workspace the Span overload of iluk_factorize needs for A. The exact
+// fill count is only known after the numeric phase (drop tolerance and fill
+// control both prune entries), so this sizes against the symbolic pattern, which
+// is an upper bound. Running it costs one symbolic factorization.
+template <Backend B, typename T>
+size_t iluk_buffer_size(Queue& ctx,
+                        const MatrixView<T, MatrixFormat::CSR>& A,
+                        const ILUKParams<T>& params = ILUKParams<T>());
+
+// Factorize A into caller-supplied memory instead of allocating. Lets an
+// iterative solver carve the preconditioner out of the workspace it was already
+// given. The returned view aliases `workspace` and dies with it.
+// `bytes_used`, when given, receives how much of `workspace` the factor occupies.
+// The exact figure is only knowable after the numeric phase, so a caller that
+// wants to keep sub-allocating from the same pool needs it reported back rather
+// than predicted -- predicting it means running the symbolic phase a second time.
+template <Backend B, typename T>
+ILUKView<T> iluk_factorize(Queue& ctx,
+                           const MatrixView<T, MatrixFormat::CSR>& A,
+                           Span<std::byte> workspace,
+                           const ILUKParams<T>& params,
+                           size_t* bytes_used = nullptr);
+
+template <Backend B, typename T>
+Event iluk_apply(Queue& ctx,
+                 const ILUKView<T>& M,
+                 const MatrixView<T, MatrixFormat::Dense>& rhs,
+                 const MatrixView<T, MatrixFormat::Dense>& out,
+                 Span<std::byte> workspace = Span<std::byte>());
+
+// Convenience overload so callers holding an owning factor need not spell .view().
 template <Backend B, typename T>
 Event iluk_apply(Queue& ctx,
                  const ILUKPreconditioner<T>& M,
                  const MatrixView<T, MatrixFormat::Dense>& rhs,
                  const MatrixView<T, MatrixFormat::Dense>& out,
-                 Span<std::byte> workspace = Span<std::byte>());
+                 Span<std::byte> workspace = Span<std::byte>()) {
+    return iluk_apply<B, T>(ctx, M.view(), rhs, out, workspace);
+}
+
+template <Backend B, typename T>
+size_t iluk_apply_buffer_size(Queue& ctx,
+                              const ILUKView<T>& M,
+                              const MatrixView<T, MatrixFormat::Dense>& rhs,
+                              const MatrixView<T, MatrixFormat::Dense>& out);
 
 template <Backend B, typename T>
 size_t iluk_apply_buffer_size(Queue& ctx,
                               const ILUKPreconditioner<T>& M,
                               const MatrixView<T, MatrixFormat::Dense>& rhs,
-                              const MatrixView<T, MatrixFormat::Dense>& out);
+                              const MatrixView<T, MatrixFormat::Dense>& out) {
+    return iluk_apply_buffer_size<B, T>(ctx, M.view(), rhs, out);
+}
 
 }  // namespace batchlas

--- a/include/blas/functions/iluk.hh
+++ b/include/blas/functions/iluk.hh
@@ -30,6 +30,25 @@ struct ILUKPreconditioner {
     // Factor storage uses unit-diagonal L in the strict lower triangle and explicit-diagonal U on/above the diagonal.
     Matrix<T, MatrixFormat::CSR> lu;
     UnifiedVector<int> diag_positions;  // size = n * batch_size
+
+    // Level schedule for the two sparse triangular solves. Rows inside one level
+    // depend only on rows in earlier levels, so they can be solved concurrently;
+    // this turns the n-step serial walk in iluk_apply into a walk over
+    // `l_levels`/`u_levels` steps. The sparsity pattern is shared across the
+    // batch, so a single schedule serves every batch element.
+    UnifiedVector<int> l_rows;       // row indices ordered by forward-solve level
+    UnifiedVector<int> l_level_ptr;  // size l_levels + 1
+    UnifiedVector<int> u_rows;       // row indices ordered by backward-solve level
+    UnifiedVector<int> u_level_ptr;  // size u_levels + 1
+    int l_levels = 0;
+    int u_levels = 0;
+
+    // Whether every U diagonal can be made non-singular with `diagonal_shift`.
+    // The factor values do not change between applications, so this is decided once
+    // (by iluk_factorize / iluk_build_level_schedule) rather than re-checked on the
+    // host after every solve, which would force a device sync per LOBPCG iteration.
+    bool u_diagonals_usable = false;
+
     int n = 0;
     int batch_size = 0;
     int levels_of_fill = 0;
@@ -39,6 +58,12 @@ struct ILUKPreconditioner {
     typename base_type<T>::type diag_pivot_threshold = typename base_type<T>::type(0.1);
     bool modified_ilu = true;
 };
+
+// Populate the triangular-solve level schedule from M.lu's sparsity pattern.
+// iluk_factorize does this already; call it only when building an
+// ILUKPreconditioner by hand, since iluk_apply requires a valid schedule.
+template <typename T>
+void iluk_build_level_schedule(ILUKPreconditioner<T>& M);
 
 template <Backend B, typename T>
 ILUKPreconditioner<T> iluk_factorize(Queue& ctx,

--- a/include/util/mempool.hh
+++ b/include/util/mempool.hh
@@ -56,6 +56,21 @@ struct BumpAllocator {
 
     template<typename T>
     constexpr inline Span<T> allocate(Queue& ctx, size_t size) {return allocate<T>(ctx.device(), size);}
+
+    // The still-unclaimed tail of the pool. Lets a callee sub-allocate without the
+    // caller having to know its size up front; pair with consume() to hand the
+    // bytes it actually took back to this allocator.
+    inline Span<std::byte> remaining() const {
+        return Span<std::byte>(static_cast<std::byte*>(data), byte_size);
+    }
+
+    inline void consume(size_t bytes) {
+        if (bytes > byte_size) {
+            throw std::runtime_error("BumpAllocator::consume called with more bytes than remain.");
+        }
+        data = static_cast<std::byte*>(data) + bytes;
+        byte_size -= bytes;
+    }
     
     private:
 

--- a/python/batchlas/_options.py
+++ b/python/batchlas/_options.py
@@ -27,6 +27,13 @@ class SyevxOptions:
     store_current_residual: bool = False
     store_convergence_rate: bool = True
     store_ritz_values: bool = False
+    # Build an ILU(k) preconditioner inside syevx, out of the workspace syevx
+    # already allocates. Requires a sparse `a` and find_largest=False. Mutually
+    # exclusive with passing a preconditioner built by iluk_factorize.
+    build_preconditioner: bool = False
+    iluk_levels_of_fill: int = 0
+    iluk_drop_tolerance: object = None
+    iluk_fill_factor: object = None
 
 
 @dataclass(slots=True)

--- a/python/batchlas/bindings/support.hh
+++ b/python/batchlas/bindings/support.hh
@@ -1176,6 +1176,16 @@ SyevxParams<T> parse_syevx_params(const py::dict& options,
     params.absolute_tolerance = py_scalar_or_default<T>(options, "absolute_tolerance", params.absolute_tolerance);
     params.relative_tolerance = py_scalar_or_default<T>(options, "relative_tolerance", params.relative_tolerance);
     params.preconditioner = preconditioner;
+    // Opt-in in-solver ILU(k): syevx forms the factor from its own workspace, so
+    // an end-to-end timing from Python covers formation as well as application.
+    params.build_preconditioner =
+        py_scalar_or_default<bool>(options, "build_preconditioner", params.build_preconditioner);
+    params.iluk_params.levels_of_fill =
+        py_scalar_or_default<int>(options, "iluk_levels_of_fill", params.iluk_params.levels_of_fill);
+    params.iluk_params.drop_tolerance = py_scalar_or_default<typename base_type<T>::type>(
+        options, "iluk_drop_tolerance", params.iluk_params.drop_tolerance);
+    params.iluk_params.fill_factor = py_scalar_or_default<typename base_type<T>::type>(
+        options, "iluk_fill_factor", params.iluk_params.fill_factor);
     params.instrumentation = instrumentation;
     return params;
 }

--- a/python/tests/test_batchlas.py
+++ b/python/tests/test_batchlas.py
@@ -142,7 +142,9 @@ def test_sparse_syevx_accepts_iluk_preconditioner():
     base[np.arange(1, n), np.arange(n - 1)] = offdiag
 
     matrices = [sp.csr_matrix(base), sp.csr_matrix(base + 0.1 * np.eye(n, dtype=np.float64))]
-    options = bl.SyevxOptions(iterations=2, extra_directions=1, find_largest=True)
+    # ILU(k) approximates A^-1, so it is only a valid preconditioner for the
+    # smallest eigenpairs; syevx rejects find_largest=True with a preconditioner.
+    options = bl.SyevxOptions(iterations=2, extra_directions=1, find_largest=False)
 
     try:
         handle = bl.iluk_factorize(matrices, backend="cuda", device="gpu")

--- a/src/extensions/iluk.cc
+++ b/src/extensions/iluk.cc
@@ -2,10 +2,8 @@
 
 #include <blas/functions/iluk.hh>
 #include <util/mempool.hh>
-#include <atomic>
+#include <optional>
 #include <cstdlib>
-#include <exception>
-#include <thread>
 #include <algorithm>
 #include <cmath>
 #include <complex>
@@ -172,8 +170,13 @@ void apply_drop_and_fill_control(T* row_values,
 
     const int offdiag_quota = std::max(0, static_cast<int>(std::ceil(params.fill_factor * static_cast<RealT<T>>(original_row_nnz))) - 1);
     if (static_cast<int>(candidates.size()) > offdiag_quota) {
+        // Ties are broken by column position so the surviving pattern is a function of
+        // the input alone. Leaving it to std::sort's unspecified order would make the
+        // factor depend on the sort implementation, and would stop the host and device
+        // paths from producing the same result.
         std::sort(candidates.begin(), candidates.end(), [](const auto& lhs, const auto& rhs) {
-            return lhs.first > rhs.first;
+            if (lhs.first != rhs.first) return lhs.first > rhs.first;
+            return lhs.second < rhs.second;
         });
         for (int drop_idx = offdiag_quota; drop_idx < static_cast<int>(candidates.size()); ++drop_idx) {
             const int idx = candidates[static_cast<std::size_t>(drop_idx)].second;
@@ -283,26 +286,18 @@ LevelSchedule build_level_schedule(const std::vector<int>& row_offsets,
     return out;
 }
 
-// How many host threads the numeric phase may use. A library that unilaterally
-// grabs every core fights a caller that is already parallel over its own work, so
-// this stays modest by default and BATCHLAS_ILUK_THREADS overrides it (1 = serial).
-//
-// The batch floor is measured, not guessed: below 64 elements threading was a net
-// loss (0.55-0.74x at batch 16), and above it a gain of 1.4-1.8x. The gain is
-// modest because the phase is memory-bound rather than compute-bound, so this
-// narrows the large-batch formation cost without eliminating it -- doing that
-// means factorizing on the device.
-constexpr int kILUKMinBatchForThreads = 64;
-
-int iluk_factor_thread_count(int batch_size) {
-    if (batch_size < kILUKMinBatchForThreads) return 1;
-    if (const char* v = std::getenv("BATCHLAS_ILUK_THREADS")) {
-        const int requested = std::atoi(v);
-        if (requested >= 1) return std::min(requested, batch_size);
+// Which numeric path to take. The device path has a fixed cost per call -- one
+// kernel launch per dependency level, plus a few host round trips -- that does not
+// shrink for small problems, while the host path costs time proportional to the
+// batch. Measured on a 2D Laplacian the two cross at roughly 32 elements.
+// BATCHLAS_ILUK_DEVICE forces either side, which is also how the two are checked
+// against each other.
+bool iluk_prefer_device(int batch_size) {
+    if (const char* v = std::getenv("BATCHLAS_ILUK_DEVICE")) {
+        if (v[0] == '0') return false;
+        if (v[0] == '1') return true;
     }
-    const unsigned hw = std::thread::hardware_concurrency();
-    const int cap = hw == 0 ? 1 : static_cast<int>(hw / 2);
-    return std::max(1, std::min(cap, batch_size));
+    return batch_size >= 32;
 }
 
 // Everything ILU(k) computes on the host, in a storage-agnostic form. The
@@ -486,36 +481,10 @@ HostFactor<T> compute_iluk(const MatrixView<T, MatrixFormat::CSR>& A, const ILUK
         }
     };
 
-    const int num_threads = iluk_factor_thread_count(batch_size);
-    if (num_threads <= 1) {
+    {
         std::vector<int> col_to_slot(static_cast<std::size_t>(n), -1);
         std::vector<std::pair<RealT<T>, int>> candidates;
         for (int b = 0; b < batch_size; ++b) factor_batch_element(b, col_to_slot, candidates);
-    } else {
-        // A pivot failure throws from inside the worker; letting that escape a
-        // std::thread would call std::terminate, so it is captured and rethrown on
-        // the calling thread after every worker has been joined.
-        std::atomic<int> next_element{0};
-        std::vector<std::exception_ptr> errors(static_cast<std::size_t>(num_threads));
-        std::vector<std::thread> workers;
-        workers.reserve(static_cast<std::size_t>(num_threads));
-        for (int t = 0; t < num_threads; ++t) {
-            workers.emplace_back([&, t]() {
-                std::vector<int> col_to_slot(static_cast<std::size_t>(n), -1);
-                std::vector<std::pair<RealT<T>, int>> candidates;
-                try {
-                    for (int b = next_element.fetch_add(1); b < batch_size; b = next_element.fetch_add(1)) {
-                        factor_batch_element(b, col_to_slot, candidates);
-                    }
-                } catch (...) {
-                    errors[static_cast<std::size_t>(t)] = std::current_exception();
-                }
-            });
-        }
-        for (auto& w : workers) w.join();
-        for (auto& e : errors) {
-            if (e) std::rethrow_exception(e);
-        }
     }
 
     for (int b = 0; b < batch_size; ++b) {
@@ -580,6 +549,592 @@ HostFactor<T> compute_iluk(const MatrixView<T, MatrixFormat::CSR>& A, const ILUK
     return out;
 }
 
+// Copy a host-computed factor into caller storage. Only used on the small-batch
+// path, where the copy is proportional to a batch the host already walked.
+template <typename T>
+void write_host_factor(const HostFactor<T>& host,
+                       int n,
+                       int batch,
+                       Span<T> values,
+                       Span<int> col_indices,
+                       Span<int> row_offsets,
+                       Span<int> diag_positions,
+                       int matrix_stride,
+                       int offset_stride) {
+    const int nnz = host.nnz;
+    for (int b = 0; b < batch; ++b) {
+        const std::size_t src_base = static_cast<std::size_t>(b) * static_cast<std::size_t>(nnz);
+        const std::size_t val_base = static_cast<std::size_t>(b) * static_cast<std::size_t>(matrix_stride);
+        const std::size_t ro_base = static_cast<std::size_t>(b) * static_cast<std::size_t>(offset_stride);
+        for (int i = 0; i < n + 1; ++i) row_offsets[ro_base + static_cast<std::size_t>(i)] = host.row_offsets[static_cast<std::size_t>(i)];
+        for (int p = 0; p < nnz; ++p) {
+            col_indices[val_base + static_cast<std::size_t>(p)] = host.col_indices[static_cast<std::size_t>(p)];
+            values[val_base + static_cast<std::size_t>(p)] = host.values[src_base + static_cast<std::size_t>(p)];
+        }
+        for (int i = 0; i < n; ++i) {
+            diag_positions[static_cast<std::size_t>(b * n + i)] =
+                static_cast<int>(val_base) + host.diag_offsets[static_cast<std::size_t>(i)];
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Device factorization
+//
+// The batch shares one sparsity pattern, so every *index* the numeric phase
+// needs -- which slot each elimination reads, which slot it updates, which rows
+// may run concurrently -- depends only on that pattern and can be computed once
+// on the host regardless of batch size. What is left for the device is pure
+// arithmetic over each batch element's values, which is what actually scales.
+// ---------------------------------------------------------------------------
+
+template <Backend B, typename T> struct ILUKSparsityCheckKernel;
+template <Backend B, typename T> struct ILUKZeroKernel;
+template <Backend B, typename T> struct ILUKScatterKernel;
+template <Backend B, typename T> struct ILUKRowOffsetKernel;
+template <Backend B, typename T> struct ILUKDiagPosKernel;
+template <Backend B, typename T> struct ILUKEliminateKernel;
+template <Backend B, typename T> struct ILUKUnionKernel;
+template <Backend B, typename T> struct ILUKGatherKernel;
+template <Backend B, typename T> struct ILUKDiagCheckKernel;
+
+// Kernel-safe counterpart of stabilize_pivot_or_mark: reports an unusable pivot
+// through `status` instead of throwing, since the host cannot catch an exception
+// raised inside a kernel. The caller rechecks status once, after the queue drains.
+template <typename T>
+inline T stabilize_pivot_no_throw(const T& pivot,
+                                  RealT<T> scale,
+                                  const T& diagonal_shift,
+                                  RealT<T> diag_pivot_threshold,
+                                  int32_t* status) {
+    const auto shift_mag = abs_value(diagonal_shift);
+    const auto pivot_mag = abs_value(pivot);
+    const auto one = RealT<T>(1);
+    const auto scaled = diag_pivot_threshold * (scale > one ? scale : one);
+    const auto threshold = shift_mag > scaled ? shift_mag : scaled;
+
+    if (pivot_mag >= threshold && pivot_mag > RealT<T>(0)) return pivot;
+    if (shift_mag > RealT<T>(0)) {
+        const T shifted = pivot + diagonal_shift;
+        if (abs_value(shifted) >= threshold && abs_value(shifted) > RealT<T>(0)) return shifted;
+        if (shift_mag >= threshold) return diagonal_shift;
+    }
+    if (threshold > RealT<T>(0)) return real_scalar<T>(threshold);
+    if (status != nullptr) *status = 1;
+    return T(1);
+}
+
+// Everything about an ILU(k) factorization that is fixed by A's sparsity pattern.
+// Building this costs the same as one batch element's structural walk no matter
+// how large the batch is.
+struct ILUKSymbolic {
+    int n = 0;
+    int sym_nnz = 0;
+    int a_nnz = 0;
+    std::vector<int> sym_ro;          // n + 1
+    std::vector<int> sym_ci;          // sym_nnz
+    std::vector<int> diag_abs;        // n, absolute slot of each row's diagonal
+    std::vector<int> original_row_nnz;// n, row counts of A (drives the fill quota)
+    std::vector<int> a_to_sym;        // a_nnz, where each entry of A lands
+    std::vector<int> is_diag;         // sym_nnz
+
+    // Elimination schedule. Row i performs steps [step_ptr[i], step_ptr[i+1]);
+    // step e divides slot step_target[e] by the pivot row's diagonal at
+    // step_pivot_diag[e], then applies updates [step_upd_ptr[e], step_upd_ptr[e+1]).
+    std::vector<int> step_ptr;        // n + 1
+    std::vector<int> step_target;
+    std::vector<int> step_pivot_diag;
+    std::vector<int> step_upd_ptr;    // steps + 1
+    std::vector<int> upd_src;
+    std::vector<int> upd_dst;
+
+    // Rows within one level depend only on earlier levels, so a level's rows can
+    // be eliminated concurrently across the whole batch.
+    LevelSchedule levels;
+};
+
+ILUKSymbolic build_iluk_symbolic(const Span<int>& ro, const Span<int>& ci, int n, int a_nnz, int level_k) {
+    ILUKSymbolic s;
+    s.n = n;
+    s.a_nnz = a_nnz;
+    const auto rows = symbolic_iluk_pattern_single(ro, ci, n, 0, 0, level_k);
+
+    s.sym_ro.assign(static_cast<std::size_t>(n) + 1, 0);
+    for (int i = 0; i < n; ++i) {
+        s.sym_ro[static_cast<std::size_t>(i + 1)] =
+            s.sym_ro[static_cast<std::size_t>(i)] + static_cast<int>(rows[static_cast<std::size_t>(i)].size());
+    }
+    s.sym_nnz = s.sym_ro[static_cast<std::size_t>(n)];
+    s.sym_ci.resize(static_cast<std::size_t>(s.sym_nnz));
+    for (int i = 0; i < n; ++i) {
+        std::copy(rows[static_cast<std::size_t>(i)].begin(), rows[static_cast<std::size_t>(i)].end(),
+                  s.sym_ci.begin() + s.sym_ro[static_cast<std::size_t>(i)]);
+    }
+
+    s.diag_abs.assign(static_cast<std::size_t>(n), -1);
+    s.original_row_nnz.assign(static_cast<std::size_t>(n), 0);
+    s.is_diag.assign(static_cast<std::size_t>(s.sym_nnz), 0);
+    std::vector<int> diag_local(static_cast<std::size_t>(n), -1);
+    for (int i = 0; i < n; ++i) {
+        s.original_row_nnz[static_cast<std::size_t>(i)] = ro[i + 1] - ro[i];
+        const int rs = s.sym_ro[static_cast<std::size_t>(i)];
+        const int re = s.sym_ro[static_cast<std::size_t>(i + 1)];
+        for (int p = rs; p < re; ++p) {
+            if (s.sym_ci[static_cast<std::size_t>(p)] == i) {
+                s.diag_abs[static_cast<std::size_t>(i)] = p;
+                diag_local[static_cast<std::size_t>(i)] = p - rs;
+                s.is_diag[static_cast<std::size_t>(p)] = 1;
+                break;
+            }
+        }
+        if (s.diag_abs[static_cast<std::size_t>(i)] < 0) {
+            throw std::runtime_error("ILU(k): symbolic phase produced a row without diagonal");
+        }
+    }
+
+    // Where each entry of A lands in the symbolic pattern.
+    s.a_to_sym.assign(static_cast<std::size_t>(a_nnz), -1);
+    std::vector<int> col_to_slot(static_cast<std::size_t>(n), -1);
+    for (int i = 0; i < n; ++i) {
+        const int rs = s.sym_ro[static_cast<std::size_t>(i)];
+        const int re = s.sym_ro[static_cast<std::size_t>(i + 1)];
+        for (int p = rs; p < re; ++p) col_to_slot[static_cast<std::size_t>(s.sym_ci[static_cast<std::size_t>(p)])] = p;
+        for (int p = ro[i]; p < ro[i + 1]; ++p) {
+            s.a_to_sym[static_cast<std::size_t>(p)] = col_to_slot[static_cast<std::size_t>(ci[p])];
+        }
+        for (int p = rs; p < re; ++p) col_to_slot[static_cast<std::size_t>(s.sym_ci[static_cast<std::size_t>(p)])] = -1;
+    }
+
+    // Elimination schedule. The host path skips updates whose source was dropped;
+    // dropped entries are set to zero, so applying them anyway is a no-op and the
+    // schedule stays independent of the values.
+    s.step_ptr.assign(static_cast<std::size_t>(n) + 1, 0);
+    s.step_upd_ptr.push_back(0);
+    for (int i = 0; i < n; ++i) {
+        const int rs = s.sym_ro[static_cast<std::size_t>(i)];
+        const int re = s.sym_ro[static_cast<std::size_t>(i + 1)];
+        for (int p = rs; p < re; ++p) col_to_slot[static_cast<std::size_t>(s.sym_ci[static_cast<std::size_t>(p)])] = p;
+
+        for (int p = rs; p < re; ++p) {
+            const int j = s.sym_ci[static_cast<std::size_t>(p)];
+            if (j >= i) break;
+            s.step_target.push_back(p);
+            s.step_pivot_diag.push_back(s.diag_abs[static_cast<std::size_t>(j)]);
+
+            const int prs = s.sym_ro[static_cast<std::size_t>(j)];
+            const int pre = s.sym_ro[static_cast<std::size_t>(j + 1)];
+            for (int q = s.diag_abs[static_cast<std::size_t>(j)] + 1; q < pre; ++q) {
+                const int dst = col_to_slot[static_cast<std::size_t>(s.sym_ci[static_cast<std::size_t>(q)])];
+                if (dst >= 0) {
+                    s.upd_src.push_back(q);
+                    s.upd_dst.push_back(dst);
+                }
+            }
+            (void)prs;
+            s.step_upd_ptr.push_back(static_cast<int>(s.upd_src.size()));
+        }
+        s.step_ptr[static_cast<std::size_t>(i + 1)] = static_cast<int>(s.step_target.size());
+
+        for (int p = rs; p < re; ++p) col_to_slot[static_cast<std::size_t>(s.sym_ci[static_cast<std::size_t>(p)])] = -1;
+    }
+
+    s.levels = build_level_schedule(s.sym_ro, s.sym_ci, n, /*lower=*/true);
+    return s;
+}
+
+template <typename U>
+UnifiedVector<U> to_device(const std::vector<U>& src) {
+    UnifiedVector<U> dst(src.size());
+    if (!src.empty()) std::copy(src.begin(), src.end(), dst.data());
+    return dst;
+}
+
+// The symbolic index arrays are small but numerous, and one managed allocation
+// each turned out to dominate the cost of factorizing a single small system.
+// Packing them into one buffer keeps that fixed overhead to a single allocation.
+struct PackedInts {
+    UnifiedVector<int> buffer;
+    std::vector<int> offsets;
+    int tail_offset = 0;
+
+    const int* at(std::size_t which) const { return buffer.data() + offsets[which]; }
+    int* tail() { return buffer.data() + tail_offset; }
+};
+
+// `tail` reserves uninitialised trailing room in the same allocation, used for the
+// compaction scratch and status flags so the whole factorization needs one integer
+// buffer rather than one per array.
+PackedInts pack_ints(std::initializer_list<const std::vector<int>*> arrays, std::size_t tail) {
+    PackedInts packed;
+    std::size_t total = 0;
+    packed.offsets.reserve(arrays.size());
+    for (const auto* a : arrays) {
+        packed.offsets.push_back(static_cast<int>(total));
+        total += a->size();
+    }
+    packed.tail_offset = static_cast<int>(total);
+    packed.buffer = UnifiedVector<int>(total + tail == 0 ? 1 : total + tail);
+    std::size_t cursor = 0;
+    for (const auto* a : arrays) {
+        if (!a->empty()) std::copy(a->begin(), a->end(), packed.buffer.data() + cursor);
+        cursor += a->size();
+    }
+    return packed;
+}
+
+// Batch elements must share a pattern. Checking that on the host means reading
+// every element's indices back across the bus, which is exactly the kind of
+// batch-proportional host work this path exists to avoid.
+template <Backend B, typename T>
+void check_batch_sparsity_on_device(Queue& ctx, const MatrixView<T, MatrixFormat::CSR>& A) {
+    const int batch = A.batch_size();
+    if (batch <= 1) return;
+    const int rows = A.rows();
+    const int nnz = A.nnz();
+    UnifiedVector<int32_t> mismatch(1, 0);
+    auto kv = A.kernel_view();
+    auto* flag = mismatch.data();
+    const int per_element = rows + 1 + nnz;
+    ctx->parallel_for<ILUKSparsityCheckKernel<B, T>>(
+        sycl::range<1>(static_cast<size_t>(batch - 1) * per_element), [=](sycl::id<1> id) {
+        const int linear = static_cast<int>(id[0]);
+        const int b = linear / per_element + 1;
+        const int k = linear % per_element;
+        if (k <= rows) {
+            if (kv.row_offsets_[b * kv.offset_stride_ + k] != kv.row_offsets_[k]) *flag = 1;
+        } else {
+            const int p = k - rows - 1;
+            if (kv.col_indices_[b * kv.matrix_stride_ + p] != kv.col_indices_[p]) *flag = 1;
+        }
+    });
+    ctx.wait_and_throw();
+    if (mismatch[0] != 0) {
+        throw std::invalid_argument(
+            "ILU(k): heterogeneous batch sparsity is not supported; batches must share an identical CSR pattern");
+    }
+}
+
+template <typename T>
+struct DeviceFactorOut {
+    int nnz = 0;
+    std::vector<int> row_offsets;    // n + 1, shared by the batch
+    std::vector<int> col_indices;    // nnz, shared by the batch
+    std::vector<int> diag_offsets;   // n, offset of each diagonal within one element
+    LevelSchedule l;
+    LevelSchedule u;
+    UnifiedVector<T> work;           // sym_nnz * batch, laid out slot-major
+    // The single integer buffer: symbolic index arrays followed by the compaction
+    // scratch (keep-union flags, compact_to_sym, compacted column indices, row
+    // offsets, diagonal offsets) and the status flags.
+    UnifiedVector<int> ints;
+    int compact_offset = 0, col_offset = 0, row_offset = 0, diag_offset = 0;
+    bool u_diagonals_usable = false;
+};
+
+// The working values are stored slot-major (`work[slot * batch + b]`) rather than
+// batch-major. One work-item handles one (row, batch element) pair, so adjacent
+// work-items differ in b -- slot-major makes those accesses contiguous. The final
+// gather transposes into the CSR batch-major layout the apply kernel expects.
+template <Backend B, typename T>
+DeviceFactorOut<T> run_device_numeric(Queue& ctx,
+                                      const MatrixView<T, MatrixFormat::CSR>& A,
+                                      const ILUKSymbolic& sym,
+                                      const ILUKParams<T>& params) {
+    const int n = sym.n;
+    const int batch = A.batch_size();
+    const int sym_nnz = sym.sym_nnz;
+
+    // Layout of the reserved tail: keep-union flags, compact_to_sym, compacted column
+    // indices (each at most sym_nnz), row offsets, diagonal offsets, then two status ints.
+    const std::size_t ku_off = 0;
+    const std::size_t c2s_off = ku_off + static_cast<std::size_t>(sym_nnz);
+    const std::size_t ci_off = c2s_off + static_cast<std::size_t>(sym_nnz);
+    const std::size_t ro_off = ci_off + static_cast<std::size_t>(sym_nnz);
+    const std::size_t do_off = ro_off + static_cast<std::size_t>(n) + 1;
+    const std::size_t status_off = do_off + static_cast<std::size_t>(n);
+    auto packed = pack_ints({&sym.sym_ro, &sym.diag_abs, &sym.original_row_nnz, &sym.a_to_sym,
+                                   &sym.step_ptr, &sym.step_target, &sym.step_pivot_diag,
+                                   &sym.step_upd_ptr, &sym.upd_src, &sym.upd_dst,
+                                   &sym.levels.rows, &sym.levels.level_ptr, &sym.is_diag},
+                            status_off + 2);
+    // Index map for `packed`: 0 sym_ro, 1 diag_abs, 2 original_row_nnz, 3 a_to_sym,
+    // 4 step_ptr, 5 step_target, 6 step_pivot_diag, 7 step_upd_ptr, 8 upd_src,
+    // 9 upd_dst, 10 levels.rows, 11 levels.level_ptr, 12 is_diag.
+
+    DeviceFactorOut<T> out;
+    out.work = UnifiedVector<T>(static_cast<std::size_t>(sym_nnz) * static_cast<std::size_t>(batch));
+    // status[0] flags an unusable pivot during elimination, status[1] an unusable U
+    // diagonal afterwards.
+    int* status = packed.tail() + status_off;
+    status[0] = 0;
+    status[1] = 0;
+
+    auto* work = out.work.data();
+    auto* st = status;
+    const auto akv = A.kernel_view();
+    const auto* a_to_sym = packed.at(3);
+
+    // Scatter A into the symbolic pattern; slots with no counterpart stay zero.
+    const int a_nnz = sym.a_nnz;
+    ctx->parallel_for<ILUKZeroKernel<B, T>>(
+        sycl::range<1>(static_cast<size_t>(sym_nnz) * batch), [=](sycl::id<1> id) {
+        work[id[0]] = T(0);
+    });
+    ctx.wait_and_throw();  // the zero fill must land before A is scattered over it
+    ctx->parallel_for<ILUKScatterKernel<B, T>>(
+        sycl::range<1>(static_cast<size_t>(a_nnz) * batch), [=](sycl::id<1> id) {
+        const int linear = static_cast<int>(id[0]);
+        const int p = linear / batch;
+        const int b = linear % batch;
+        const int slot = a_to_sym[p];
+        if (slot >= 0) work[static_cast<size_t>(slot) * batch + b] = akv.data_[b * akv.matrix_stride_ + p];
+    });
+
+    const auto* sym_ro = packed.at(0);
+    const auto* diag_abs = packed.at(1);
+    const auto* orig_nnz = packed.at(2);
+    const auto* step_ptr = packed.at(4);
+    const auto* step_target = packed.at(5);
+    const auto* step_pivot = packed.at(6);
+    const auto* step_upd_ptr = packed.at(7);
+    const auto* upd_src = packed.at(8);
+    const auto* upd_dst = packed.at(9);
+    const auto* level_rows = packed.at(10);
+
+    const auto drop_tolerance = params.drop_tolerance;
+    const auto fill_factor = params.fill_factor;
+    const auto diag_pivot_threshold = params.diag_pivot_threshold;
+    const T diagonal_shift = params.diagonal_shift;
+    const bool modified_ilu = params.modified_ilu;
+
+    // One kernel launch per dependency level. The launch count follows the
+    // factor's depth, which is a property of the pattern, so it does not grow
+    // with the batch -- the batch only makes each launch wider.
+    // Level kernels must run in order, but that ordering is the queue's job. Waiting
+    // on the host between levels cost one round trip per level -- 53 of them for a
+    // 4096-row ILU(1) factor -- which is why an in-order queue is used here instead.
+    Queue ordered(ctx, /*in_order=*/true);
+    Queue& q = ctx.in_order() ? ctx : ordered;
+    if (!ctx.in_order()) {
+        Event dep = ctx.get_event();
+        ordered.enqueue(dep);
+    }
+    for (int lv = 0; lv < sym.levels.levels; ++lv) {
+        const int begin = sym.levels.level_ptr[static_cast<std::size_t>(lv)];
+        const int end = sym.levels.level_ptr[static_cast<std::size_t>(lv) + 1];
+        const int count = end - begin;
+        if (count <= 0) continue;
+        q->parallel_for<ILUKEliminateKernel<B, T>>(
+            sycl::range<1>(static_cast<size_t>(count) * batch), [=](sycl::id<1> id) {
+            const int linear = static_cast<int>(id[0]);
+            const int t = linear / batch;
+            const int b = linear % batch;
+            const int i = level_rows[begin + t];
+
+            auto at = [&](int slot) -> T& { return work[static_cast<size_t>(slot) * batch + b]; };
+
+            for (int e = step_ptr[i]; e < step_ptr[i + 1]; ++e) {
+                const T lij = at(step_target[e]) / at(step_pivot[e]);
+                at(step_target[e]) = lij;
+                for (int u = step_upd_ptr[e]; u < step_upd_ptr[e + 1]; ++u) {
+                    at(upd_dst[u]) -= lij * at(upd_src[u]);
+                }
+            }
+
+            const int rs = sym_ro[i];
+            const int re = sym_ro[i + 1];
+            const int dg = diag_abs[i];
+
+            RealT<T> scale = RealT<T>(0);
+            for (int p = rs; p < re; ++p) {
+                const auto m = abs_value(at(p));
+                if (m > scale) scale = m;
+            }
+            const auto one = RealT<T>(1);
+            const auto threshold = drop_tolerance * (scale > one ? scale : one);
+
+            int kept = 0;
+            for (int p = rs; p < re; ++p) {
+                if (p == dg) continue;
+                if (abs_value(at(p)) <= threshold) {
+                    if (modified_ilu) at(dg) += at(p);
+                    at(p) = T(0);
+                } else {
+                    ++kept;
+                }
+            }
+
+            // Fill quota: keep the largest `quota` off-diagonal entries. Repeatedly
+            // dropping the smallest survivor is equivalent to sorting and truncating,
+            // and avoids needing per-row scratch in the kernel. With the default
+            // fill_factor this loop does not run at all.
+            const int quota_raw = static_cast<int>(sycl::ceil(fill_factor * static_cast<RealT<T>>(orig_nnz[i]))) - 1;
+            const int quota = quota_raw > 0 ? quota_raw : 0;
+            while (kept > quota) {
+                int victim = -1;
+                RealT<T> smallest = RealT<T>(0);
+                for (int p = rs; p < re; ++p) {
+                    if (p == dg) continue;
+                    const auto m = abs_value(at(p));
+                    if (m == RealT<T>(0)) continue;
+                    // Smallest magnitude wins; on a tie the later column is dropped, which
+                    // is the same survivor set the host path's tie-break produces.
+                    if (victim < 0 || m < smallest || (m == smallest && p > victim)) {
+                        victim = p;
+                        smallest = m;
+                    }
+                }
+                if (victim < 0) break;
+                if (modified_ilu) at(dg) += at(victim);
+                at(victim) = T(0);
+                --kept;
+            }
+
+            RealT<T> final_scale = RealT<T>(0);
+            for (int p = rs; p < re; ++p) {
+                const auto m = abs_value(at(p));
+                if (m > final_scale) final_scale = m;
+            }
+            at(dg) = stabilize_pivot_no_throw(at(dg), final_scale, diagonal_shift, diag_pivot_threshold, st);
+        });
+    }
+    q.wait_and_throw();
+
+    if (status[0] != 0) {
+        throw std::runtime_error(
+            "ILU(k): encountered a zero or effectively zero pivot without a usable diagonal shift");
+    }
+
+    // An entry survives compaction if any batch element kept it. Reducing over the
+    // batch on the device leaves the host with sym_nnz flags to scan -- a figure
+    // that does not depend on the batch size.
+    // One scratch buffer covering keep_union, compact_to_sym, the compacted row
+    // offsets, column indices and diagonal offsets. compact_to_sym cannot exceed
+    // sym_nnz, so the whole layout is known before compaction runs.
+    auto* ku = packed.tail() + ku_off;
+    const auto* is_diag = packed.at(12);
+    ctx->parallel_for<ILUKUnionKernel<B, T>>(sycl::range<1>(static_cast<size_t>(sym_nnz)), [=](sycl::id<1> id) {
+        const size_t slot = id[0];
+        int keep = is_diag[slot];
+        for (int b = 0; b < batch && keep == 0; ++b) {
+            // Dropped entries were zeroed, and any entry at or below the drop
+            // threshold was dropped, so a non-zero value is exactly a kept one.
+            if (abs_value(work[slot * batch + b]) != RealT<T>(0)) keep = 1;
+        }
+        ku[slot] = keep;
+    });
+    ctx.wait_and_throw();
+
+    // Compaction is a scan over sym_nnz flags -- a figure fixed by the pattern, so
+    // this host pass does not grow with the batch.
+    int* c2s_w = packed.tail() + c2s_off;
+    int* ci_w = packed.tail() + ci_off;
+    int* ro_w = packed.tail() + ro_off;
+    int* do_w = packed.tail() + do_off;
+    out.row_offsets.assign(static_cast<std::size_t>(n) + 1, 0);
+    out.diag_offsets.assign(static_cast<std::size_t>(n), 0);
+    out.col_indices.reserve(static_cast<std::size_t>(sym_nnz));
+    int cursor = 0;
+    ro_w[0] = 0;
+    for (int i = 0; i < n; ++i) {
+        const int rs = sym.sym_ro[static_cast<std::size_t>(i)];
+        const int re = sym.sym_ro[static_cast<std::size_t>(i + 1)];
+        int kept = 0;
+        for (int p = rs; p < re; ++p) {
+            if (ku[p] == 0) continue;
+            if (p == sym.diag_abs[static_cast<std::size_t>(i)]) {
+                out.diag_offsets[static_cast<std::size_t>(i)] = out.row_offsets[static_cast<std::size_t>(i)] + kept;
+            }
+            c2s_w[cursor] = p;
+            ci_w[cursor] = sym.sym_ci[static_cast<std::size_t>(p)];
+            out.col_indices.push_back(sym.sym_ci[static_cast<std::size_t>(p)]);
+            ++cursor;
+            ++kept;
+        }
+        out.row_offsets[static_cast<std::size_t>(i + 1)] = out.row_offsets[static_cast<std::size_t>(i)] + kept;
+        ro_w[i + 1] = out.row_offsets[static_cast<std::size_t>(i + 1)];
+    }
+    out.nnz = cursor;
+    for (int i = 0; i < n; ++i) do_w[i] = out.diag_offsets[static_cast<std::size_t>(i)];
+
+    out.l = build_level_schedule(out.row_offsets, out.col_indices, n, /*lower=*/true);
+    out.u = build_level_schedule(out.row_offsets, out.col_indices, n, /*lower=*/false);
+
+    // Whether every U diagonal can be shifted into usability, reduced on the device
+    // so the host reads one flag rather than n * batch values.
+    auto* df = status + 1;
+    const auto* c2s = packed.tail() + c2s_off;
+    const auto* diag_off = packed.tail() + do_off;
+    ctx->parallel_for<ILUKDiagCheckKernel<B, T>>(
+        sycl::range<1>(static_cast<size_t>(n) * batch), [=](sycl::id<1> id) {
+        const int linear = static_cast<int>(id[0]);
+        const int i = linear / batch;
+        const int b = linear % batch;
+        const int slot = c2s[diag_off[i]];
+        int32_t local = 0;
+        (void)stabilize_pivot_no_throw(work[static_cast<size_t>(slot) * batch + b], RealT<T>(0),
+                                       diagonal_shift, RealT<T>(0), &local);
+        if (local != 0) *df = 1;
+    });
+    ctx.wait_and_throw();
+    out.u_diagonals_usable = (status[1] == 0);
+    out.ints = std::move(packed.buffer);
+    out.compact_offset = static_cast<int>(packed.tail_offset + c2s_off);
+    out.col_offset = static_cast<int>(packed.tail_offset + ci_off);
+    out.row_offset = static_cast<int>(packed.tail_offset + ro_off);
+    out.diag_offset = static_cast<int>(packed.tail_offset + do_off);
+    return out;
+}
+
+// Transpose the slot-major working values into the batch-major CSR the apply
+// kernel reads, and fill in the replicated pattern and diagonal positions.
+template <Backend B, typename T>
+void write_factor_to_storage(Queue& ctx,
+                             const DeviceFactorOut<T>& dev,
+                             int n,
+                             int batch,
+                             Span<T> values,
+                             Span<int> col_indices,
+                             Span<int> row_offsets,
+                             Span<int> diag_positions,
+                             int matrix_stride,
+                             int offset_stride) {
+    const int nnz = dev.nnz;
+    auto* vals = values.data();
+    auto* ci = col_indices.data();
+    auto* ro = row_offsets.data();
+    auto* dp = diag_positions.data();
+    const auto* c2s = dev.ints.data() + dev.compact_offset;
+    const auto* src = dev.work.data();
+    const auto* host_ro = dev.ints.data() + dev.row_offset;
+    const auto* host_ci = dev.ints.data() + dev.col_offset;
+    const auto* diag_off = dev.ints.data() + dev.diag_offset;
+
+    ctx->parallel_for<ILUKGatherKernel<B, T>>(
+        sycl::range<1>(static_cast<size_t>(nnz) * batch), [=](sycl::id<1> id) {
+        const int linear = static_cast<int>(id[0]);
+        const int q = linear / batch;
+        const int b = linear % batch;
+        vals[static_cast<size_t>(b) * matrix_stride + q] = src[static_cast<size_t>(c2s[q]) * batch + b];
+        ci[static_cast<size_t>(b) * matrix_stride + q] = host_ci[q];
+    });
+    ctx->parallel_for<ILUKRowOffsetKernel<B, T>>(
+        sycl::range<1>(static_cast<size_t>(n + 1) * batch), [=](sycl::id<1> id) {
+        const int linear = static_cast<int>(id[0]);
+        const int i = linear / batch;
+        const int b = linear % batch;
+        ro[static_cast<size_t>(b) * offset_stride + i] = host_ro[i];
+    });
+    ctx->parallel_for<ILUKDiagPosKernel<B, T>>(
+        sycl::range<1>(static_cast<size_t>(n) * batch), [=](sycl::id<1> id) {
+        const int linear = static_cast<int>(id[0]);
+        const int i = linear / batch;
+        const int b = linear % batch;
+        dp[static_cast<size_t>(b) * n + i] = b * matrix_stride + diag_off[i];
+    });
+    ctx.wait_and_throw();
+}
+
 }  // namespace
 
 template <typename T>
@@ -619,13 +1174,46 @@ template <Backend B, typename T>
 ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
                                      const MatrixView<T, MatrixFormat::CSR>& A,
                                      const ILUKParams<T>& params) {
-    (void)ctx;
-    const auto host = compute_iluk(A, params);
-    const int n = host.n;
-    const int batch_size = host.batch_size;
+    validate_iluk_params_or_throw(A, params, /*check_batch_sparsity=*/false);
+    check_batch_sparsity_on_device<B, T>(ctx, A);
+
+    const int n = A.rows();
+    const int batch_size = A.batch_size();
+
+    if (!iluk_prefer_device(batch_size)) {
+        const auto host = compute_iluk(A, params);
+        ILUKPreconditioner<T> result;
+        result.lu = Matrix<T, MatrixFormat::CSR>(n, n, host.nnz, batch_size);
+        result.diag_positions = UnifiedVector<int>(static_cast<std::size_t>(n) * static_cast<std::size_t>(batch_size));
+        result.n = n;
+        result.batch_size = batch_size;
+        result.levels_of_fill = params.levels_of_fill;
+        result.diagonal_shift = params.diagonal_shift;
+        result.drop_tolerance = params.drop_tolerance;
+        result.fill_factor = params.fill_factor;
+        result.diag_pivot_threshold = params.diag_pivot_threshold;
+        result.modified_ilu = params.modified_ilu;
+        result.l_rows = to_device(host.l.rows);
+        result.l_level_ptr = to_device(host.l.level_ptr);
+        result.l_levels = host.l.levels;
+        result.u_rows = to_device(host.u.rows);
+        result.u_level_ptr = to_device(host.u.level_ptr);
+        result.u_levels = host.u.levels;
+        auto host_view = result.lu.view();
+        write_host_factor(host, n, batch_size, host_view.data(), host_view.col_indices(),
+                          host_view.row_offsets(), result.diag_positions,
+                          host_view.matrix_stride(), host_view.offset_stride());
+        result.u_diagonals_usable = u_diagonals_are_usable(host_view.data().data(),
+                                                           result.diag_positions.data(), n, batch_size,
+                                                           result.diagonal_shift);
+        return result;
+    }
+
+    const auto sym = build_iluk_symbolic(A.row_offsets(), A.col_indices(), n, A.nnz(), params.levels_of_fill);
+    auto dev = run_device_numeric<B, T>(ctx, A, sym, params);
 
     ILUKPreconditioner<T> result;
-    result.lu = Matrix<T, MatrixFormat::CSR>(n, n, host.nnz, batch_size);
+    result.lu = Matrix<T, MatrixFormat::CSR>(n, n, dev.nnz, batch_size);
     result.diag_positions = UnifiedVector<int>(static_cast<std::size_t>(n) * static_cast<std::size_t>(batch_size));
     result.n = n;
     result.batch_size = batch_size;
@@ -636,38 +1224,18 @@ ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
     result.diag_pivot_threshold = params.diag_pivot_threshold;
     result.modified_ilu = params.modified_ilu;
 
-    auto to_unified = [](const std::vector<int>& src) {
-        UnifiedVector<int> dst(src.size());
-        for (std::size_t i = 0; i < src.size(); ++i) dst[i] = src[i];
-        return dst;
-    };
-    result.l_rows = to_unified(host.l.rows);
-    result.l_level_ptr = to_unified(host.l.level_ptr);
-    result.l_levels = host.l.levels;
-    result.u_rows = to_unified(host.u.rows);
-    result.u_level_ptr = to_unified(host.u.level_ptr);
-    result.u_levels = host.u.levels;
+    result.l_rows = to_device(dev.l.rows);
+    result.l_level_ptr = to_device(dev.l.level_ptr);
+    result.l_levels = dev.l.levels;
+    result.u_rows = to_device(dev.u.rows);
+    result.u_level_ptr = to_device(dev.u.level_ptr);
+    result.u_levels = dev.u.levels;
 
     auto lu_view = result.lu.view();
-    auto lu_ro = lu_view.row_offsets();
-    auto lu_ci = lu_view.col_indices();
-    auto lu_vals = lu_view.data();
-    for (int b = 0; b < batch_size; ++b) {
-        const int ro_base = b * lu_view.offset_stride();
-        const int val_base = b * lu_view.matrix_stride();
-        for (int i = 0; i < n + 1; ++i) lu_ro[ro_base + i] = host.row_offsets[static_cast<std::size_t>(i)];
-        for (int p = 0; p < host.nnz; ++p) {
-            lu_ci[val_base + p] = host.col_indices[static_cast<std::size_t>(p)];
-            lu_vals[val_base + p] = host.values[static_cast<std::size_t>(b) * static_cast<std::size_t>(host.nnz) + static_cast<std::size_t>(p)];
-        }
-        for (int i = 0; i < n; ++i) {
-            result.diag_positions[static_cast<std::size_t>(b * n + i)] = val_base + host.diag_offsets[static_cast<std::size_t>(i)];
-        }
-    }
-
-    result.u_diagonals_usable = u_diagonals_are_usable(lu_vals.data(), result.diag_positions.data(), n,
-                                                       batch_size, result.diagonal_shift);
-
+    write_factor_to_storage<B, T>(ctx, dev, n, batch_size, lu_view.data(), lu_view.col_indices(),
+                                  lu_view.row_offsets(), result.diag_positions,
+                                  lu_view.matrix_stride(), lu_view.offset_stride());
+    result.u_diagonals_usable = dev.u_diagonals_usable;
     return result;
 }
 
@@ -705,10 +1273,24 @@ ILUKView<T> iluk_factorize(Queue& ctx,
                            Span<std::byte> workspace,
                            const ILUKParams<T>& params,
                            size_t* bytes_used) {
-    const auto host = compute_iluk(A, params);
-    const int n = host.n;
-    const int batch_size = host.batch_size;
-    const int nnz = host.nnz;
+    validate_iluk_params_or_throw(A, params, /*check_batch_sparsity=*/false);
+    check_batch_sparsity_on_device<B, T>(ctx, A);
+
+    const int n = A.rows();
+    const int batch_size = A.batch_size();
+    const bool on_device = iluk_prefer_device(batch_size);
+
+    std::optional<HostFactor<T>> host;
+    std::optional<DeviceFactorOut<T>> dev_opt;
+    if (on_device) {
+        const auto sym = build_iluk_symbolic(A.row_offsets(), A.col_indices(), n, A.nnz(), params.levels_of_fill);
+        dev_opt = run_device_numeric<B, T>(ctx, A, sym, params);
+    } else {
+        host = compute_iluk(A, params);
+    }
+    const int nnz = on_device ? dev_opt->nnz : host->nnz;
+    const LevelSchedule& sched_l = on_device ? dev_opt->l : host->l;
+    const LevelSchedule& sched_u = on_device ? dev_opt->u : host->u;
 
     auto pool = BumpAllocator(workspace);
     auto values = pool.allocate<T>(ctx, static_cast<size_t>(nnz) * static_cast<size_t>(batch_size));
@@ -717,30 +1299,27 @@ ILUKView<T> iluk_factorize(Queue& ctx,
     auto diag_positions = pool.allocate<int>(ctx, static_cast<size_t>(n) * static_cast<size_t>(batch_size));
     auto l_rows = pool.allocate<int>(ctx, static_cast<size_t>(n));
     auto u_rows = pool.allocate<int>(ctx, static_cast<size_t>(n));
-    auto l_level_ptr = pool.allocate<int>(ctx, host.l.level_ptr.size());
-    auto u_level_ptr = pool.allocate<int>(ctx, host.u.level_ptr.size());
+    auto l_level_ptr = pool.allocate<int>(ctx, sched_l.level_ptr.size());
+    auto u_level_ptr = pool.allocate<int>(ctx, sched_u.level_ptr.size());
 
     // The pattern is identical across the batch, but the apply kernel indexes
     // values and column indices with the same matrix stride, so both are
     // replicated per batch element rather than shared.
-    for (int b = 0; b < batch_size; ++b) {
-        const size_t val_base = static_cast<size_t>(b) * static_cast<size_t>(nnz);
-        const size_t ro_base = static_cast<size_t>(b) * static_cast<size_t>(n + 1);
-        for (int i = 0; i < n + 1; ++i) row_offsets[ro_base + static_cast<size_t>(i)] = host.row_offsets[static_cast<std::size_t>(i)];
-        for (int p = 0; p < nnz; ++p) {
-            col_indices[val_base + static_cast<size_t>(p)] = host.col_indices[static_cast<std::size_t>(p)];
-            values[val_base + static_cast<size_t>(p)] = host.values[val_base + static_cast<size_t>(p)];
-        }
-        for (int i = 0; i < n; ++i) {
-            diag_positions[static_cast<size_t>(b * n + i)] = static_cast<int>(val_base) + host.diag_offsets[static_cast<std::size_t>(i)];
-        }
+    if (on_device) {
+        write_factor_to_storage<B, T>(ctx, *dev_opt, n, batch_size, values, col_indices, row_offsets,
+                                      diag_positions, nnz, n + 1);
+    } else {
+        write_host_factor(*host, n, batch_size, values, col_indices, row_offsets, diag_positions, nnz, n + 1);
     }
+
+    // The level schedules are a few n-sized arrays derived from the compacted
+    // pattern, so copying them on the host costs nothing that grows with batch.
     for (int i = 0; i < n; ++i) {
-        l_rows[static_cast<size_t>(i)] = host.l.rows[static_cast<std::size_t>(i)];
-        u_rows[static_cast<size_t>(i)] = host.u.rows[static_cast<std::size_t>(i)];
+        l_rows[static_cast<size_t>(i)] = sched_l.rows[static_cast<std::size_t>(i)];
+        u_rows[static_cast<size_t>(i)] = sched_u.rows[static_cast<std::size_t>(i)];
     }
-    for (std::size_t i = 0; i < host.l.level_ptr.size(); ++i) l_level_ptr[i] = host.l.level_ptr[i];
-    for (std::size_t i = 0; i < host.u.level_ptr.size(); ++i) u_level_ptr[i] = host.u.level_ptr[i];
+    for (std::size_t i = 0; i < sched_l.level_ptr.size(); ++i) l_level_ptr[i] = sched_l.level_ptr[i];
+    for (std::size_t i = 0; i < sched_u.level_ptr.size(); ++i) u_level_ptr[i] = sched_u.level_ptr[i];
 
     ILUKView<T> view;
     view.lu = MatrixView<T, MatrixFormat::CSR>(values.data(), row_offsets.data(), col_indices.data(), nnz, n, n,
@@ -748,15 +1327,16 @@ ILUKView<T> iluk_factorize(Queue& ctx,
     view.diag_positions = diag_positions;
     view.l_rows = l_rows;
     view.l_level_ptr = l_level_ptr;
-    view.l_levels = host.l.levels;
+    view.l_levels = sched_l.levels;
     view.u_rows = u_rows;
     view.u_level_ptr = u_level_ptr;
-    view.u_levels = host.u.levels;
+    view.u_levels = sched_u.levels;
     view.n = n;
     view.batch_size = batch_size;
     view.diagonal_shift = params.diagonal_shift;
-    view.u_diagonals_usable = u_diagonals_are_usable(values.data(), diag_positions.data(), n, batch_size,
-                                                     params.diagonal_shift);
+    view.u_diagonals_usable = on_device
+        ? dev_opt->u_diagonals_usable
+        : u_diagonals_are_usable(values.data(), diag_positions.data(), n, batch_size, params.diagonal_shift);
     if (bytes_used != nullptr) {
         *bytes_used = static_cast<size_t>(workspace.size() - pool.remaining().size());
     }

--- a/src/extensions/iluk.cc
+++ b/src/extensions/iluk.cc
@@ -90,6 +90,24 @@ inline T stabilize_pivot_or_mark(const T& pivot,
 }
 
 template <typename T>
+bool u_diagonals_are_usable(const Matrix<T, MatrixFormat::CSR>& lu,
+                            const UnifiedVector<int>& diag_positions,
+                            int n,
+                            int batch_size,
+                            const T& diagonal_shift) {
+    const auto vals = lu.view().data();
+    for (int b = 0; b < batch_size; ++b) {
+        for (int i = 0; i < n; ++i) {
+            int32_t status = 0;
+            (void)stabilize_pivot_or_mark(vals[diag_positions[static_cast<std::size_t>(b * n + i)]],
+                                          diagonal_shift, &status);
+            if (status != 0) return false;
+        }
+    }
+    return true;
+}
+
+template <typename T>
 bool has_identical_batch_sparsity(const MatrixView<T, MatrixFormat::CSR>& A) {
     if (A.batch_size() <= 1) return true;
     const auto ro = A.row_offsets();
@@ -212,7 +230,70 @@ std::vector<std::vector<int>> symbolic_iluk_pattern_single(const Span<int>& row_
 template <Backend B, typename T>
 struct ILUKApplyKernel;
 
+// Bucket rows of a triangular factor into dependency levels. `lower` selects the
+// unit-lower forward solve (row i depends on columns j < i, scanned in increasing
+// row order) versus the upper backward solve (row i depends on columns j > i,
+// scanned in decreasing row order). Rows sharing a level are mutually independent.
+void build_level_schedule(const std::vector<int>& row_offsets,
+                          const std::vector<int>& col_indices,
+                          int n,
+                          bool lower,
+                          UnifiedVector<int>& rows_out,
+                          UnifiedVector<int>& level_ptr_out,
+                          int& num_levels) {
+    std::vector<int> level(static_cast<std::size_t>(n), 0);
+    int max_level = 0;
+
+    for (int step = 0; step < n; ++step) {
+        const int i = lower ? step : (n - 1 - step);
+        int lvl = 0;
+        for (int p = row_offsets[static_cast<std::size_t>(i)]; p < row_offsets[static_cast<std::size_t>(i + 1)]; ++p) {
+            const int j = col_indices[static_cast<std::size_t>(p)];
+            const bool depends = lower ? (j < i) : (j > i);
+            if (depends) {
+                lvl = std::max(lvl, level[static_cast<std::size_t>(j)] + 1);
+            }
+        }
+        level[static_cast<std::size_t>(i)] = lvl;
+        max_level = std::max(max_level, lvl);
+    }
+
+    num_levels = max_level + 1;
+    std::vector<int> counts(static_cast<std::size_t>(num_levels) + 1, 0);
+    for (int i = 0; i < n; ++i) counts[static_cast<std::size_t>(level[static_cast<std::size_t>(i)]) + 1] += 1;
+    for (int l = 0; l < num_levels; ++l) counts[static_cast<std::size_t>(l) + 1] += counts[static_cast<std::size_t>(l)];
+
+    level_ptr_out = UnifiedVector<int>(static_cast<std::size_t>(num_levels) + 1);
+    for (int l = 0; l <= num_levels; ++l) level_ptr_out[static_cast<std::size_t>(l)] = counts[static_cast<std::size_t>(l)];
+
+    rows_out = UnifiedVector<int>(static_cast<std::size_t>(n));
+    std::vector<int> cursor(counts.begin(), counts.end() - 1);
+    for (int i = 0; i < n; ++i) {
+        rows_out[static_cast<std::size_t>(cursor[static_cast<std::size_t>(level[static_cast<std::size_t>(i)])]++)] = i;
+    }
+}
+
 }  // namespace
+
+template <typename T>
+void iluk_build_level_schedule(ILUKPreconditioner<T>& M) {
+    const int n = M.n;
+    if (n <= 0) {
+        throw std::invalid_argument("ILU(k): cannot build a level schedule for an empty factor");
+    }
+    auto lu = M.lu.view();
+    const auto ro = lu.row_offsets();
+    const auto ci = lu.col_indices();
+
+    std::vector<int> row_offsets(static_cast<std::size_t>(n) + 1);
+    for (int i = 0; i <= n; ++i) row_offsets[static_cast<std::size_t>(i)] = ro[i];
+    std::vector<int> col_indices(static_cast<std::size_t>(row_offsets[static_cast<std::size_t>(n)]));
+    for (std::size_t p = 0; p < col_indices.size(); ++p) col_indices[p] = ci[p];
+
+    build_level_schedule(row_offsets, col_indices, n, /*lower=*/true, M.l_rows, M.l_level_ptr, M.l_levels);
+    build_level_schedule(row_offsets, col_indices, n, /*lower=*/false, M.u_rows, M.u_level_ptr, M.u_levels);
+    M.u_diagonals_usable = u_diagonals_are_usable(M.lu, M.diag_positions, M.n, M.batch_size, M.diagonal_shift);
+}
 
 template <Backend B, typename T>
 ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
@@ -274,6 +355,12 @@ ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
     std::vector<std::vector<std::vector<uint8_t>>> batch_keep(static_cast<std::size_t>(batch_size));
 
     const auto a_vals = A.data();
+
+    // Scatter workspace mapping a column index to its slot in the row currently
+    // being assembled. Replaces a binary search per touched entry with an O(1)
+    // lookup; -1 means the column is outside this row's symbolic pattern.
+    std::vector<int> col_to_slot(static_cast<std::size_t>(n), -1);
+
     for (int b = 0; b < batch_size; ++b) {
         auto& values_by_row = batch_values[static_cast<std::size_t>(b)];
         auto& keep_by_row = batch_keep[static_cast<std::size_t>(b)];
@@ -289,15 +376,19 @@ ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
             row_vals.assign(row_cols.size(), T(0));
             row_keep.assign(row_cols.size(), 1);
 
+            const int row_nnz = static_cast<int>(row_cols.size());
+            for (int p = 0; p < row_nnz; ++p) col_to_slot[static_cast<std::size_t>(row_cols[static_cast<std::size_t>(p)])] = p;
+
             const int ars = ro[ro_base + i];
             const int are = ro[ro_base + i + 1];
             for (int p = ars; p < are; ++p) {
-                const int col = ci[val_base + p];
-                const auto it = std::lower_bound(row_cols.begin(), row_cols.end(), col);
-                if (it != row_cols.end() && *it == col) {
-                    row_vals[static_cast<std::size_t>(it - row_cols.begin())] = a_vals[val_base + p];
+                const int slot = col_to_slot[static_cast<std::size_t>(ci[val_base + p])];
+                if (slot >= 0) {
+                    row_vals[static_cast<std::size_t>(slot)] = a_vals[val_base + p];
                 }
             }
+
+            for (int p = 0; p < row_nnz; ++p) col_to_slot[static_cast<std::size_t>(row_cols[static_cast<std::size_t>(p)])] = -1;
         }
 
         for (int i = 0; i < n; ++i) {
@@ -305,30 +396,32 @@ ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
             auto& row_keep = keep_by_row[static_cast<std::size_t>(i)];
             const auto& row_cols = symbolic_rows[static_cast<std::size_t>(i)];
 
-            for (int p = 0; p < static_cast<int>(row_cols.size()); ++p) {
+            const int row_nnz = static_cast<int>(row_cols.size());
+            for (int p = 0; p < row_nnz; ++p) col_to_slot[static_cast<std::size_t>(row_cols[static_cast<std::size_t>(p)])] = p;
+
+            for (int p = 0; p < row_nnz; ++p) {
                 const int j = row_cols[static_cast<std::size_t>(p)];
                 if (j >= i) break;
 
-                auto& pivot_row_vals = values_by_row[static_cast<std::size_t>(j)];
-                auto& pivot_row_keep = keep_by_row[static_cast<std::size_t>(j)];
-                const auto pivot_scale = row_scale(pivot_row_vals, pivot_row_keep);
+                const auto& pivot_row_vals = values_by_row[static_cast<std::size_t>(j)];
+                const auto& pivot_row_keep = keep_by_row[static_cast<std::size_t>(j)];
                 const int diag_j = diag_local[static_cast<std::size_t>(j)];
-                pivot_row_vals[static_cast<std::size_t>(diag_j)] = stabilize_pivot_or_mark(
-                    pivot_row_vals[static_cast<std::size_t>(diag_j)], pivot_scale, params, &factor_status[static_cast<std::size_t>(b)]);
 
+                // Row j < i is already finalized: its diagonal was stabilized when row j
+                // was processed and the row has not changed since. Stabilization is
+                // idempotent, so re-deriving the row scale here (an O(nnz_j) scan on every
+                // elimination step) would recompute the value already stored.
                 const T lij = row_vals[static_cast<std::size_t>(p)] / pivot_row_vals[static_cast<std::size_t>(diag_j)];
                 row_vals[static_cast<std::size_t>(p)] = lij;
 
+                // Columns are sorted, so the strict upper part of row j starts past its diagonal.
                 const auto& pivot_cols = symbolic_rows[static_cast<std::size_t>(j)];
-                for (int q = 0; q < static_cast<int>(pivot_cols.size()); ++q) {
+                const int pivot_nnz = static_cast<int>(pivot_cols.size());
+                for (int q = diag_j + 1; q < pivot_nnz; ++q) {
                     if (pivot_row_keep[static_cast<std::size_t>(q)] == 0) continue;
-                    const int col = pivot_cols[static_cast<std::size_t>(q)];
-                    if (col <= j) continue;
-
-                    const auto it = std::lower_bound(row_cols.begin(), row_cols.end(), col);
-                    if (it != row_cols.end() && *it == col) {
-                        const auto target = static_cast<std::size_t>(it - row_cols.begin());
-                        row_vals[target] -= lij * pivot_row_vals[static_cast<std::size_t>(q)];
+                    const int slot = col_to_slot[static_cast<std::size_t>(pivot_cols[static_cast<std::size_t>(q)])];
+                    if (slot >= 0) {
+                        row_vals[static_cast<std::size_t>(slot)] -= lij * pivot_row_vals[static_cast<std::size_t>(q)];
                     }
                 }
             }
@@ -337,6 +430,8 @@ ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
             const auto final_scale = row_scale(row_vals, row_keep);
             row_vals[static_cast<std::size_t>(diag_local[static_cast<std::size_t>(i)])] = stabilize_pivot_or_mark(
                 row_vals[static_cast<std::size_t>(diag_local[static_cast<std::size_t>(i)])], final_scale, params, &factor_status[static_cast<std::size_t>(b)]);
+
+            for (int p = 0; p < row_nnz; ++p) col_to_slot[static_cast<std::size_t>(row_cols[static_cast<std::size_t>(p)])] = -1;
         }
     }
 
@@ -384,6 +479,10 @@ ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
 
     const int nnz = static_cast<int>(col_indices.size());
     ILUKPreconditioner<T> result;
+    build_level_schedule(row_offsets, col_indices, n, /*lower=*/true,
+                         result.l_rows, result.l_level_ptr, result.l_levels);
+    build_level_schedule(row_offsets, col_indices, n, /*lower=*/false,
+                         result.u_rows, result.u_level_ptr, result.u_levels);
     result.lu = Matrix<T, MatrixFormat::CSR>(n, n, nnz, batch_size);
     result.diag_positions = UnifiedVector<int>(static_cast<std::size_t>(n * batch_size));
     result.n = n;
@@ -422,6 +521,9 @@ ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
         }
     }
 
+    result.u_diagonals_usable = u_diagonals_are_usable(result.lu, result.diag_positions, n, batch_size,
+                                                       result.diagonal_shift);
+
     return result;
 }
 
@@ -439,6 +541,17 @@ Event iluk_apply(Queue& ctx,
     }
     if (rhs.batch_size() != M.batch_size || out.batch_size() != M.batch_size) {
         throw std::invalid_argument("ILU(k) apply: rhs/out batch size must match factor batch size");
+    }
+    if (M.l_levels <= 0 || M.u_levels <= 0 ||
+        M.l_rows.size() != static_cast<std::size_t>(M.n) ||
+        M.u_rows.size() != static_cast<std::size_t>(M.n)) {
+        throw std::invalid_argument(
+            "ILU(k) apply: preconditioner has no triangular-solve level schedule; "
+            "call iluk_build_level_schedule() when constructing one by hand");
+    }
+    if (!M.u_diagonals_usable) {
+        throw std::runtime_error(
+            "ILU(k) apply: encountered a zero or effectively zero U diagonal without a usable diagonal shift");
     }
 
     const int n = M.n;
@@ -459,56 +572,74 @@ Event iluk_apply(Queue& ctx,
     const T diag_shift = M.diagonal_shift;
 
     const size_t total_systems = static_cast<size_t>(batch * nrhs);
-    UnifiedVector<int32_t> apply_status(total_systems, 0);
-    auto apply_status_ptr = apply_status.data();
-    ctx->parallel_for<ILUKApplyKernel<B, T>>(sycl::range<1>(total_systems), [=](sycl::id<1> id) {
-        const int linear = static_cast<int>(id[0]);
+
+    // One work-group per (batch, rhs column) system. Within a group the rows of a
+    // dependency level are split across work-items and a group barrier separates
+    // levels, so the serial chain is the level count rather than n. Each group owns
+    // its system exclusively, so no cross-group synchronization is needed.
+    const int l_levels = M.l_levels;
+    const int u_levels = M.u_levels;
+    auto l_rows = M.l_rows.data();
+    auto l_level_ptr = M.l_level_ptr.data();
+    auto u_rows = M.u_rows.data();
+    auto u_level_ptr = M.u_level_ptr.data();
+
+    constexpr int wg_size = 128;
+    ctx->parallel_for<ILUKApplyKernel<B, T>>(
+        sycl::nd_range<1>(total_systems * wg_size, wg_size), [=](sycl::nd_item<1> item) {
+        const int linear = static_cast<int>(item.get_group(0));
         const int b = linear / nrhs;
         const int col = linear % nrhs;
+        const int lid = static_cast<int>(item.get_local_id(0));
 
         const int ro_base = b * lu_kv.offset_stride_;
         const int lu_base = b * lu_kv.matrix_stride_;
         const int rhs_base = b * rhs_kv.stride_ + col * rhs_kv.ld_;
         const int out_base = b * out_kv.stride_ + col * out_kv.ld_;
-        // Forward solve into out (as temporary y).
-        for (int i = 0; i < n; ++i) {
-            T sum = rhs_data[rhs_base + i];
-            const int rs = lu_ro[ro_base + i];
-            const int re = lu_ro[ro_base + i + 1];
-            for (int p = rs; p < re; ++p) {
-                const int j = lu_ci[lu_base + p];
-                if (j >= i) break;
-                sum -= lu_vals[lu_base + p] * out_data[out_base + j];
-            }
-            out_data[out_base + i] = sum;
-        }
 
-        for (int i = n - 1; i >= 0; --i) {
-            T sum = out_data[out_base + i];
-            const int rs = lu_ro[ro_base + i];
-            const int re = lu_ro[ro_base + i + 1];
-            T diag = stabilize_pivot_or_mark(lu_vals[diag_pos[b * n + i]],
-                                             diag_shift,
-                                             &apply_status_ptr[linear]);
-            for (int p = rs; p < re; ++p) {
-                const int j = lu_ci[lu_base + p];
-                if (j > i) {
+        // Forward solve into out (as temporary y).
+        for (int lv = 0; lv < l_levels; ++lv) {
+            const int begin = l_level_ptr[lv];
+            const int end = l_level_ptr[lv + 1];
+            for (int t = begin + lid; t < end; t += wg_size) {
+                const int i = l_rows[t];
+                T sum = rhs_data[rhs_base + i];
+                const int rs = lu_ro[ro_base + i];
+                const int re = lu_ro[ro_base + i + 1];
+                for (int p = rs; p < re; ++p) {
+                    const int j = lu_ci[lu_base + p];
+                    if (j >= i) break;
                     sum -= lu_vals[lu_base + p] * out_data[out_base + j];
                 }
+                out_data[out_base + i] = sum;
             }
-            out_data[out_base + i] = sum / diag;
+            sycl::group_barrier(item.get_group());
+        }
+
+        for (int lv = 0; lv < u_levels; ++lv) {
+            const int begin = u_level_ptr[lv];
+            const int end = u_level_ptr[lv + 1];
+            for (int t = begin + lid; t < end; t += wg_size) {
+                const int i = u_rows[t];
+                T sum = out_data[out_base + i];
+                const int diag_abs = diag_pos[b * n + i];
+                const int re = lu_ro[ro_base + i + 1];
+                // Usability of every U diagonal was established when the factor was
+                // built; this only substitutes the shifted value.
+                T diag = stabilize_pivot_or_mark(lu_vals[diag_abs], diag_shift, nullptr);
+                // Columns are sorted ascending, so the strict upper part of row i
+                // starts one past the diagonal.
+                for (int p = diag_abs - lu_base + 1; p < re; ++p) {
+                    sum -= lu_vals[lu_base + p] * out_data[out_base + lu_ci[lu_base + p]];
+                }
+                out_data[out_base + i] = sum / diag;
+            }
+            sycl::group_barrier(item.get_group());
         }
     });
 
-    ctx.wait_and_throw();
-
-    for (size_t idx = 0; idx < total_systems; ++idx) {
-        if (apply_status[idx] != 0) {
-            throw std::runtime_error(
-                "ILU(k) apply: encountered a zero or effectively zero U diagonal without a usable diagonal shift");
-        }
-    }
-
+    // No host sync here: the caller owns synchronization, so repeated applications
+    // inside an iterative solver stay pipelined.
     return ctx.get_event();
 }
 
@@ -516,6 +647,15 @@ template <Backend B, typename T>
 size_t iluk_apply_buffer_size(Queue&, const ILUKPreconditioner<T>&, const MatrixView<T, MatrixFormat::Dense>&, const MatrixView<T, MatrixFormat::Dense>&) {
     return 0;
 }
+
+#define ILUK_INSTANTIATE_COMMON(FP) \
+    template void iluk_build_level_schedule<FP>(ILUKPreconditioner<FP>&);
+
+ILUK_INSTANTIATE_COMMON(float)
+ILUK_INSTANTIATE_COMMON(double)
+ILUK_INSTANTIATE_COMMON(std::complex<float>)
+ILUK_INSTANTIATE_COMMON(std::complex<double>)
+#undef ILUK_INSTANTIATE_COMMON
 
 #define ILUK_INSTANTIATE(BACK, FP) \
     template ILUKPreconditioner<FP> iluk_factorize<BACK, FP>(Queue&, const MatrixView<FP, MatrixFormat::CSR>&, const ILUKParams<FP>&); \

--- a/src/extensions/iluk.cc
+++ b/src/extensions/iluk.cc
@@ -2,6 +2,10 @@
 
 #include <blas/functions/iluk.hh>
 #include <util/mempool.hh>
+#include <atomic>
+#include <cstdlib>
+#include <exception>
+#include <thread>
 #include <algorithm>
 #include <cmath>
 #include <complex>
@@ -128,38 +132,42 @@ bool has_identical_batch_sparsity(const MatrixView<T, MatrixFormat::CSR>& A) {
 }
 
 template <typename T>
-RealT<T> row_scale(const std::vector<T>& values, const std::vector<uint8_t>& keep_flags) {
+RealT<T> row_scale(const T* values, const uint8_t* keep_flags, int len) {
     RealT<T> scale = RealT<T>(0);
-    for (std::size_t idx = 0; idx < values.size(); ++idx) {
-        if (!keep_flags.empty() && keep_flags[idx] == 0) continue;
+    for (int idx = 0; idx < len; ++idx) {
+        if (keep_flags != nullptr && keep_flags[idx] == 0) continue;
         scale = std::max(scale, abs_value(values[idx]));
     }
     return scale;
 }
 
+// `candidates` is caller-owned scratch reused across rows. Allocating it per row
+// put a heap allocation in the innermost loop, which became the limiting factor
+// once the batch loop was parallelised.
 template <typename T>
-void apply_drop_and_fill_control(std::vector<T>& row_values,
-                                 std::vector<uint8_t>& keep_flags,
+void apply_drop_and_fill_control(T* row_values,
+                                 uint8_t* keep_flags,
+                                 int len,
                                  int diag_index,
                                  int original_row_nnz,
-                                 const ILUKParams<T>& params) {
-    const auto scale = row_scale(row_values, keep_flags);
+                                 const ILUKParams<T>& params,
+                                 std::vector<std::pair<RealT<T>, int>>& candidates) {
+    const auto scale = row_scale(row_values, keep_flags, len);
     const auto drop_threshold = params.drop_tolerance * std::max(scale, RealT<T>(1));
 
-    std::vector<std::pair<RealT<T>, int>> candidates;
-    candidates.reserve(row_values.size());
-    for (int idx = 0; idx < static_cast<int>(row_values.size()); ++idx) {
-        keep_flags[static_cast<std::size_t>(idx)] = 1;
+    candidates.clear();
+    for (int idx = 0; idx < len; ++idx) {
+        keep_flags[idx] = 1;
         if (idx == diag_index) continue;
-        if (abs_value(row_values[static_cast<std::size_t>(idx)]) <= drop_threshold) {
+        if (abs_value(row_values[idx]) <= drop_threshold) {
             if (params.modified_ilu) {
-                row_values[static_cast<std::size_t>(diag_index)] += row_values[static_cast<std::size_t>(idx)];
+                row_values[diag_index] += row_values[idx];
             }
-            row_values[static_cast<std::size_t>(idx)] = T(0);
-            keep_flags[static_cast<std::size_t>(idx)] = 0;
+            row_values[idx] = T(0);
+            keep_flags[idx] = 0;
             continue;
         }
-        candidates.emplace_back(abs_value(row_values[static_cast<std::size_t>(idx)]), idx);
+        candidates.emplace_back(abs_value(row_values[idx]), idx);
     }
 
     const int offdiag_quota = std::max(0, static_cast<int>(std::ceil(params.fill_factor * static_cast<RealT<T>>(original_row_nnz))) - 1);
@@ -170,14 +178,14 @@ void apply_drop_and_fill_control(std::vector<T>& row_values,
         for (int drop_idx = offdiag_quota; drop_idx < static_cast<int>(candidates.size()); ++drop_idx) {
             const int idx = candidates[static_cast<std::size_t>(drop_idx)].second;
             if (params.modified_ilu) {
-                row_values[static_cast<std::size_t>(diag_index)] += row_values[static_cast<std::size_t>(idx)];
+                row_values[diag_index] += row_values[idx];
             }
-            row_values[static_cast<std::size_t>(idx)] = T(0);
-            keep_flags[static_cast<std::size_t>(idx)] = 0;
+            row_values[idx] = T(0);
+            keep_flags[idx] = 0;
         }
     }
 
-    keep_flags[static_cast<std::size_t>(diag_index)] = 1;
+    keep_flags[diag_index] = 1;
 }
 
 std::vector<std::vector<int>> symbolic_iluk_pattern_single(const Span<int>& row_offsets,
@@ -275,6 +283,28 @@ LevelSchedule build_level_schedule(const std::vector<int>& row_offsets,
     return out;
 }
 
+// How many host threads the numeric phase may use. A library that unilaterally
+// grabs every core fights a caller that is already parallel over its own work, so
+// this stays modest by default and BATCHLAS_ILUK_THREADS overrides it (1 = serial).
+//
+// The batch floor is measured, not guessed: below 64 elements threading was a net
+// loss (0.55-0.74x at batch 16), and above it a gain of 1.4-1.8x. The gain is
+// modest because the phase is memory-bound rather than compute-bound, so this
+// narrows the large-batch formation cost without eliminating it -- doing that
+// means factorizing on the device.
+constexpr int kILUKMinBatchForThreads = 64;
+
+int iluk_factor_thread_count(int batch_size) {
+    if (batch_size < kILUKMinBatchForThreads) return 1;
+    if (const char* v = std::getenv("BATCHLAS_ILUK_THREADS")) {
+        const int requested = std::atoi(v);
+        if (requested >= 1) return std::min(requested, batch_size);
+    }
+    const unsigned hw = std::thread::hardware_concurrency();
+    const int cap = hw == 0 ? 1 : static_cast<int>(hw / 2);
+    return std::max(1, std::min(cap, batch_size));
+}
+
 // Everything ILU(k) computes on the host, in a storage-agnostic form. The
 // sparsity pattern (row_offsets/col_indices/diag_offsets) and both level
 // schedules are shared across the batch; only `values` varies per batch element.
@@ -332,108 +362,159 @@ HostFactor<T> compute_iluk(const MatrixView<T, MatrixFormat::CSR>& A, const ILUK
 
     const auto ro = A.row_offsets();
     const auto ci = A.col_indices();
-    auto symbolic_rows = symbolic_iluk_pattern_single(ro, ci, n, 0, 0, params.levels_of_fill);
-    std::vector<int> diag_local(n, -1);
-    std::vector<int> original_row_nnz(n, 0);
+    const auto symbolic_rows = symbolic_iluk_pattern_single(ro, ci, n, 0, 0, params.levels_of_fill);
+
+    // Flatten the symbolic pattern into CSR-style arrays shared by the whole batch.
+    // Keeping it as vector<vector<int>>, and the per-batch values as
+    // vector<vector<T>>, meant one heap allocation per row per batch element --
+    // n * batch_size of them. That is invisible at batch 1 and is the dominant cost
+    // once the batch loop below runs on several threads, since they all contend on
+    // the same allocator.
+    std::vector<int> sym_ro(static_cast<std::size_t>(n) + 1, 0);
+    for (int i = 0; i < n; ++i) {
+        sym_ro[static_cast<std::size_t>(i + 1)] =
+            sym_ro[static_cast<std::size_t>(i)] + static_cast<int>(symbolic_rows[static_cast<std::size_t>(i)].size());
+    }
+    const int sym_nnz = sym_ro[static_cast<std::size_t>(n)];
+    std::vector<int> sym_ci(static_cast<std::size_t>(sym_nnz));
+    for (int i = 0; i < n; ++i) {
+        std::copy(symbolic_rows[static_cast<std::size_t>(i)].begin(), symbolic_rows[static_cast<std::size_t>(i)].end(),
+                  sym_ci.begin() + sym_ro[static_cast<std::size_t>(i)]);
+    }
+
+    // diag_local[i] is the diagonal's offset within row i of the symbolic pattern.
+    std::vector<int> diag_local(static_cast<std::size_t>(n), -1);
+    std::vector<int> original_row_nnz(static_cast<std::size_t>(n), 0);
     for (int i = 0; i < n; ++i) {
         original_row_nnz[static_cast<std::size_t>(i)] = ro[i + 1] - ro[i];
-        const int re = static_cast<int>(symbolic_rows[static_cast<std::size_t>(i)].size());
+        const int rs = sym_ro[static_cast<std::size_t>(i)];
+        const int re = sym_ro[static_cast<std::size_t>(i + 1)];
         int pos = -1;
-        for (int p = 0; p < re; ++p) {
-            if (symbolic_rows[static_cast<std::size_t>(i)][static_cast<std::size_t>(p)] == i) {
-                pos = p;
-                break;
-            }
+        for (int p = rs; p < re; ++p) {
+            if (sym_ci[static_cast<std::size_t>(p)] == i) { pos = p - rs; break; }
         }
         if (pos < 0) {
             throw std::runtime_error("ILU(k): symbolic phase produced a row without diagonal");
         }
-        diag_local[i] = pos;
+        diag_local[static_cast<std::size_t>(i)] = pos;
     }
 
     UnifiedVector<int32_t> factor_status(static_cast<std::size_t>(batch_size), 0);
 
-    std::vector<std::vector<std::vector<T>>> batch_values(static_cast<std::size_t>(batch_size));
-    std::vector<std::vector<std::vector<uint8_t>>> batch_keep(static_cast<std::size_t>(batch_size));
+    const std::size_t stride = static_cast<std::size_t>(sym_nnz);
+    std::vector<T> sym_values(stride * static_cast<std::size_t>(batch_size), T(0));
+    std::vector<uint8_t> sym_keep(stride * static_cast<std::size_t>(batch_size), 1);
 
     const auto a_vals = A.data();
 
-    // Scatter workspace mapping a column index to its slot in the row currently
-    // being assembled. Replaces a binary search per touched entry with an O(1)
-    // lookup; -1 means the column is outside this row's symbolic pattern.
-    std::vector<int> col_to_slot(static_cast<std::size_t>(n), -1);
-
-    for (int b = 0; b < batch_size; ++b) {
-        auto& values_by_row = batch_values[static_cast<std::size_t>(b)];
-        auto& keep_by_row = batch_keep[static_cast<std::size_t>(b)];
-        values_by_row.resize(static_cast<std::size_t>(n));
-        keep_by_row.resize(static_cast<std::size_t>(n));
+    // Batch elements share a sparsity pattern but nothing else: each one's numeric
+    // phase reads only its own slice of A and writes only its own slice of
+    // sym_values, so the batch loop is embarrassingly parallel. It is also the part
+    // that scales with batch size -- at batch 1024 it dominated everything else the
+    // solver did.
+    //
+    // `col_to_slot` and `candidates` are per-thread scratch. col_to_slot maps a
+    // column index to its slot in the row being assembled: an O(1) lookup in place
+    // of a binary search per touched entry, with -1 meaning the column is outside
+    // this row's pattern.
+    auto factor_batch_element = [&](int b, std::vector<int>& col_to_slot,
+                                    std::vector<std::pair<RealT<T>, int>>& candidates) {
+        T* values = sym_values.data() + static_cast<std::size_t>(b) * stride;
+        uint8_t* keep = sym_keep.data() + static_cast<std::size_t>(b) * stride;
 
         const int ro_base = b * A.offset_stride();
         const int val_base = b * A.matrix_stride();
         for (int i = 0; i < n; ++i) {
-            const auto& row_cols = symbolic_rows[static_cast<std::size_t>(i)];
-            auto& row_vals = values_by_row[static_cast<std::size_t>(i)];
-            auto& row_keep = keep_by_row[static_cast<std::size_t>(i)];
-            row_vals.assign(row_cols.size(), T(0));
-            row_keep.assign(row_cols.size(), 1);
-
-            const int row_nnz = static_cast<int>(row_cols.size());
-            for (int p = 0; p < row_nnz; ++p) col_to_slot[static_cast<std::size_t>(row_cols[static_cast<std::size_t>(p)])] = p;
+            const int rs = sym_ro[static_cast<std::size_t>(i)];
+            const int row_nnz = sym_ro[static_cast<std::size_t>(i + 1)] - rs;
+            for (int p = 0; p < row_nnz; ++p) {
+                values[rs + p] = T(0);
+                keep[rs + p] = 1;
+                col_to_slot[static_cast<std::size_t>(sym_ci[static_cast<std::size_t>(rs + p)])] = p;
+            }
 
             const int ars = ro[ro_base + i];
             const int are = ro[ro_base + i + 1];
             for (int p = ars; p < are; ++p) {
                 const int slot = col_to_slot[static_cast<std::size_t>(ci[val_base + p])];
-                if (slot >= 0) {
-                    row_vals[static_cast<std::size_t>(slot)] = a_vals[val_base + p];
-                }
+                if (slot >= 0) values[rs + slot] = a_vals[val_base + p];
             }
 
-            for (int p = 0; p < row_nnz; ++p) col_to_slot[static_cast<std::size_t>(row_cols[static_cast<std::size_t>(p)])] = -1;
+            for (int p = 0; p < row_nnz; ++p) col_to_slot[static_cast<std::size_t>(sym_ci[static_cast<std::size_t>(rs + p)])] = -1;
         }
 
         for (int i = 0; i < n; ++i) {
-            auto& row_vals = values_by_row[static_cast<std::size_t>(i)];
-            auto& row_keep = keep_by_row[static_cast<std::size_t>(i)];
-            const auto& row_cols = symbolic_rows[static_cast<std::size_t>(i)];
+            const int rs = sym_ro[static_cast<std::size_t>(i)];
+            const int row_nnz = sym_ro[static_cast<std::size_t>(i + 1)] - rs;
+            T* row_vals = values + rs;
 
-            const int row_nnz = static_cast<int>(row_cols.size());
-            for (int p = 0; p < row_nnz; ++p) col_to_slot[static_cast<std::size_t>(row_cols[static_cast<std::size_t>(p)])] = p;
+            for (int p = 0; p < row_nnz; ++p) col_to_slot[static_cast<std::size_t>(sym_ci[static_cast<std::size_t>(rs + p)])] = p;
 
             for (int p = 0; p < row_nnz; ++p) {
-                const int j = row_cols[static_cast<std::size_t>(p)];
+                const int j = sym_ci[static_cast<std::size_t>(rs + p)];
                 if (j >= i) break;
 
-                const auto& pivot_row_vals = values_by_row[static_cast<std::size_t>(j)];
-                const auto& pivot_row_keep = keep_by_row[static_cast<std::size_t>(j)];
+                const int prs = sym_ro[static_cast<std::size_t>(j)];
+                const int pivot_nnz = sym_ro[static_cast<std::size_t>(j + 1)] - prs;
+                const T* pivot_vals = values + prs;
+                const uint8_t* pivot_keep = keep + prs;
                 const int diag_j = diag_local[static_cast<std::size_t>(j)];
 
                 // Row j < i is already finalized: its diagonal was stabilized when row j
                 // was processed and the row has not changed since. Stabilization is
                 // idempotent, so re-deriving the row scale here (an O(nnz_j) scan on every
                 // elimination step) would recompute the value already stored.
-                const T lij = row_vals[static_cast<std::size_t>(p)] / pivot_row_vals[static_cast<std::size_t>(diag_j)];
-                row_vals[static_cast<std::size_t>(p)] = lij;
+                const T lij = row_vals[p] / pivot_vals[diag_j];
+                row_vals[p] = lij;
 
                 // Columns are sorted, so the strict upper part of row j starts past its diagonal.
-                const auto& pivot_cols = symbolic_rows[static_cast<std::size_t>(j)];
-                const int pivot_nnz = static_cast<int>(pivot_cols.size());
                 for (int q = diag_j + 1; q < pivot_nnz; ++q) {
-                    if (pivot_row_keep[static_cast<std::size_t>(q)] == 0) continue;
-                    const int slot = col_to_slot[static_cast<std::size_t>(pivot_cols[static_cast<std::size_t>(q)])];
-                    if (slot >= 0) {
-                        row_vals[static_cast<std::size_t>(slot)] -= lij * pivot_row_vals[static_cast<std::size_t>(q)];
-                    }
+                    if (pivot_keep[q] == 0) continue;
+                    const int slot = col_to_slot[static_cast<std::size_t>(sym_ci[static_cast<std::size_t>(prs + q)])];
+                    if (slot >= 0) row_vals[slot] -= lij * pivot_vals[q];
                 }
             }
 
-            apply_drop_and_fill_control(row_vals, row_keep, diag_local[static_cast<std::size_t>(i)], original_row_nnz[static_cast<std::size_t>(i)], params);
-            const auto final_scale = row_scale(row_vals, row_keep);
-            row_vals[static_cast<std::size_t>(diag_local[static_cast<std::size_t>(i)])] = stabilize_pivot_or_mark(
-                row_vals[static_cast<std::size_t>(diag_local[static_cast<std::size_t>(i)])], final_scale, params, &factor_status[static_cast<std::size_t>(b)]);
+            const int diag_i = diag_local[static_cast<std::size_t>(i)];
+            apply_drop_and_fill_control(row_vals, keep + rs, row_nnz, diag_i,
+                                        original_row_nnz[static_cast<std::size_t>(i)], params, candidates);
+            const auto final_scale = row_scale(row_vals, keep + rs, row_nnz);
+            row_vals[diag_i] = stabilize_pivot_or_mark(row_vals[diag_i], final_scale, params,
+                                                       &factor_status[static_cast<std::size_t>(b)]);
 
-            for (int p = 0; p < row_nnz; ++p) col_to_slot[static_cast<std::size_t>(row_cols[static_cast<std::size_t>(p)])] = -1;
+            for (int p = 0; p < row_nnz; ++p) col_to_slot[static_cast<std::size_t>(sym_ci[static_cast<std::size_t>(rs + p)])] = -1;
+        }
+    };
+
+    const int num_threads = iluk_factor_thread_count(batch_size);
+    if (num_threads <= 1) {
+        std::vector<int> col_to_slot(static_cast<std::size_t>(n), -1);
+        std::vector<std::pair<RealT<T>, int>> candidates;
+        for (int b = 0; b < batch_size; ++b) factor_batch_element(b, col_to_slot, candidates);
+    } else {
+        // A pivot failure throws from inside the worker; letting that escape a
+        // std::thread would call std::terminate, so it is captured and rethrown on
+        // the calling thread after every worker has been joined.
+        std::atomic<int> next_element{0};
+        std::vector<std::exception_ptr> errors(static_cast<std::size_t>(num_threads));
+        std::vector<std::thread> workers;
+        workers.reserve(static_cast<std::size_t>(num_threads));
+        for (int t = 0; t < num_threads; ++t) {
+            workers.emplace_back([&, t]() {
+                std::vector<int> col_to_slot(static_cast<std::size_t>(n), -1);
+                std::vector<std::pair<RealT<T>, int>> candidates;
+                try {
+                    for (int b = next_element.fetch_add(1); b < batch_size; b = next_element.fetch_add(1)) {
+                        factor_batch_element(b, col_to_slot, candidates);
+                    }
+                } catch (...) {
+                    errors[static_cast<std::size_t>(t)] = std::current_exception();
+                }
+            });
+        }
+        for (auto& w : workers) w.join();
+        for (auto& e : errors) {
+            if (e) std::rethrow_exception(e);
         }
     }
 
@@ -444,63 +525,52 @@ HostFactor<T> compute_iluk(const MatrixView<T, MatrixFormat::CSR>& A, const ILUK
         }
     }
 
-    std::vector<std::vector<uint8_t>> union_keep(static_cast<std::size_t>(n));
-    std::vector<std::vector<int>> compact_rows(static_cast<std::size_t>(n));
-    std::vector<std::vector<int>> compact_index(static_cast<std::size_t>(n));
-
+    // Compaction: an entry survives if any batch element kept it, so the batch keeps
+    // sharing one pattern. compact_pos maps a symbolic slot to its compacted slot.
     HostFactor<T> out;
     out.n = n;
     out.batch_size = batch_size;
     out.row_offsets.assign(static_cast<std::size_t>(n) + 1, 0);
+    std::vector<int> compact_pos(static_cast<std::size_t>(sym_nnz), -1);
 
     for (int i = 0; i < n; ++i) {
-        const auto& row_cols = symbolic_rows[static_cast<std::size_t>(i)];
-        auto& row_union = union_keep[static_cast<std::size_t>(i)];
-        row_union.assign(row_cols.size(), 0);
-        row_union[static_cast<std::size_t>(diag_local[static_cast<std::size_t>(i)])] = 1;
-        for (int b = 0; b < batch_size; ++b) {
-            const auto& row_keep = batch_keep[static_cast<std::size_t>(b)][static_cast<std::size_t>(i)];
-            for (int p = 0; p < static_cast<int>(row_cols.size()); ++p) {
-                row_union[static_cast<std::size_t>(p)] = static_cast<uint8_t>(row_union[static_cast<std::size_t>(p)] | row_keep[static_cast<std::size_t>(p)]);
+        const int rs = sym_ro[static_cast<std::size_t>(i)];
+        const int row_nnz = sym_ro[static_cast<std::size_t>(i + 1)] - rs;
+        int kept = 0;
+        for (int p = 0; p < row_nnz; ++p) {
+            bool keep_entry = (p == diag_local[static_cast<std::size_t>(i)]);
+            for (int b = 0; b < batch_size && !keep_entry; ++b) {
+                if (sym_keep[static_cast<std::size_t>(b) * stride + static_cast<std::size_t>(rs + p)] != 0) keep_entry = true;
+            }
+            if (keep_entry) {
+                compact_pos[static_cast<std::size_t>(rs + p)] = kept++;
+                out.col_indices.push_back(sym_ci[static_cast<std::size_t>(rs + p)]);
             }
         }
-
-        auto& compact_row = compact_rows[static_cast<std::size_t>(i)];
-        auto& compact_pos = compact_index[static_cast<std::size_t>(i)];
-        compact_pos.assign(row_cols.size(), -1);
-        for (int p = 0; p < static_cast<int>(row_cols.size()); ++p) {
-            if (row_union[static_cast<std::size_t>(p)] == 0) continue;
-            compact_pos[static_cast<std::size_t>(p)] = static_cast<int>(compact_row.size());
-            compact_row.push_back(row_cols[static_cast<std::size_t>(p)]);
-        }
-        out.row_offsets[static_cast<std::size_t>(i + 1)] = out.row_offsets[static_cast<std::size_t>(i)] + static_cast<int>(compact_row.size());
-    }
-
-    out.col_indices.reserve(static_cast<std::size_t>(out.row_offsets.back()));
-    for (int i = 0; i < n; ++i) {
-        const auto& compact_row = compact_rows[static_cast<std::size_t>(i)];
-        out.col_indices.insert(out.col_indices.end(), compact_row.begin(), compact_row.end());
+        out.row_offsets[static_cast<std::size_t>(i + 1)] = out.row_offsets[static_cast<std::size_t>(i)] + kept;
     }
     out.nnz = static_cast<int>(out.col_indices.size());
 
     out.diag_offsets.assign(static_cast<std::size_t>(n), 0);
-    out.values.assign(static_cast<std::size_t>(out.nnz) * static_cast<std::size_t>(batch_size), T(0));
     for (int i = 0; i < n; ++i) {
         out.diag_offsets[static_cast<std::size_t>(i)] =
-            out.row_offsets[static_cast<std::size_t>(i)] + compact_index[static_cast<std::size_t>(i)][static_cast<std::size_t>(diag_local[static_cast<std::size_t>(i)])];
+            out.row_offsets[static_cast<std::size_t>(i)] +
+            compact_pos[static_cast<std::size_t>(sym_ro[static_cast<std::size_t>(i)] + diag_local[static_cast<std::size_t>(i)])];
     }
+
+    out.values.assign(static_cast<std::size_t>(out.nnz) * static_cast<std::size_t>(batch_size), T(0));
     for (int b = 0; b < batch_size; ++b) {
-        const std::size_t vbase = static_cast<std::size_t>(b) * static_cast<std::size_t>(out.nnz);
+        const std::size_t src_base = static_cast<std::size_t>(b) * stride;
+        const std::size_t dst_base = static_cast<std::size_t>(b) * static_cast<std::size_t>(out.nnz);
         for (int i = 0; i < n; ++i) {
-            const auto& row_vals = batch_values[static_cast<std::size_t>(b)][static_cast<std::size_t>(i)];
-            const auto& row_keep = batch_keep[static_cast<std::size_t>(b)][static_cast<std::size_t>(i)];
-            const auto& compact_pos = compact_index[static_cast<std::size_t>(i)];
-            for (int p = 0; p < static_cast<int>(row_vals.size()); ++p) {
-                const int new_pos = compact_pos[static_cast<std::size_t>(p)];
+            const int rs = sym_ro[static_cast<std::size_t>(i)];
+            const int row_nnz = sym_ro[static_cast<std::size_t>(i + 1)] - rs;
+            for (int p = 0; p < row_nnz; ++p) {
+                const int new_pos = compact_pos[static_cast<std::size_t>(rs + p)];
                 if (new_pos < 0) continue;
-                if (row_keep[static_cast<std::size_t>(p)] == 0 && p != diag_local[static_cast<std::size_t>(i)]) continue;
-                out.values[vbase + static_cast<std::size_t>(out.row_offsets[static_cast<std::size_t>(i)] + new_pos)] =
-                    row_vals[static_cast<std::size_t>(p)];
+                if (sym_keep[src_base + static_cast<std::size_t>(rs + p)] == 0 && p != diag_local[static_cast<std::size_t>(i)]) continue;
+                out.values[dst_base + static_cast<std::size_t>(out.row_offsets[static_cast<std::size_t>(i)] + new_pos)] =
+                    sym_values[src_base + static_cast<std::size_t>(rs + p)];
             }
         }
     }

--- a/src/extensions/iluk.cc
+++ b/src/extensions/iluk.cc
@@ -1,6 +1,7 @@
 #include "../linalg-impl.hh"
 
 #include <blas/functions/iluk.hh>
+#include <util/mempool.hh>
 #include <algorithm>
 #include <cmath>
 #include <complex>
@@ -90,17 +91,15 @@ inline T stabilize_pivot_or_mark(const T& pivot,
 }
 
 template <typename T>
-bool u_diagonals_are_usable(const Matrix<T, MatrixFormat::CSR>& lu,
-                            const UnifiedVector<int>& diag_positions,
+bool u_diagonals_are_usable(const T* vals,
+                            const int* diag_positions,
                             int n,
                             int batch_size,
                             const T& diagonal_shift) {
-    const auto vals = lu.view().data();
     for (int b = 0; b < batch_size; ++b) {
         for (int i = 0; i < n; ++i) {
             int32_t status = 0;
-            (void)stabilize_pivot_or_mark(vals[diag_positions[static_cast<std::size_t>(b * n + i)]],
-                                          diagonal_shift, &status);
+            (void)stabilize_pivot_or_mark(vals[diag_positions[b * n + i]], diagonal_shift, &status);
             if (status != 0) return false;
         }
     }
@@ -234,13 +233,16 @@ struct ILUKApplyKernel;
 // unit-lower forward solve (row i depends on columns j < i, scanned in increasing
 // row order) versus the upper backward solve (row i depends on columns j > i,
 // scanned in decreasing row order). Rows sharing a level are mutually independent.
-void build_level_schedule(const std::vector<int>& row_offsets,
-                          const std::vector<int>& col_indices,
-                          int n,
-                          bool lower,
-                          UnifiedVector<int>& rows_out,
-                          UnifiedVector<int>& level_ptr_out,
-                          int& num_levels) {
+struct LevelSchedule {
+    std::vector<int> rows;
+    std::vector<int> level_ptr;
+    int levels = 0;
+};
+
+LevelSchedule build_level_schedule(const std::vector<int>& row_offsets,
+                                   const std::vector<int>& col_indices,
+                                   int n,
+                                   bool lower) {
     std::vector<int> level(static_cast<std::size_t>(n), 0);
     int max_level = 0;
 
@@ -258,47 +260,44 @@ void build_level_schedule(const std::vector<int>& row_offsets,
         max_level = std::max(max_level, lvl);
     }
 
-    num_levels = max_level + 1;
-    std::vector<int> counts(static_cast<std::size_t>(num_levels) + 1, 0);
+    LevelSchedule out;
+    out.levels = max_level + 1;
+    std::vector<int> counts(static_cast<std::size_t>(out.levels) + 1, 0);
     for (int i = 0; i < n; ++i) counts[static_cast<std::size_t>(level[static_cast<std::size_t>(i)]) + 1] += 1;
-    for (int l = 0; l < num_levels; ++l) counts[static_cast<std::size_t>(l) + 1] += counts[static_cast<std::size_t>(l)];
+    for (int l = 0; l < out.levels; ++l) counts[static_cast<std::size_t>(l) + 1] += counts[static_cast<std::size_t>(l)];
 
-    level_ptr_out = UnifiedVector<int>(static_cast<std::size_t>(num_levels) + 1);
-    for (int l = 0; l <= num_levels; ++l) level_ptr_out[static_cast<std::size_t>(l)] = counts[static_cast<std::size_t>(l)];
-
-    rows_out = UnifiedVector<int>(static_cast<std::size_t>(n));
+    out.level_ptr = counts;
+    out.rows.assign(static_cast<std::size_t>(n), 0);
     std::vector<int> cursor(counts.begin(), counts.end() - 1);
     for (int i = 0; i < n; ++i) {
-        rows_out[static_cast<std::size_t>(cursor[static_cast<std::size_t>(level[static_cast<std::size_t>(i)])]++)] = i;
+        out.rows[static_cast<std::size_t>(cursor[static_cast<std::size_t>(level[static_cast<std::size_t>(i)])]++)] = i;
     }
+    return out;
 }
 
-}  // namespace
-
+// Everything ILU(k) computes on the host, in a storage-agnostic form. The
+// sparsity pattern (row_offsets/col_indices/diag_offsets) and both level
+// schedules are shared across the batch; only `values` varies per batch element.
 template <typename T>
-void iluk_build_level_schedule(ILUKPreconditioner<T>& M) {
-    const int n = M.n;
-    if (n <= 0) {
-        throw std::invalid_argument("ILU(k): cannot build a level schedule for an empty factor");
-    }
-    auto lu = M.lu.view();
-    const auto ro = lu.row_offsets();
-    const auto ci = lu.col_indices();
+struct HostFactor {
+    int n = 0;
+    int batch_size = 0;
+    int nnz = 0;
+    std::vector<int> row_offsets;   // n + 1
+    std::vector<int> col_indices;   // nnz
+    std::vector<T> values;          // batch_size * nnz, batch b at offset b * nnz
+    std::vector<int> diag_offsets;  // n, index into a single batch element's values
+    LevelSchedule l;
+    LevelSchedule u;
+};
 
-    std::vector<int> row_offsets(static_cast<std::size_t>(n) + 1);
-    for (int i = 0; i <= n; ++i) row_offsets[static_cast<std::size_t>(i)] = ro[i];
-    std::vector<int> col_indices(static_cast<std::size_t>(row_offsets[static_cast<std::size_t>(n)]));
-    for (std::size_t p = 0; p < col_indices.size(); ++p) col_indices[p] = ci[p];
-
-    build_level_schedule(row_offsets, col_indices, n, /*lower=*/true, M.l_rows, M.l_level_ptr, M.l_levels);
-    build_level_schedule(row_offsets, col_indices, n, /*lower=*/false, M.u_rows, M.u_level_ptr, M.u_levels);
-    M.u_diagonals_usable = u_diagonals_are_usable(M.lu, M.diag_positions, M.n, M.batch_size, M.diagonal_shift);
-}
-
-template <Backend B, typename T>
-ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
-                                     const MatrixView<T, MatrixFormat::CSR>& A,
-                                     const ILUKParams<T>& params) {
+// `check_batch_sparsity` walks every batch element's pattern, which on unified
+// memory the device has just written means a page migration per batch element.
+// iluk_buffer_size skips it: it only sizes against batch element 0's pattern, and
+// the factorization that follows validates before it uses anything.
+template <typename T>
+void validate_iluk_params_or_throw(const MatrixView<T, MatrixFormat::CSR>& A, const ILUKParams<T>& params,
+                                   bool check_batch_sparsity = true) {
     if (A.rows() != A.cols()) {
         throw std::invalid_argument("ILU(k): matrix must be square");
     }
@@ -314,18 +313,22 @@ ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
     if (params.diag_pivot_threshold < RealT<T>(0)) {
         throw std::invalid_argument("ILU(k): diag_pivot_threshold must be >= 0");
     }
-
-    const int n = A.rows();
-    const int batch_size = A.batch_size();
-
-    if (!params.validate_batch_sparsity && batch_size > 1) {
+    if (!params.validate_batch_sparsity && A.batch_size() > 1) {
         throw std::invalid_argument(
             "ILU(k): disabling batch sparsity validation is not supported; current implementation requires identical CSR sparsity across the batch");
     }
-    if (batch_size > 1 && !has_identical_batch_sparsity(A)) {
+    if (check_batch_sparsity && A.batch_size() > 1 && !has_identical_batch_sparsity(A)) {
         throw std::invalid_argument(
             "ILU(k): heterogeneous batch sparsity is not supported; batches must share an identical CSR pattern");
     }
+}
+
+template <typename T>
+HostFactor<T> compute_iluk(const MatrixView<T, MatrixFormat::CSR>& A, const ILUKParams<T>& params) {
+    validate_iluk_params_or_throw(A, params);
+
+    const int n = A.rows();
+    const int batch_size = A.batch_size();
 
     const auto ro = A.row_offsets();
     const auto ci = A.col_indices();
@@ -334,10 +337,9 @@ ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
     std::vector<int> original_row_nnz(n, 0);
     for (int i = 0; i < n; ++i) {
         original_row_nnz[static_cast<std::size_t>(i)] = ro[i + 1] - ro[i];
-        const int rs = 0;
         const int re = static_cast<int>(symbolic_rows[static_cast<std::size_t>(i)].size());
         int pos = -1;
-        for (int p = rs; p < re; ++p) {
+        for (int p = 0; p < re; ++p) {
             if (symbolic_rows[static_cast<std::size_t>(i)][static_cast<std::size_t>(p)] == i) {
                 pos = p;
                 break;
@@ -445,7 +447,11 @@ ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
     std::vector<std::vector<uint8_t>> union_keep(static_cast<std::size_t>(n));
     std::vector<std::vector<int>> compact_rows(static_cast<std::size_t>(n));
     std::vector<std::vector<int>> compact_index(static_cast<std::size_t>(n));
-    std::vector<int> row_offsets(n + 1, 0);
+
+    HostFactor<T> out;
+    out.n = n;
+    out.batch_size = batch_size;
+    out.row_offsets.assign(static_cast<std::size_t>(n) + 1, 0);
 
     for (int i = 0; i < n; ++i) {
         const auto& row_cols = symbolic_rows[static_cast<std::size_t>(i)];
@@ -467,24 +473,90 @@ ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
             compact_pos[static_cast<std::size_t>(p)] = static_cast<int>(compact_row.size());
             compact_row.push_back(row_cols[static_cast<std::size_t>(p)]);
         }
-        row_offsets[static_cast<std::size_t>(i + 1)] = row_offsets[static_cast<std::size_t>(i)] + static_cast<int>(compact_row.size());
+        out.row_offsets[static_cast<std::size_t>(i + 1)] = out.row_offsets[static_cast<std::size_t>(i)] + static_cast<int>(compact_row.size());
     }
 
-    std::vector<int> col_indices;
-    col_indices.reserve(static_cast<std::size_t>(row_offsets.back()));
+    out.col_indices.reserve(static_cast<std::size_t>(out.row_offsets.back()));
     for (int i = 0; i < n; ++i) {
         const auto& compact_row = compact_rows[static_cast<std::size_t>(i)];
-        col_indices.insert(col_indices.end(), compact_row.begin(), compact_row.end());
+        out.col_indices.insert(out.col_indices.end(), compact_row.begin(), compact_row.end());
+    }
+    out.nnz = static_cast<int>(out.col_indices.size());
+
+    out.diag_offsets.assign(static_cast<std::size_t>(n), 0);
+    out.values.assign(static_cast<std::size_t>(out.nnz) * static_cast<std::size_t>(batch_size), T(0));
+    for (int i = 0; i < n; ++i) {
+        out.diag_offsets[static_cast<std::size_t>(i)] =
+            out.row_offsets[static_cast<std::size_t>(i)] + compact_index[static_cast<std::size_t>(i)][static_cast<std::size_t>(diag_local[static_cast<std::size_t>(i)])];
+    }
+    for (int b = 0; b < batch_size; ++b) {
+        const std::size_t vbase = static_cast<std::size_t>(b) * static_cast<std::size_t>(out.nnz);
+        for (int i = 0; i < n; ++i) {
+            const auto& row_vals = batch_values[static_cast<std::size_t>(b)][static_cast<std::size_t>(i)];
+            const auto& row_keep = batch_keep[static_cast<std::size_t>(b)][static_cast<std::size_t>(i)];
+            const auto& compact_pos = compact_index[static_cast<std::size_t>(i)];
+            for (int p = 0; p < static_cast<int>(row_vals.size()); ++p) {
+                const int new_pos = compact_pos[static_cast<std::size_t>(p)];
+                if (new_pos < 0) continue;
+                if (row_keep[static_cast<std::size_t>(p)] == 0 && p != diag_local[static_cast<std::size_t>(i)]) continue;
+                out.values[vbase + static_cast<std::size_t>(out.row_offsets[static_cast<std::size_t>(i)] + new_pos)] =
+                    row_vals[static_cast<std::size_t>(p)];
+            }
+        }
     }
 
-    const int nnz = static_cast<int>(col_indices.size());
+    out.l = build_level_schedule(out.row_offsets, out.col_indices, n, /*lower=*/true);
+    out.u = build_level_schedule(out.row_offsets, out.col_indices, n, /*lower=*/false);
+    return out;
+}
+
+}  // namespace
+
+template <typename T>
+void iluk_build_level_schedule(ILUKPreconditioner<T>& M) {
+    const int n = M.n;
+    if (n <= 0) {
+        throw std::invalid_argument("ILU(k): cannot build a level schedule for an empty factor");
+    }
+    auto lu = M.lu.view();
+    const auto ro = lu.row_offsets();
+    const auto ci = lu.col_indices();
+
+    std::vector<int> row_offsets(static_cast<std::size_t>(n) + 1);
+    for (int i = 0; i <= n; ++i) row_offsets[static_cast<std::size_t>(i)] = ro[i];
+    std::vector<int> col_indices(static_cast<std::size_t>(row_offsets[static_cast<std::size_t>(n)]));
+    for (std::size_t p = 0; p < col_indices.size(); ++p) col_indices[p] = ci[p];
+
+    const auto l = build_level_schedule(row_offsets, col_indices, n, /*lower=*/true);
+    const auto u = build_level_schedule(row_offsets, col_indices, n, /*lower=*/false);
+
+    auto to_unified = [](const std::vector<int>& src) {
+        UnifiedVector<int> dst(src.size());
+        for (std::size_t i = 0; i < src.size(); ++i) dst[i] = src[i];
+        return dst;
+    };
+    M.l_rows = to_unified(l.rows);
+    M.l_level_ptr = to_unified(l.level_ptr);
+    M.l_levels = l.levels;
+    M.u_rows = to_unified(u.rows);
+    M.u_level_ptr = to_unified(u.level_ptr);
+    M.u_levels = u.levels;
+    M.u_diagonals_usable = u_diagonals_are_usable(M.lu.view().data().data(), M.diag_positions.data(),
+                                                  M.n, M.batch_size, M.diagonal_shift);
+}
+
+template <Backend B, typename T>
+ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
+                                     const MatrixView<T, MatrixFormat::CSR>& A,
+                                     const ILUKParams<T>& params) {
+    (void)ctx;
+    const auto host = compute_iluk(A, params);
+    const int n = host.n;
+    const int batch_size = host.batch_size;
+
     ILUKPreconditioner<T> result;
-    build_level_schedule(row_offsets, col_indices, n, /*lower=*/true,
-                         result.l_rows, result.l_level_ptr, result.l_levels);
-    build_level_schedule(row_offsets, col_indices, n, /*lower=*/false,
-                         result.u_rows, result.u_level_ptr, result.u_levels);
-    result.lu = Matrix<T, MatrixFormat::CSR>(n, n, nnz, batch_size);
-    result.diag_positions = UnifiedVector<int>(static_cast<std::size_t>(n * batch_size));
+    result.lu = Matrix<T, MatrixFormat::CSR>(n, n, host.nnz, batch_size);
+    result.diag_positions = UnifiedVector<int>(static_cast<std::size_t>(n) * static_cast<std::size_t>(batch_size));
     result.n = n;
     result.batch_size = batch_size;
     result.levels_of_fill = params.levels_of_fill;
@@ -494,6 +566,18 @@ ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
     result.diag_pivot_threshold = params.diag_pivot_threshold;
     result.modified_ilu = params.modified_ilu;
 
+    auto to_unified = [](const std::vector<int>& src) {
+        UnifiedVector<int> dst(src.size());
+        for (std::size_t i = 0; i < src.size(); ++i) dst[i] = src[i];
+        return dst;
+    };
+    result.l_rows = to_unified(host.l.rows);
+    result.l_level_ptr = to_unified(host.l.level_ptr);
+    result.l_levels = host.l.levels;
+    result.u_rows = to_unified(host.u.rows);
+    result.u_level_ptr = to_unified(host.u.level_ptr);
+    result.u_levels = host.u.levels;
+
     auto lu_view = result.lu.view();
     auto lu_ro = lu_view.row_offsets();
     auto lu_ci = lu_view.col_indices();
@@ -501,35 +585,117 @@ ILUKPreconditioner<T> iluk_factorize(Queue& ctx,
     for (int b = 0; b < batch_size; ++b) {
         const int ro_base = b * lu_view.offset_stride();
         const int val_base = b * lu_view.matrix_stride();
-        for (int i = 0; i < n + 1; ++i) lu_ro[ro_base + i] = row_offsets[static_cast<std::size_t>(i)];
-        for (int p = 0; p < nnz; ++p) {
-            lu_ci[val_base + p] = col_indices[static_cast<std::size_t>(p)];
-            lu_vals[val_base + p] = T(0);
+        for (int i = 0; i < n + 1; ++i) lu_ro[ro_base + i] = host.row_offsets[static_cast<std::size_t>(i)];
+        for (int p = 0; p < host.nnz; ++p) {
+            lu_ci[val_base + p] = host.col_indices[static_cast<std::size_t>(p)];
+            lu_vals[val_base + p] = host.values[static_cast<std::size_t>(b) * static_cast<std::size_t>(host.nnz) + static_cast<std::size_t>(p)];
         }
-
         for (int i = 0; i < n; ++i) {
-            const auto& row_vals = batch_values[static_cast<std::size_t>(b)][static_cast<std::size_t>(i)];
-            const auto& row_keep = batch_keep[static_cast<std::size_t>(b)][static_cast<std::size_t>(i)];
-            const auto& compact_pos = compact_index[static_cast<std::size_t>(i)];
-            for (int p = 0; p < static_cast<int>(row_vals.size()); ++p) {
-                const int new_pos = compact_pos[static_cast<std::size_t>(p)];
-                if (new_pos < 0) continue;
-                if (row_keep[static_cast<std::size_t>(p)] == 0 && p != diag_local[static_cast<std::size_t>(i)]) continue;
-                lu_vals[val_base + row_offsets[static_cast<std::size_t>(i)] + new_pos] = row_vals[static_cast<std::size_t>(p)];
-            }
-            result.diag_positions[static_cast<std::size_t>(b * n + i)] = val_base + row_offsets[static_cast<std::size_t>(i)] + compact_pos[static_cast<std::size_t>(diag_local[static_cast<std::size_t>(i)])];
+            result.diag_positions[static_cast<std::size_t>(b * n + i)] = val_base + host.diag_offsets[static_cast<std::size_t>(i)];
         }
     }
 
-    result.u_diagonals_usable = u_diagonals_are_usable(result.lu, result.diag_positions, n, batch_size,
-                                                       result.diagonal_shift);
+    result.u_diagonals_usable = u_diagonals_are_usable(lu_vals.data(), result.diag_positions.data(), n,
+                                                       batch_size, result.diagonal_shift);
 
     return result;
 }
 
 template <Backend B, typename T>
+size_t iluk_buffer_size(Queue& ctx,
+                        const MatrixView<T, MatrixFormat::CSR>& A,
+                        const ILUKParams<T>& params) {
+    validate_iluk_params_or_throw(A, params, /*check_batch_sparsity=*/false);
+
+    const int n = A.rows();
+    const int batch_size = A.batch_size();
+
+    // Size against the symbolic pattern. The numeric phase only ever prunes
+    // entries (drop tolerance, fill quota), so this is an upper bound on the
+    // final nnz and the workspace factorization is guaranteed to fit.
+    const auto symbolic_rows = symbolic_iluk_pattern_single(A.row_offsets(), A.col_indices(), n, 0, 0,
+                                                            params.levels_of_fill);
+    size_t nnz_upper = 0;
+    for (const auto& row : symbolic_rows) nnz_upper += row.size();
+
+    size_t bytes = 0;
+    bytes += BumpAllocator::allocation_size<T>(ctx, nnz_upper * static_cast<size_t>(batch_size));    // values
+    bytes += BumpAllocator::allocation_size<int>(ctx, nnz_upper * static_cast<size_t>(batch_size));  // col indices
+    bytes += BumpAllocator::allocation_size<int>(ctx, static_cast<size_t>(n + 1) * static_cast<size_t>(batch_size));  // row offsets
+    bytes += BumpAllocator::allocation_size<int>(ctx, static_cast<size_t>(n) * static_cast<size_t>(batch_size));      // diag positions
+    // Level counts are bounded by n, so the pointer arrays need at most n + 1 slots.
+    bytes += BumpAllocator::allocation_size<int>(ctx, static_cast<size_t>(n)) * 2;      // l_rows, u_rows
+    bytes += BumpAllocator::allocation_size<int>(ctx, static_cast<size_t>(n + 1)) * 2;  // l/u level_ptr
+    return bytes;
+}
+
+template <Backend B, typename T>
+ILUKView<T> iluk_factorize(Queue& ctx,
+                           const MatrixView<T, MatrixFormat::CSR>& A,
+                           Span<std::byte> workspace,
+                           const ILUKParams<T>& params,
+                           size_t* bytes_used) {
+    const auto host = compute_iluk(A, params);
+    const int n = host.n;
+    const int batch_size = host.batch_size;
+    const int nnz = host.nnz;
+
+    auto pool = BumpAllocator(workspace);
+    auto values = pool.allocate<T>(ctx, static_cast<size_t>(nnz) * static_cast<size_t>(batch_size));
+    auto col_indices = pool.allocate<int>(ctx, static_cast<size_t>(nnz) * static_cast<size_t>(batch_size));
+    auto row_offsets = pool.allocate<int>(ctx, static_cast<size_t>(n + 1) * static_cast<size_t>(batch_size));
+    auto diag_positions = pool.allocate<int>(ctx, static_cast<size_t>(n) * static_cast<size_t>(batch_size));
+    auto l_rows = pool.allocate<int>(ctx, static_cast<size_t>(n));
+    auto u_rows = pool.allocate<int>(ctx, static_cast<size_t>(n));
+    auto l_level_ptr = pool.allocate<int>(ctx, host.l.level_ptr.size());
+    auto u_level_ptr = pool.allocate<int>(ctx, host.u.level_ptr.size());
+
+    // The pattern is identical across the batch, but the apply kernel indexes
+    // values and column indices with the same matrix stride, so both are
+    // replicated per batch element rather than shared.
+    for (int b = 0; b < batch_size; ++b) {
+        const size_t val_base = static_cast<size_t>(b) * static_cast<size_t>(nnz);
+        const size_t ro_base = static_cast<size_t>(b) * static_cast<size_t>(n + 1);
+        for (int i = 0; i < n + 1; ++i) row_offsets[ro_base + static_cast<size_t>(i)] = host.row_offsets[static_cast<std::size_t>(i)];
+        for (int p = 0; p < nnz; ++p) {
+            col_indices[val_base + static_cast<size_t>(p)] = host.col_indices[static_cast<std::size_t>(p)];
+            values[val_base + static_cast<size_t>(p)] = host.values[val_base + static_cast<size_t>(p)];
+        }
+        for (int i = 0; i < n; ++i) {
+            diag_positions[static_cast<size_t>(b * n + i)] = static_cast<int>(val_base) + host.diag_offsets[static_cast<std::size_t>(i)];
+        }
+    }
+    for (int i = 0; i < n; ++i) {
+        l_rows[static_cast<size_t>(i)] = host.l.rows[static_cast<std::size_t>(i)];
+        u_rows[static_cast<size_t>(i)] = host.u.rows[static_cast<std::size_t>(i)];
+    }
+    for (std::size_t i = 0; i < host.l.level_ptr.size(); ++i) l_level_ptr[i] = host.l.level_ptr[i];
+    for (std::size_t i = 0; i < host.u.level_ptr.size(); ++i) u_level_ptr[i] = host.u.level_ptr[i];
+
+    ILUKView<T> view;
+    view.lu = MatrixView<T, MatrixFormat::CSR>(values.data(), row_offsets.data(), col_indices.data(), nnz, n, n,
+                                               nnz, n + 1, batch_size);
+    view.diag_positions = diag_positions;
+    view.l_rows = l_rows;
+    view.l_level_ptr = l_level_ptr;
+    view.l_levels = host.l.levels;
+    view.u_rows = u_rows;
+    view.u_level_ptr = u_level_ptr;
+    view.u_levels = host.u.levels;
+    view.n = n;
+    view.batch_size = batch_size;
+    view.diagonal_shift = params.diagonal_shift;
+    view.u_diagonals_usable = u_diagonals_are_usable(values.data(), diag_positions.data(), n, batch_size,
+                                                     params.diagonal_shift);
+    if (bytes_used != nullptr) {
+        *bytes_used = static_cast<size_t>(workspace.size() - pool.remaining().size());
+    }
+    return view;
+}
+
+template <Backend B, typename T>
 Event iluk_apply(Queue& ctx,
-                 const ILUKPreconditioner<T>& M,
+                 const ILUKView<T>& M,
                  const MatrixView<T, MatrixFormat::Dense>& rhs,
                  const MatrixView<T, MatrixFormat::Dense>& out,
                  Span<std::byte>) {
@@ -644,7 +810,7 @@ Event iluk_apply(Queue& ctx,
 }
 
 template <Backend B, typename T>
-size_t iluk_apply_buffer_size(Queue&, const ILUKPreconditioner<T>&, const MatrixView<T, MatrixFormat::Dense>&, const MatrixView<T, MatrixFormat::Dense>&) {
+size_t iluk_apply_buffer_size(Queue&, const ILUKView<T>&, const MatrixView<T, MatrixFormat::Dense>&, const MatrixView<T, MatrixFormat::Dense>&) {
     return 0;
 }
 
@@ -659,8 +825,10 @@ ILUK_INSTANTIATE_COMMON(std::complex<double>)
 
 #define ILUK_INSTANTIATE(BACK, FP) \
     template ILUKPreconditioner<FP> iluk_factorize<BACK, FP>(Queue&, const MatrixView<FP, MatrixFormat::CSR>&, const ILUKParams<FP>&); \
-    template Event iluk_apply<BACK, FP>(Queue&, const ILUKPreconditioner<FP>&, const MatrixView<FP, MatrixFormat::Dense>&, const MatrixView<FP, MatrixFormat::Dense>&, Span<std::byte>); \
-    template size_t iluk_apply_buffer_size<BACK, FP>(Queue&, const ILUKPreconditioner<FP>&, const MatrixView<FP, MatrixFormat::Dense>&, const MatrixView<FP, MatrixFormat::Dense>&);
+    template ILUKView<FP> iluk_factorize<BACK, FP>(Queue&, const MatrixView<FP, MatrixFormat::CSR>&, Span<std::byte>, const ILUKParams<FP>&, size_t*); \
+    template size_t iluk_buffer_size<BACK, FP>(Queue&, const MatrixView<FP, MatrixFormat::CSR>&, const ILUKParams<FP>&); \
+    template Event iluk_apply<BACK, FP>(Queue&, const ILUKView<FP>&, const MatrixView<FP, MatrixFormat::Dense>&, const MatrixView<FP, MatrixFormat::Dense>&, Span<std::byte>); \
+    template size_t iluk_apply_buffer_size<BACK, FP>(Queue&, const ILUKView<FP>&, const MatrixView<FP, MatrixFormat::Dense>&, const MatrixView<FP, MatrixFormat::Dense>&);
 
 #if BATCHLAS_HAS_CUDA_BACKEND
 ILUK_INSTANTIATE(Backend::CUDA, float)

--- a/src/extensions/syevx.cc
+++ b/src/extensions/syevx.cc
@@ -199,13 +199,23 @@ namespace batchlas {
         // The chosen SYEV provider can change with matrix size (e.g. CTA for n<=32
         // but blocked/vendor for larger n), so a single pre-sized workspace must cover
         // the maximum of the internal problems.
+        // Restart iterations solve a 2*block_vectors projected problem rather than the
+        // full 3*block_vectors one (see Nvecs below). Because the provider is chosen
+        // from the shape, that intermediate size can demand *more* workspace than
+        // either the block_vectors or 3*block_vectors problem, so it has to be sized
+        // explicitly instead of assumed to be bounded by them.
+        auto StAS_restart = MatrixView(StAS_base, block_vectors * 2, block_vectors * 2,
+                                       StAS_base.ld(), StAS_base.stride());
         const size_t ws_xtax = syev_buffer_size<B>(ctx, XtAX, lambdas, JobType::EigenVectors, Uplo::Lower);
+        const size_t ws_stas_restart = syev_buffer_size<B>(ctx, StAS_restart, lambdas, JobType::EigenVectors, Uplo::Lower);
         const size_t ws_stas = syev_buffer_size<B>(ctx, StAS_base, lambdas, JobType::EigenVectors, Uplo::Lower);
-        size_t ws_projected = std::max(ws_xtax, ws_stas);
+        size_t ws_projected = std::max(ws_xtax, std::max(ws_stas_restart, ws_stas));
         if (prefer_vendor_projected_syev) {
             const size_t ws_xtax_vendor = backend::syev_vendor_buffer_size<B, T>(ctx, XtAX, lambdas, JobType::EigenVectors, Uplo::Lower);
+            const size_t ws_stas_restart_vendor = backend::syev_vendor_buffer_size<B, T>(ctx, StAS_restart, lambdas, JobType::EigenVectors, Uplo::Lower);
             const size_t ws_stas_vendor = backend::syev_vendor_buffer_size<B, T>(ctx, StAS_base, lambdas, JobType::EigenVectors, Uplo::Lower);
-            ws_projected = std::max(ws_projected, std::max(ws_xtax_vendor, ws_stas_vendor));
+            ws_projected = std::max(ws_projected,
+                                    std::max(ws_xtax_vendor, std::max(ws_stas_restart_vendor, ws_stas_vendor)));
         }
         auto syev_workspace = pool.allocate<std::byte>(ctx, ws_projected);
         auto ortho_workspace = pool.allocate<std::byte>(ctx, std::max(  ortho_buffer_size<B>(ctx, R, XP, Transpose::NoTrans, Transpose::NoTrans, params.algorithm),
@@ -647,20 +657,35 @@ namespace batchlas {
                     static_cast<int>(block_vectors * 3),
                     static_cast<int>(3 * 3 * block_vectors * block_vectors),
                     static_cast<int>(batch_size), nullptr);
-                auto StAS_base_dummy = MatrixView<T, MatrixFormat::Dense>(nullptr,
-                    static_cast<int>(block_vectors * 3), static_cast<int>(block_vectors * 3),
-                    static_cast<int>(block_vectors * 3), static_cast<int>(3 * 3 * block_vectors * block_vectors),
-                    static_cast<int>(batch_size), nullptr);
+                // The projected problem is Nvecs x Nvecs with Nvecs = 2*block_vectors on
+                // restart iterations and 3*block_vectors otherwise, always viewed with the
+                // backing buffer's ld. Both must be sized: syev picks its provider from the
+                // matrix shape, so workspace demand is not monotone in Nvecs and the
+                // 3*block_vectors figure does not bound the 2*block_vectors one. Omitting
+                // the restart shape made syevx throw "insufficient workspace for chosen
+                // provider" at, for instance, block_vectors = 12 and 16.
+                auto projected_dummy = [&](int64_t nvecs) {
+                    return MatrixView<T, MatrixFormat::Dense>(nullptr,
+                        static_cast<int>(nvecs), static_cast<int>(nvecs),
+                        static_cast<int>(block_vectors * 3),
+                        static_cast<int>(3 * 3 * block_vectors * block_vectors),
+                        static_cast<int>(batch_size), nullptr);
+                };
+                auto StAS_restart_dummy = projected_dummy(block_vectors * 2);
+                auto StAS_base_dummy = projected_dummy(block_vectors * 3);
 
                 const size_t ws_xtax = syev_buffer_size<B>(ctx, XtAX_dummy, Span<typename base_type<T>::type>(), JobType::EigenVectors, Uplo::Lower);
+                const size_t ws_stas_restart = syev_buffer_size<B>(ctx, StAS_restart_dummy, Span<typename base_type<T>::type>(), JobType::EigenVectors, Uplo::Lower);
                 const size_t ws_stas = syev_buffer_size<B>(ctx, StAS_base_dummy, Span<typename base_type<T>::type>(), JobType::EigenVectors, Uplo::Lower);
-                size_t ws_projected = std::max(ws_xtax, ws_stas);
+                size_t ws_projected = std::max(ws_xtax, std::max(ws_stas_restart, ws_stas));
 
                 // Match the runtime behavior: projected problems prefer the vendor SYEV path on GPUs.
                 if constexpr (B != Backend::NETLIB) {
                     const size_t ws_xtax_vendor = backend::syev_vendor_buffer_size<B, T>(ctx, XtAX_dummy, Span<typename base_type<T>::type>(), JobType::EigenVectors, Uplo::Lower);
+                    const size_t ws_stas_restart_vendor = backend::syev_vendor_buffer_size<B, T>(ctx, StAS_restart_dummy, Span<typename base_type<T>::type>(), JobType::EigenVectors, Uplo::Lower);
                     const size_t ws_stas_vendor = backend::syev_vendor_buffer_size<B, T>(ctx, StAS_base_dummy, Span<typename base_type<T>::type>(), JobType::EigenVectors, Uplo::Lower);
-                    ws_projected = std::max(ws_projected, std::max(ws_xtax_vendor, ws_stas_vendor));
+                    ws_projected = std::max(ws_projected,
+                                            std::max(ws_xtax_vendor, std::max(ws_stas_restart_vendor, ws_stas_vendor)));
                 }
 
                 work_size += BumpAllocator::allocation_size<std::byte>(ctx, ws_projected);

--- a/src/extensions/syevx.cc
+++ b/src/extensions/syevx.cc
@@ -52,16 +52,29 @@ namespace batchlas {
             std::cout << msg << std::endl;
             ctx.wait_and_throw();
         };
+        if (params.preconditioner != nullptr && params.build_preconditioner) {
+            throw std::invalid_argument(
+                "syevx: SyevxParams::preconditioner and SyevxParams::build_preconditioner are "
+                "mutually exclusive; supply a factor or ask syevx to build one, not both");
+        }
+        const bool use_preconditioner = params.preconditioner != nullptr || params.build_preconditioner;
         // An ILU(k) factorization approximates A^{-1}. Applying it to the LOBPCG
         // residual accelerates convergence toward the smallest eigenpairs, but for
         // the largest eigenpairs it suppresses the wanted directions and boosts the
         // unwanted ones -- measurably worse than running unpreconditioned. Reject the
         // combination instead of silently degrading.
-        if (params.preconditioner != nullptr && params.find_largest) {
+        if (use_preconditioner && params.find_largest) {
             throw std::invalid_argument(
                 "syevx: an ILU(k) preconditioner approximates A^{-1} and is only valid when "
                 "searching for the smallest eigenpairs; set SyevxParams::find_largest = false "
-                "or clear SyevxParams::preconditioner");
+                "or clear SyevxParams::preconditioner / build_preconditioner");
+        }
+        if constexpr (MFormat != MatrixFormat::CSR) {
+            if (params.build_preconditioner) {
+                throw std::invalid_argument(
+                    "syevx: SyevxParams::build_preconditioner requires a CSR matrix; ILU(k) is "
+                    "only defined for sparse input");
+            }
         }
 
         // Implementation of the syevx function
@@ -120,8 +133,25 @@ namespace batchlas {
                 pool.allocate<T*>(ctx, batch_size).data());
         }
 
-        MatrixView<T, MatrixFormat::Dense> R_contiguous;
+        // Built either from the caller's factor or, when asked, from one formed here
+        // out of `workspace` -- no allocation of its own, so syevx stays pool-only.
+        ILUKView<T> precond;
         if (params.preconditioner != nullptr) {
+            precond = params.preconditioner->view();
+        } else if (params.build_preconditioner) {
+            if constexpr (MFormat == MatrixFormat::CSR) {
+                // Hand ILU(k) the unclaimed tail of the pool and take back only what
+                // it used. Asking iluk_buffer_size first would work, but it costs a
+                // second symbolic factorization on the critical path for a number
+                // the factorization is about to compute anyway.
+                size_t iluk_bytes = 0;
+                precond = iluk_factorize<B, T>(ctx, A, pool.remaining(), params.iluk_params, &iluk_bytes);
+                pool.consume(iluk_bytes);
+            }
+        }
+
+        MatrixView<T, MatrixFormat::Dense> R_contiguous;
+        if (use_preconditioner) {
             auto R_contiguous_data = pool.allocate<T>(ctx, n * block_vectors * batch_size);
             R_contiguous = MatrixView(
                 R_contiguous_data.data(),
@@ -444,11 +474,11 @@ namespace batchlas {
                 break;
             }
 
-            if (params.preconditioner != nullptr) {
+            if (use_preconditioner) {
                 trace("syevx: ILU(k) apply on residuals");
                 MatrixView<T, MatrixFormat::Dense>::copy(ctx, R_contiguous, R);
                 ctx.wait_and_throw();
-                iluk_apply<B>(ctx, *params.preconditioner, R_contiguous, R_preconditioned);
+                iluk_apply<B, T>(ctx, precond, R_contiguous, R_preconditioned);
                 MatrixView<T, MatrixFormat::Dense>::copy(ctx, R, R_preconditioned);
                 ctx.wait_and_throw();
                 trace("syevx: ILU(k) apply done");
@@ -642,9 +672,18 @@ namespace batchlas {
                 work_size += BumpAllocator::allocation_size<std::byte>(ctx,spmm_buffer_size<B>(ctx, A, Xview, AXview, T(1.0), T(0.0), Transpose::NoTrans, Transpose::NoTrans));
             }
                         
-            if (params.preconditioner != nullptr) {
+            if (params.preconditioner != nullptr || params.build_preconditioner) {
                 work_size += BumpAllocator::allocation_size<T>(ctx, n * block_vectors * batch_size);            //R_contiguous_data
                 work_size += BumpAllocator::allocation_size<T*>(ctx, batch_size);                               //R_contiguous ptrs
+            }
+            if constexpr (MFormat == MatrixFormat::CSR) {
+                // This runs ILU(k)'s symbolic phase to get an upper bound on the fill.
+                // syevx itself does not repeat it -- it sub-allocates from the pool tail
+                // and reports back what it took -- so the cost lands here, on the sizing
+                // call a caller makes once and amortizes over every solve.
+                if (params.build_preconditioner) {
+                    work_size += BumpAllocator::allocation_size<std::byte>(ctx, iluk_buffer_size<B, T>(ctx, A, params.iluk_params));
+                }
             }
             work_size += BumpAllocator::allocation_size<T*>(ctx, batch_size) * 7;
             if (jobz == JobType::EigenVectors) {

--- a/src/extensions/syevx.cc
+++ b/src/extensions/syevx.cc
@@ -52,6 +52,18 @@ namespace batchlas {
             std::cout << msg << std::endl;
             ctx.wait_and_throw();
         };
+        // An ILU(k) factorization approximates A^{-1}. Applying it to the LOBPCG
+        // residual accelerates convergence toward the smallest eigenpairs, but for
+        // the largest eigenpairs it suppresses the wanted directions and boosts the
+        // unwanted ones -- measurably worse than running unpreconditioned. Reject the
+        // combination instead of silently degrading.
+        if (params.preconditioner != nullptr && params.find_largest) {
+            throw std::invalid_argument(
+                "syevx: an ILU(k) preconditioner approximates A^{-1} and is only valid when "
+                "searching for the smallest eigenpairs; set SyevxParams::find_largest = false "
+                "or clear SyevxParams::preconditioner");
+        }
+
         // Implementation of the syevx function
         // This function computes the eigenvalues and eigenvectors of a symmetric matrix
         int64_t block_vectors = neigs + params.extra_directions;

--- a/src/matrix.cc
+++ b/src/matrix.cc
@@ -1109,11 +1109,14 @@ Event MatrixView<T, MType>::fill_random_sparse_hermitian(const Queue& ctx,
 
     for (int b = 0; b < batch_size_; ++b) {
         row_offsets_ptr[static_cast<std::size_t>(b) * static_cast<std::size_t>(offset_stride_)] = 0;
-        std::exclusive_scan(
+        // row_offsets[0] = 0 and row_offsets[i+1] = sum(counts[0..i]), i.e. an
+        // inclusive scan of the per-row counts written one slot in. Using an
+        // exclusive scan here shifts every offset down by one row, which leaves
+        // row 0 empty and makes rows 0 and 1 share a start index.
+        std::inclusive_scan(
             row_counts.data() + static_cast<std::size_t>(b) * static_cast<std::size_t>(n),
             row_counts.data() + static_cast<std::size_t>(b + 1) * static_cast<std::size_t>(n),
-            row_offsets_ptr + static_cast<std::size_t>(b) * static_cast<std::size_t>(offset_stride_) + 1,
-            0);
+            row_offsets_ptr + static_cast<std::size_t>(b) * static_cast<std::size_t>(offset_stride_) + 1);
     }
     ctx.wait_and_throw();
 

--- a/tests/iluk_tests.cc
+++ b/tests/iluk_tests.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <optional>
 #include <cmath>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -952,6 +953,68 @@ TEST_F(ILUKTests, SyevxBuildPreconditionerRejectsIllegalConfigurations) {
         syevx<test_utils::gpu_backend>(*ctx, view, W, neigs, workspace, JobType::NoEigenVectors,
                                        MatrixView<float, MatrixFormat::Dense>(), params));
     ctx->wait_and_throw();
+}
+
+// Two numeric implementations exist -- host for small batches, device beyond the
+// crossover -- so they must not drift apart. Forcing each in turn and comparing the
+// factor entry by entry is what keeps them honest.
+TEST_F(ILUKTests, HostAndDeviceFactorizationsAgree) {
+    struct Case { int m; int batch; int level; float drop; float fill; };
+    const std::vector<Case> cases = {
+        {8, 1, 0, 1e-4f, 10.0f},
+        {8, 3, 1, 1e-4f, 10.0f},
+        {12, 5, 2, 1e-4f, 10.0f},
+        {8, 4, 1, 1e-2f, 10.0f},   // drop tolerance actually bites
+        {8, 4, 2, 0.0f, 1.0f},     // fill quota actually bites
+    };
+
+    for (const auto& c : cases) {
+        auto csr = make_laplacian_2d(c.m, c.batch);
+        auto view = csr.view();
+        ILUKParams<float> params;
+        params.levels_of_fill = c.level;
+        params.drop_tolerance = c.drop;
+        params.fill_factor = c.fill;
+
+        auto factor_with = [&](const char* mode) {
+            setenv("BATCHLAS_ILUK_DEVICE", mode, 1);
+            auto M = iluk_factorize<test_utils::gpu_backend>(*ctx, view, params);
+            ctx->wait_and_throw();
+            unsetenv("BATCHLAS_ILUK_DEVICE");
+            return M;
+        };
+
+        auto host = factor_with("0");
+        auto device = factor_with("1");
+
+        const std::string label = "m=" + std::to_string(c.m) + " batch=" + std::to_string(c.batch) +
+                                  " level=" + std::to_string(c.level);
+        ASSERT_EQ(host.lu.nnz(), device.lu.nnz()) << label << ": compacted patterns differ";
+        ASSERT_EQ(host.l_levels, device.l_levels) << label;
+        ASSERT_EQ(host.u_levels, device.u_levels) << label;
+        EXPECT_EQ(host.u_diagonals_usable, device.u_diagonals_usable) << label;
+
+        auto hv = host.lu.view();
+        auto dv = device.lu.view();
+        const int n = c.m * c.m;
+        for (int b = 0; b < c.batch; ++b) {
+            for (int i = 0; i <= n; ++i) {
+                ASSERT_EQ(hv.row_offsets()[b * hv.offset_stride() + i],
+                          dv.row_offsets()[b * dv.offset_stride() + i]) << label << " row " << i;
+            }
+            for (int p = 0; p < host.lu.nnz(); ++p) {
+                ASSERT_EQ(hv.col_indices()[b * hv.matrix_stride() + p],
+                          dv.col_indices()[b * dv.matrix_stride() + p]) << label << " entry " << p;
+                const float a = hv.data()[b * hv.matrix_stride() + p];
+                const float d = dv.data()[b * dv.matrix_stride() + p];
+                EXPECT_NEAR(a, d, 1e-4f * std::max(1.0f, std::abs(a)))
+                    << label << " batch " << b << " entry " << p;
+            }
+            for (int i = 0; i < n; ++i) {
+                EXPECT_EQ(host.diag_positions[b * n + i], device.diag_positions[b * n + i]) << label;
+            }
+        }
+    }
 }
 
 // Dense counterpart of make_laplacian_2d, for timing a full eigendecomposition

--- a/tests/iluk_tests.cc
+++ b/tests/iluk_tests.cc
@@ -2,6 +2,7 @@
 
 #include <batchlas/backend_config.h>
 #include <blas/linalg.hh>
+#include <blas/functions/syev.hh>
 
 #include <algorithm>
 #include <optional>
@@ -953,12 +954,185 @@ TEST_F(ILUKTests, SyevxBuildPreconditionerRejectsIllegalConfigurations) {
     ctx->wait_and_throw();
 }
 
+// Dense counterpart of make_laplacian_2d, for timing a full eigendecomposition
+// of the same operator that syevx is handed in CSR form.
+Matrix<float, MatrixFormat::Dense> make_laplacian_2d_dense(int m, int batch) {
+    const int n = m * m;
+    Matrix<float, MatrixFormat::Dense> A(n, n, batch);
+    auto v = A.view();
+    auto data = v.data();
+    for (int b = 0; b < batch; ++b) {
+        const int64_t base = static_cast<int64_t>(b) * v.stride();
+        for (int64_t i = 0; i < static_cast<int64_t>(n) * n; ++i) data[base + i] = 0.0f;
+        for (int idx = 0; idx < n; ++idx) {
+            const int r = idx / m;
+            const int c = idx % m;
+            auto put = [&](int row, int col, float val) {
+                data[base + static_cast<int64_t>(col) * v.ld() + row] = val;
+            };
+            // make_laplacian_2d perturbs each batch element's diagonal so the batch is
+            // genuinely distinct systems; the dense reference must match it exactly or
+            // the cross-check compares two different operators.
+            put(idx, idx, 4.0f + 0.01f * static_cast<float>(b));
+            if (r > 0)     put(idx, idx - m, -1.0f);
+            if (c > 0)     put(idx, idx - 1, -1.0f);
+            if (c < m - 1) put(idx, idx + 1, -1.0f);
+            if (r < m - 1) put(idx, idx + m, -1.0f);
+        }
+    }
+    return A;
+}
+
+
+// Where does computing k eigenpairs iteratively beat a full dense
+// eigendecomposition? syev returns the whole spectrum, syevx only the k smallest,
+// so this is the practical question of when to reach for which.
+// Run with --gtest_also_run_disabled_tests.
+TEST_F(ILUKTests, DISABLED_SyevxVsSyevThreshold) {
+    struct Shape { int m; int batch; };
+    const std::vector<Shape> shapes = {
+        {16, 1}, {16, 64}, {16, 256}, {16, 1024},
+        {32, 1}, {32, 64}, {32, 256},
+        {64, 1}, {64, 16},
+    };
+    const std::vector<int> ks = {1, 2, 4, 8, 16, 32};
+    constexpr int max_iters = 500;
+    // syevx's criterion is ||r|| / (||x|| |lambda|); the smallest Laplacian
+    // eigenvalues are O(1e-3), so 1e-6 is below float32 resolution here.
+    constexpr float tol = 1e-3f;
+    constexpr int level = 1;
+    constexpr int reps = 3;
+
+    auto seconds_since = [](std::chrono::steady_clock::time_point t0) {
+        return std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
+    };
+    auto median = [](std::vector<double> v) {
+        std::sort(v.begin(), v.end());
+        return v[v.size() / 2];
+    };
+
+    std::cout << "\n[syevx vs syev] 2D Laplacian, ILU(" << level << "), tol=" << tol
+              << ", max_iters=" << max_iters << ", block width = k\n";
+    std::cout << "  n  batch  k  syev_s  lobpcg_s  lobpcg_it  iluk_s  iluk_it  "
+                 "speedup_lobpcg  speedup_iluk  max_rel_err  note\n";
+
+    for (const auto& s : shapes) {
+        const int n = s.m * s.m;
+        auto csr = make_laplacian_2d(s.m, s.batch);
+        auto csr_view = csr.view();
+        auto dense_ref = make_laplacian_2d_dense(s.m, s.batch);
+
+        // syev overwrites its input, so each timed call gets a fresh copy; the copy is
+        // untimed because a caller with a matrix in hand would not pay it.
+        Matrix<float, MatrixFormat::Dense> dense_work(n, n, s.batch);
+        UnifiedVector<float> W_full(static_cast<std::size_t>(n) * s.batch, 0.0f);
+
+        double syev_s = std::numeric_limits<double>::quiet_NaN();
+        std::string shape_note = "";
+        bool have_syev = false;
+        try {
+            UnifiedVector<std::byte> ws(syev_buffer_size<test_utils::gpu_backend>(
+                *ctx, dense_work.view(), W_full, JobType::NoEigenVectors, Uplo::Lower));
+            std::vector<double> samples;
+            for (int r = 0; r < reps + 1; ++r) {  // first pass is a discarded warm-up
+                MatrixView<float, MatrixFormat::Dense>::copy(*ctx, dense_work.view(), dense_ref.view());
+                ctx->wait_and_throw();
+                const auto t0 = std::chrono::steady_clock::now();
+                syev<test_utils::gpu_backend>(*ctx, dense_work.view(), W_full, JobType::NoEigenVectors,
+                                              Uplo::Lower, ws);
+                ctx->wait_and_throw();
+                if (r > 0) samples.push_back(seconds_since(t0));
+            }
+            syev_s = median(samples);
+            have_syev = true;
+        } catch (const std::exception& e) {
+            shape_note = std::string("syev_failed:") + e.what();
+        }
+
+        auto run_syevx = [&](int k, bool preconditioned, int& iters_out, double& max_rel_err) {
+            UnifiedVector<float> W(static_cast<std::size_t>(k) * s.batch, 0.0f);
+            UnifiedVector<int32_t> iters(s.batch, 0);
+            SyevxInstrumentation<float> instr;
+            instr.max_iterations = max_iters;
+            instr.iterations_done = iters.data();
+
+            SyevxParams<float> params;
+            params.iterations = max_iters;
+            params.extra_directions = 0;  // block width == k, i.e. "give me exactly k"
+            params.find_largest = false;
+            params.absolute_tolerance = tol;
+            params.relative_tolerance = tol;
+            params.instrumentation = &instr;
+            params.build_preconditioner = preconditioned;
+            params.iluk_params.levels_of_fill = level;
+
+            UnifiedVector<std::byte> ws(syevx_buffer_size<test_utils::gpu_backend>(
+                *ctx, csr_view, W, static_cast<size_t>(k), JobType::NoEigenVectors,
+                MatrixView<float, MatrixFormat::Dense>(), params));
+            std::vector<double> samples;
+            for (int r = 0; r < reps + 1; ++r) {
+                const auto t0 = std::chrono::steady_clock::now();
+                syevx<test_utils::gpu_backend>(*ctx, csr_view, W, static_cast<size_t>(k), ws,
+                                               JobType::NoEigenVectors,
+                                               MatrixView<float, MatrixFormat::Dense>(), params);
+                ctx->wait_and_throw();
+                if (r > 0) samples.push_back(seconds_since(t0));
+            }
+            iters_out = *std::max_element(iters.begin(), iters.end());
+
+            // Cross-check against syev's spectrum: a speedup only means something if
+            // the two agree on the answer. W_full holds all n eigenvalues ascending.
+            max_rel_err = 0.0;
+            if (have_syev) {
+                for (int b = 0; b < s.batch; ++b) {
+                    for (int i = 0; i < k; ++i) {
+                        const double ref = W_full[static_cast<std::size_t>(b) * n + i];
+                        const double got = W[static_cast<std::size_t>(b) * k + i];
+                        max_rel_err = std::max(max_rel_err, std::abs(got - ref) / std::max(1e-12, std::abs(ref)));
+                    }
+                }
+            }
+            return median(samples);
+        };
+
+        for (int k : ks) {
+            if (k > n / 4) continue;
+            std::string note = shape_note;
+            double lob_s = std::numeric_limits<double>::quiet_NaN();
+            double ilu_s = std::numeric_limits<double>::quiet_NaN();
+            int lob_it = -1, ilu_it = -1;
+            double err_lob = 0.0, err_ilu = 0.0;
+            try {
+                lob_s = run_syevx(k, false, lob_it, err_lob);
+            } catch (const std::exception& e) { note += std::string(" lobpcg_failed:") + e.what(); }
+            try {
+                ilu_s = run_syevx(k, true, ilu_it, err_ilu);
+            } catch (const std::exception& e) { note += std::string(" iluk_failed:") + e.what(); }
+
+            if (lob_it >= max_iters || ilu_it >= max_iters) note += " NOT_CONVERGED";
+
+            std::cout << "  " << n << "  " << s.batch << "  " << k
+                      << "  " << syev_s
+                      << "  " << lob_s << "  " << lob_it
+                      << "  " << ilu_s << "  " << ilu_it
+                      << "  " << (syev_s / lob_s) << "  " << (syev_s / ilu_s)
+                      << "  " << std::max(err_lob, err_ilu)
+                      << "  " << (note.empty() ? "-" : note) << "\n";
+        }
+    }
+}
+
 // Not a correctness test: an end-to-end cost model for whether building the
 // preconditioner pays for itself. Run with --gtest_also_run_disabled_tests.
 TEST_F(ILUKTests, DISABLED_PreconditionerAmortizationBenchmark) {
     struct Shape { int m; int batch; };
+    // Batch is swept well past the point where the GPU fills up, so the curve
+    // shows where per-solve cost stops falling and the preconditioner's advantage
+    // settles rather than just its small-batch behaviour.
     const std::vector<Shape> shapes = {
-        {16, 1}, {16, 16}, {32, 1}, {32, 16}, {64, 1}, {64, 16},
+        {16, 1}, {16, 16}, {16, 64}, {16, 256}, {16, 1024},
+        {32, 1}, {32, 16}, {32, 64}, {32, 256},
+        {64, 1}, {64, 16}, {64, 64},
     };
     constexpr size_t neigs = 5;
     constexpr size_t extra_dirs = 5;

--- a/tests/iluk_tests.cc
+++ b/tests/iluk_tests.cc
@@ -114,6 +114,51 @@ T csr_entry(const MatrixView<T, MatrixFormat::CSR>& A, int row, int col, int bat
     return T(0);
 }
 
+
+// Canonical 5-point 2D Laplacian on an m x m grid: the standard problem class
+// ILU preconditioning targets, and one where LOBPCG actually reaches tolerance
+// (the random sparse Hermitian matrices used elsewhere here do not).
+Matrix<float, MatrixFormat::CSR> make_laplacian_2d(int m, int batch) {
+    const int n = m * m;
+    std::vector<int> ro(static_cast<std::size_t>(n) + 1, 0);
+    std::vector<int> ci;
+    std::vector<float> va;
+    std::vector<int> diag_slot(static_cast<std::size_t>(n), 0);
+
+    for (int idx = 0; idx < n; ++idx) {
+        const int r = idx / m;
+        const int c = idx % m;
+        if (r > 0)     { ci.push_back(idx - m); va.push_back(-1.0f); }
+        if (c > 0)     { ci.push_back(idx - 1); va.push_back(-1.0f); }
+        diag_slot[static_cast<std::size_t>(idx)] = static_cast<int>(ci.size());
+        ci.push_back(idx); va.push_back(4.0f);
+        if (c < m - 1) { ci.push_back(idx + 1); va.push_back(-1.0f); }
+        if (r < m - 1) { ci.push_back(idx + m); va.push_back(-1.0f); }
+        ro[static_cast<std::size_t>(idx) + 1] = static_cast<int>(ci.size());
+    }
+
+    const int nnz = static_cast<int>(ci.size());
+    Matrix<float, MatrixFormat::CSR> A(n, n, nnz, batch);
+    auto v = A.view();
+    auto Ro = v.row_offsets();
+    auto Ci = v.col_indices();
+    auto Va = v.data();
+    for (int b = 0; b < batch; ++b) {
+        const int rb = b * v.offset_stride();
+        const int vb = b * v.matrix_stride();
+        for (int i = 0; i <= n; ++i) Ro[rb + i] = ro[static_cast<std::size_t>(i)];
+        for (int p = 0; p < nnz; ++p) {
+            Ci[vb + p] = ci[static_cast<std::size_t>(p)];
+            Va[vb + p] = va[static_cast<std::size_t>(p)];
+        }
+        // Make the batch elements genuinely distinct systems.
+        for (int i = 0; i < n; ++i) {
+            Va[vb + diag_slot[static_cast<std::size_t>(i)]] += 0.01f * static_cast<float>(b);
+        }
+    }
+    return A;
+}
+
 }  // namespace
 
 #if BATCHLAS_HAS_GPU_BACKEND
@@ -285,6 +330,8 @@ TEST_F(ILUKTests, ZeroShiftZeroDiagonalApplyThrows) {
     ci[1] = 1;
     vals[0] = 0.0f;
     vals[1] = 2.0f;
+
+    iluk_build_level_schedule(M);
 
     Matrix<float, MatrixFormat::Dense> rhs(n, 1, batch);
     Matrix<float, MatrixFormat::Dense> out(n, 1, batch);
@@ -794,6 +841,164 @@ TEST_F(ILUKTests, SyevxRejectsPreconditionerWhenSearchingForLargestEigenpairs) {
         syevx<test_utils::gpu_backend>(*ctx, view, W, neigs, workspace, JobType::NoEigenVectors,
                                        MatrixView<float, MatrixFormat::Dense>(), params));
     ctx->wait_and_throw();
+}
+
+// Not a correctness test: an end-to-end cost model for whether building the
+// preconditioner pays for itself. Run with --gtest_also_run_disabled_tests.
+TEST_F(ILUKTests, DISABLED_PreconditionerAmortizationBenchmark) {
+    struct Shape { int m; int batch; };
+    const std::vector<Shape> shapes = {
+        {16, 1}, {16, 16}, {32, 1}, {32, 16}, {64, 1}, {64, 16},
+    };
+    constexpr size_t neigs = 5;
+    constexpr size_t extra_dirs = 5;
+    // High enough that both configurations actually reach the tolerance: the
+    // amortization question is time-to-solution, not cost of a fixed iteration count.
+    constexpr int max_iters = 2000;
+    // syevx's criterion is ||r|| / (||x|| |lambda|). For the smallest Laplacian
+    // eigenvalues |lambda| is O(1e-3), so a 1e-6 relative target sits below float32
+    // resolution and neither configuration can ever reach it.
+    constexpr float tol = 1e-3f;
+    constexpr int level = 1;
+
+    auto seconds_since = [](std::chrono::steady_clock::time_point t0) {
+        return std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
+    };
+
+    std::cout << "\n[ILUK amortization] level=" << level << ", neigs=" << neigs
+              << ", max_iters=" << max_iters << "\n";
+    std::cout << "  n  batch    nnz  factor_s   apply_s  base_s  base_it  prec_s  prec_it  "
+                 "solve_speedup  net_speedup\n";
+    // The host is often shared with other jobs, so single timings are unreliable;
+    // report the median of several repetitions.
+    constexpr int reps = 5;
+    auto median = [](std::vector<double> v) {
+        std::sort(v.begin(), v.end());
+        return v[v.size() / 2];
+    };
+
+    for (const auto& s : shapes) {
+        auto csr = make_laplacian_2d(s.m, s.batch);
+        auto view = csr.view();
+        const int n = s.m * s.m;
+
+        auto run_syevx = [&](const ILUKPreconditioner<float>* precond, int& iters_out) {
+            UnifiedVector<float> W(neigs * s.batch, 0.0f);
+            UnifiedVector<int32_t> iters(s.batch, 0);
+            SyevxInstrumentation<float> instr;
+            instr.max_iterations = max_iters;
+            instr.iterations_done = iters.data();
+
+            SyevxParams<float> params;
+            params.iterations = max_iters;
+            params.extra_directions = extra_dirs;
+            params.find_largest = false;
+            params.absolute_tolerance = tol;
+            params.relative_tolerance = tol;
+            params.preconditioner = precond;
+            params.instrumentation = &instr;
+
+            UnifiedVector<std::byte> ws(syevx_buffer_size<test_utils::gpu_backend>(
+                *ctx, view, W, neigs, JobType::NoEigenVectors,
+                MatrixView<float, MatrixFormat::Dense>(), params));
+            ctx->wait_and_throw();
+
+            // Discarded warm-up: the first launch of each kernel pays JIT and
+            // clock ramp, which otherwise lands entirely on whichever run goes first.
+            syevx<test_utils::gpu_backend>(*ctx, view, W, neigs, ws, JobType::NoEigenVectors,
+                                           MatrixView<float, MatrixFormat::Dense>(), params);
+            ctx->wait_and_throw();
+
+            const auto t0 = std::chrono::steady_clock::now();
+            syevx<test_utils::gpu_backend>(*ctx, view, W, neigs, ws, JobType::NoEigenVectors,
+                                           MatrixView<float, MatrixFormat::Dense>(), params);
+            ctx->wait_and_throw();
+            const double elapsed = seconds_since(t0);
+            iters_out = *std::max_element(iters.begin(), iters.end());
+            return elapsed;
+        };
+
+        int base_iters = 0;
+        std::vector<double> base_samples;
+        for (int r = 0; r < reps; ++r) base_samples.push_back(run_syevx(nullptr, base_iters));
+        const double base_s = median(base_samples);
+
+        ILUKParams<float> iluk_params;
+        iluk_params.levels_of_fill = level;
+
+        std::vector<double> factor_samples;
+        for (int r = 0; r < reps; ++r) {
+            const auto tf = std::chrono::steady_clock::now();
+            auto tmp = iluk_factorize<test_utils::gpu_backend>(*ctx, view, iluk_params);
+            ctx->wait_and_throw();
+            factor_samples.push_back(seconds_since(tf));
+        }
+        const double factor_s = median(factor_samples);
+        auto M = iluk_factorize<test_utils::gpu_backend>(*ctx, view, iluk_params);
+        ctx->wait_and_throw();
+
+        // Cost of a single preconditioner application at LOBPCG block width.
+        const int block = static_cast<int>(neigs + extra_dirs);
+        Matrix<float, MatrixFormat::Dense> rhs(n, block, s.batch);
+        Matrix<float, MatrixFormat::Dense> out(n, block, s.batch);
+        rhs.view().fill(*ctx, 1.0f);
+        ctx->wait_and_throw();
+        const auto ta = std::chrono::steady_clock::now();
+        constexpr int apply_reps = 10;
+        for (int r = 0; r < apply_reps; ++r) {
+            iluk_apply<test_utils::gpu_backend>(*ctx, M, rhs.view(), out.view());
+        }
+        ctx->wait_and_throw();
+        const double apply_s = seconds_since(ta) / apply_reps;
+
+        int prec_iters = 0;
+        std::vector<double> prec_samples;
+        for (int r = 0; r < reps; ++r) prec_samples.push_back(run_syevx(&M, prec_iters));
+        const double prec_s = median(prec_samples);
+
+        const double solve_speedup = base_s / prec_s;
+        const double net_speedup = base_s / (prec_s + factor_s);
+
+        std::cout << "  " << n << "  " << s.batch << "  " << csr.nnz()
+                  << "  " << factor_s << "  " << apply_s
+                  << "  " << base_s << "  " << base_iters
+                  << "  " << prec_s << "  " << prec_iters
+                  << "  " << solve_speedup << "  " << net_speedup << "\n";
+    }
+}
+
+
+TEST_F(ILUKTests, DISABLED_FactorLevelStructure) {
+    struct Shape { int n; int batch; float density; };
+    const std::vector<Shape> shapes = {{256,1,0.02f},{1024,1,0.01f},{4096,1,0.003f}};
+    for (int level : {0, 1, 2}) {
+        for (const auto& s : shapes) {
+            auto csr = csr_generators::random_sparse_hermitian_csr<float>(s.n, s.density, s.batch, 1234u, 2.0f, true);
+            ILUKParams<float> p; p.levels_of_fill = level;
+            auto M = iluk_factorize<test_utils::gpu_backend>(*ctx, csr.view(), p);
+            auto lu = M.lu.view();
+            auto ro = lu.row_offsets(); auto ci = lu.col_indices();
+            const int n = s.n;
+            // Depth of the unit-lower-triangular forward solve dependency DAG.
+            std::vector<int> lvlL(n, 0), lvlU(n, 0);
+            for (int i = 0; i < n; ++i)
+                for (int q = ro[i]; q < ro[i+1]; ++q) {
+                    int j = ci[q];
+                    if (j < i) lvlL[i] = std::max(lvlL[i], lvlL[j] + 1);
+                }
+            for (int i = n-1; i >= 0; --i)
+                for (int q = ro[i]; q < ro[i+1]; ++q) {
+                    int j = ci[q];
+                    if (j > i) lvlU[i] = std::max(lvlU[i], lvlU[j] + 1);
+                }
+            const int depthL = *std::max_element(lvlL.begin(), lvlL.end()) + 1;
+            const int depthU = *std::max_element(lvlU.begin(), lvlU.end()) + 1;
+            std::cout << "  level=" << level << " n=" << n << " lu_nnz=" << lu.nnz()
+                      << " nnz/row=" << (double)lu.nnz()/n
+                      << "  L_depth=" << depthL << " (avg " << (double)n/depthL << " rows/level)"
+                      << "  U_depth=" << depthU << " (avg " << (double)n/depthU << " rows/level)\n";
+        }
+    }
 }
 
 int main(int argc, char** argv) {

--- a/tests/iluk_tests.cc
+++ b/tests/iluk_tests.cc
@@ -600,7 +600,8 @@ TEST_F(ILUKTests, SyevxInstrumentationAndPreconditioner) {
         SyevxParams<float> params;
         params.iterations = max_iters;
         params.extra_directions = extra_dirs;
-        params.find_largest = true;
+        // ILU(k) approximates A^{-1}, so it only accelerates the smallest eigenpairs.
+        params.find_largest = false;
         params.absolute_tolerance = 1e-6f;
         params.relative_tolerance = 1e-6f;
         params.preconditioner = precond_ptr;
@@ -744,10 +745,55 @@ TEST_F(ILUKTests, SyevxInstrumentationAndPreconditioner) {
                                     : std::nanf("");
         std::cout << "    " << runs[r].label << ": avg_ratio=" << avg_ratio
                   << ", wins=" << agg.win_count << ", losses=" << agg.lose_count << "\n";
+
+        // The whole point of wiring ILU(k) into LOBPCG is that it must beat running
+        // unpreconditioned. Assert it, so a regression here fails the build instead
+        // of quietly showing up in the printed summary.
+        ASSERT_GT(agg.ratio_count, 0) << runs[r].label << " produced no comparable runs";
+        EXPECT_LT(avg_ratio, 1.0f)
+            << runs[r].label << " should reach a smaller final residual than the unpreconditioned baseline";
+        EXPECT_EQ(agg.lose_count, 0)
+            << runs[r].label << " regressed against the unpreconditioned baseline on "
+            << agg.lose_count << " of " << agg.ratio_count << " cases";
     }
 
     csv.close();
     std::cout << "[ILUK trace] wrote " << csv_path << "\n";
+}
+
+TEST_F(ILUKTests, SyevxRejectsPreconditionerWhenSearchingForLargestEigenpairs) {
+    constexpr int n = 64;
+    constexpr int batch = 1;
+    constexpr size_t neigs = 2;
+
+    auto csr = csr_generators::random_sparse_hermitian_csr<float>(n, 0.05f, batch, 4242u, 2.0f, true);
+    auto view = csr.view();
+
+    auto M = iluk_factorize<test_utils::gpu_backend>(*ctx, view, ILUKParams<float>());
+
+    UnifiedVector<float> W(neigs * batch, 0.0f);
+    SyevxParams<float> params;
+    params.iterations = 5;
+    params.preconditioner = &M;
+    params.find_largest = false;
+
+    // Sizing the workspace for the legal (smallest-eigenpair) configuration also
+    // covers the rejected one, so the throw below is the guard and not an OOM.
+    UnifiedVector<std::byte> workspace(
+        syevx_buffer_size<test_utils::gpu_backend>(*ctx, view, W, neigs, JobType::NoEigenVectors,
+                                                   MatrixView<float, MatrixFormat::Dense>(), params));
+
+    params.find_largest = true;
+    EXPECT_THROW(
+        syevx<test_utils::gpu_backend>(*ctx, view, W, neigs, workspace, JobType::NoEigenVectors,
+                                       MatrixView<float, MatrixFormat::Dense>(), params),
+        std::invalid_argument);
+
+    params.find_largest = false;
+    EXPECT_NO_THROW(
+        syevx<test_utils::gpu_backend>(*ctx, view, W, neigs, workspace, JobType::NoEigenVectors,
+                                       MatrixView<float, MatrixFormat::Dense>(), params));
+    ctx->wait_and_throw();
 }
 
 int main(int argc, char** argv) {

--- a/tests/iluk_tests.cc
+++ b/tests/iluk_tests.cc
@@ -4,6 +4,7 @@
 #include <blas/linalg.hh>
 
 #include <algorithm>
+#include <optional>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
@@ -843,6 +844,115 @@ TEST_F(ILUKTests, SyevxRejectsPreconditionerWhenSearchingForLargestEigenpairs) {
     ctx->wait_and_throw();
 }
 
+// The in-solver path must be equivalent to handing syevx a factor the caller
+// built: same factorization, same iterates, just allocated from syevx's pool.
+TEST_F(ILUKTests, SyevxBuildsPreconditionerFromItsOwnWorkspace) {
+    constexpr int m = 24;  // 24x24 grid -> n = 576
+    constexpr int batch = 2;
+    constexpr size_t neigs = 4;
+    const int n = m * m;
+
+    auto csr = make_laplacian_2d(m, batch);
+    auto view = csr.view();
+
+    ILUKParams<float> iluk_params;
+    iluk_params.levels_of_fill = 1;
+
+    auto run = [&](bool build_in_solver, UnifiedVector<float>& W) {
+        SyevxParams<float> params;
+        params.iterations = 40;
+        params.extra_directions = 4;
+        params.find_largest = false;
+        params.algorithm = OrthoAlgorithm::Chol2;
+        params.iluk_params = iluk_params;
+
+        std::optional<ILUKPreconditioner<float>> external;
+        if (build_in_solver) {
+            params.build_preconditioner = true;
+        } else {
+            external = iluk_factorize<test_utils::gpu_backend>(*ctx, view, iluk_params);
+            params.preconditioner = &*external;
+        }
+
+        UnifiedVector<std::byte> workspace(
+            syevx_buffer_size<test_utils::gpu_backend>(*ctx, view, W, neigs, JobType::NoEigenVectors,
+                                                       MatrixView<float, MatrixFormat::Dense>(), params));
+        syevx<test_utils::gpu_backend>(*ctx, view, W, neigs, workspace, JobType::NoEigenVectors,
+                                       MatrixView<float, MatrixFormat::Dense>(), params);
+        ctx->wait_and_throw();
+    };
+
+    UnifiedVector<float> W_external(neigs * batch, 0.0f);
+    UnifiedVector<float> W_internal(neigs * batch, 0.0f);
+    run(false, W_external);
+    run(true, W_internal);
+
+    // Identical factor and identical iteration sequence, so this is bit-level
+    // reproducible up to the nondeterminism syevx already has.
+    for (size_t i = 0; i < W_external.size(); ++i) {
+        EXPECT_NEAR(W_internal[i], W_external[i], 1e-4f * std::max(1.0f, std::abs(W_external[i])))
+            << "eigenvalue " << i << " differs between the in-solver and caller-built factor";
+    }
+
+    // Sanity check against the analytic 2D Laplacian spectrum: the smallest
+    // eigenvalue of the 5-point stencil on an m x m grid is 8 sin^2(pi/(2(m+1))).
+    const float pi = 3.14159265358979323846f;
+    const float lambda_min = 8.0f * std::pow(std::sin(pi / (2.0f * (m + 1))), 2.0f);
+    EXPECT_NEAR(W_internal[0], lambda_min, 0.05f * lambda_min);
+    (void)n;
+}
+
+TEST_F(ILUKTests, SyevxBuildPreconditionerRejectsIllegalConfigurations) {
+    constexpr int n = 64;
+    constexpr int batch = 1;
+    constexpr size_t neigs = 2;
+
+    auto csr = csr_generators::random_sparse_hermitian_csr<float>(n, 0.05f, batch, 4242u, 2.0f, true);
+    auto view = csr.view();
+    auto M = iluk_factorize<test_utils::gpu_backend>(*ctx, view, ILUKParams<float>());
+
+    UnifiedVector<float> W(neigs * batch, 0.0f);
+    SyevxParams<float> params;
+    params.iterations = 5;
+    params.find_largest = false;
+    params.build_preconditioner = true;
+
+    UnifiedVector<std::byte> workspace(
+        syevx_buffer_size<test_utils::gpu_backend>(*ctx, view, W, neigs, JobType::NoEigenVectors,
+                                                   MatrixView<float, MatrixFormat::Dense>(), params));
+
+    // Supplying both a factor and asking for one is ambiguous rather than harmless:
+    // the caller clearly disagrees with itself about which factor should be used.
+    params.preconditioner = &M;
+    EXPECT_THROW(
+        syevx<test_utils::gpu_backend>(*ctx, view, W, neigs, workspace, JobType::NoEigenVectors,
+                                       MatrixView<float, MatrixFormat::Dense>(), params),
+        std::invalid_argument);
+    params.preconditioner = nullptr;
+
+    params.find_largest = true;
+    EXPECT_THROW(
+        syevx<test_utils::gpu_backend>(*ctx, view, W, neigs, workspace, JobType::NoEigenVectors,
+                                       MatrixView<float, MatrixFormat::Dense>(), params),
+        std::invalid_argument);
+    params.find_largest = false;
+
+    // ILU(k) is only defined for sparse input, so a dense A must be refused rather
+    // than silently ignored.
+    auto dense = Matrix<float, MatrixFormat::Dense>(n, n, batch);
+    auto dense_view = dense.view();
+    UnifiedVector<std::byte> dense_ws(1024);
+    EXPECT_THROW(
+        syevx<test_utils::gpu_backend>(*ctx, dense_view, W, neigs, dense_ws, JobType::NoEigenVectors,
+                                       MatrixView<float, MatrixFormat::Dense>(), params),
+        std::invalid_argument);
+
+    EXPECT_NO_THROW(
+        syevx<test_utils::gpu_backend>(*ctx, view, W, neigs, workspace, JobType::NoEigenVectors,
+                                       MatrixView<float, MatrixFormat::Dense>(), params));
+    ctx->wait_and_throw();
+}
+
 // Not a correctness test: an end-to-end cost model for whether building the
 // preconditioner pays for itself. Run with --gtest_also_run_disabled_tests.
 TEST_F(ILUKTests, DISABLED_PreconditionerAmortizationBenchmark) {
@@ -868,7 +978,7 @@ TEST_F(ILUKTests, DISABLED_PreconditionerAmortizationBenchmark) {
     std::cout << "\n[ILUK amortization] level=" << level << ", neigs=" << neigs
               << ", max_iters=" << max_iters << "\n";
     std::cout << "  n  batch    nnz  factor_s   apply_s  base_s  base_it  prec_s  prec_it  "
-                 "solve_speedup  net_speedup\n";
+                 "solve_speedup  net_speedup  inner_s  inner_it  inner_speedup\n";
     // The host is often shared with other jobs, so single timings are unreliable;
     // report the median of several repetitions.
     constexpr int reps = 5;
@@ -882,7 +992,7 @@ TEST_F(ILUKTests, DISABLED_PreconditionerAmortizationBenchmark) {
         auto view = csr.view();
         const int n = s.m * s.m;
 
-        auto run_syevx = [&](const ILUKPreconditioner<float>* precond, int& iters_out) {
+        auto run_syevx = [&](const ILUKPreconditioner<float>* precond, bool build_in_solver, int& iters_out) {
             UnifiedVector<float> W(neigs * s.batch, 0.0f);
             UnifiedVector<int32_t> iters(s.batch, 0);
             SyevxInstrumentation<float> instr;
@@ -896,6 +1006,8 @@ TEST_F(ILUKTests, DISABLED_PreconditionerAmortizationBenchmark) {
             params.absolute_tolerance = tol;
             params.relative_tolerance = tol;
             params.preconditioner = precond;
+            params.build_preconditioner = build_in_solver;
+            params.iluk_params.levels_of_fill = level;
             params.instrumentation = &instr;
 
             UnifiedVector<std::byte> ws(syevx_buffer_size<test_utils::gpu_backend>(
@@ -920,7 +1032,7 @@ TEST_F(ILUKTests, DISABLED_PreconditionerAmortizationBenchmark) {
 
         int base_iters = 0;
         std::vector<double> base_samples;
-        for (int r = 0; r < reps; ++r) base_samples.push_back(run_syevx(nullptr, base_iters));
+        for (int r = 0; r < reps; ++r) base_samples.push_back(run_syevx(nullptr, false, base_iters));
         const double base_s = median(base_samples);
 
         ILUKParams<float> iluk_params;
@@ -953,17 +1065,27 @@ TEST_F(ILUKTests, DISABLED_PreconditionerAmortizationBenchmark) {
 
         int prec_iters = 0;
         std::vector<double> prec_samples;
-        for (int r = 0; r < reps; ++r) prec_samples.push_back(run_syevx(&M, prec_iters));
+        for (int r = 0; r < reps; ++r) prec_samples.push_back(run_syevx(&M, false, prec_iters));
         const double prec_s = median(prec_samples);
+
+        // The in-solver path forms the factor from syevx's own workspace, so this
+        // one number is the honest end-to-end cost: no separate factorization to
+        // add on afterwards, and the allocation is already inside the pool.
+        int inner_iters = 0;
+        std::vector<double> inner_samples;
+        for (int r = 0; r < reps; ++r) inner_samples.push_back(run_syevx(nullptr, true, inner_iters));
+        const double inner_s = median(inner_samples);
 
         const double solve_speedup = base_s / prec_s;
         const double net_speedup = base_s / (prec_s + factor_s);
+        const double inner_speedup = base_s / inner_s;
 
         std::cout << "  " << n << "  " << s.batch << "  " << csr.nnz()
                   << "  " << factor_s << "  " << apply_s
                   << "  " << base_s << "  " << base_iters
                   << "  " << prec_s << "  " << prec_iters
-                  << "  " << solve_speedup << "  " << net_speedup << "\n";
+                  << "  " << solve_speedup << "  " << net_speedup
+                  << "  " << inner_s << "  " << inner_iters << "  " << inner_speedup << "\n";
     }
 }
 


### PR DESCRIPTION
ILU(k) turned out to be sound. Three separate defects made it look broken and made it uneconomical.

## 1. The CSR random generator was producing malformed matrices

`fill_random_sparse_hermitian` (`src/matrix.cc`) built `row_offsets` with an `exclusive_scan` written one slot in, so `row_offsets[1] = 0` — row 0 came out empty, every row inherited the previous row s count, and the last row s entries fell past `row_offsets[n]`. Rows 0 and 1 shared a start index and overwrote each other. Replaced with the intended `inclusive_scan`.

This one line accounted for all three ILUK test failures:

| Test | Before | After |
|---|---|---|
| `RandomSparseHermitianCSRProducesSortedHermitianRows` | row 0 empty (`re > rs` = 0 vs 0) | pass |
| `HigherFillImprovesApproximateInverseResidual...` | residual `1.15e8` | pass |
| `SyevxInstrumentationAndPreconditioner` | `CUDA_ERROR_ILLEGAL_ADDRESS`, core dump | pass |

## 2. ILU(k) was applied at the wrong end of the spectrum

ILU(k) approximates `A^-1`, so it is the correct LOBPCG preconditioner only for the **smallest** eigenpairs. Every preconditioned `syevx` call in the repo used `find_largest = true`, where it damps exactly the directions being sought. Over the existing 8-case sweep that was ~190x worse than no preconditioner (losing 6-7 of 8 cases).

`syevx` now throws on that combination instead of silently degrading. With `find_largest = false` it wins **8/8 at every fill level** (avg final-residual ratio 0.25; per-iteration rate 0.50-0.61 vs 0.81-0.90). The sweep now asserts this rather than only printing it.

## 3. Applying the preconditioner cost more than forming it

Measurement first: at n=4096, forming the factor cost 3.9ms while 103 LOBPCG iterations of `iluk_apply` cost ~440ms. **Formation was never the bottleneck.**

`iluk_apply` launched one work-item per (batch, rhs column) — a batch-1 solve with block width 10 ran *10 threads* on the whole GPU, each walking all n rows of both triangular factors serially.

The factors have shallow dependency graphs (n=4096, ILU(1): depth 53, ~77 independent rows per level), so the solve is now **level-scheduled**: one work-group per system, rows of a level split across work-items, group barrier between levels. Serial chain drops from n steps to the level count. The schedule depends only on the sparsity pattern — shared across the batch — so it is built once during factorization.

Two more per-application costs removed: `iluk_apply` allocated a status buffer, forced a device sync, and read it back on the host *every call*, serializing the pipeline once per LOBPCG iteration. Whether the U diagonals are usable is a property of the factor values, so it is now decided once when the factor is built.

Factorization itself: the pivot row was rescanned to recompute its row scale on every elimination step (though that row is already finalized and stabilization is idempotent), and each update did a binary search to locate its target column. Replaced with the stored diagonal and an O(1) scatter workspace.

## Does it pay for itself?

Yes. Batched 2D Laplacians, median of 5, RTX 4090:

- `iluk_apply`: **3.8-36x faster** (n=4096 batch=16: 13.4ms → 0.37ms)
- `iluk_factorize`: **up to 3.5x faster**
- ILU(1) cuts LOBPCG iterations **3.3-6x** (103 → 19 at n=4096)

End-to-end **including formation cost**, n=4096 went from a net loss to a net win:

| n | batch | net speedup before | net speedup after |
|---|---|---|---|
| 1024 | 1 | 1.58x | 2.47x |
| 1024 | 16 | 1.17x | 1.90x |
| 4096 | 1 | **0.68x (loss)** | **2.52x** |
| 4096 | 16 | **0.86x (loss)** | **2.45x** |

Iteration counts are identical before and after the optimization (7, 8, 11, 11, 19, 20), confirming these are pure performance changes with no numerical effect.

## 4. syevx can now build the preconditioner itself, from its own pool

Everything above still required the caller to factorize separately, so an
end-to-end "with vs without ILU(k)" number had to be assembled by hand from two
timings. `SyevxParams` now has:

```cpp
bool build_preconditioner = false;
ILUKParams<T> iluk_params{};
```

When set, syevx forms the factor and — per the requirement that it allocate
nothing of its own — carves it out of the workspace the caller already passed in.

Getting the factor into the pool needed a non-owning `ILUKView<T>`. `iluk_apply`
consumes that instead of the owning `ILUKPreconditioner`, so a factor can live in
either; existing entry points keep working via forwarding overloads and a
`view()` accessor.

**Sizing was the awkward part.** The final fill count is only known *after* the
numeric phase — drop tolerance and the fill quota both prune entries — so
`iluk_buffer_size` sizes against the symbolic pattern, an upper bound. Paying
that symbolic pass twice at solve time was measurable, so syevx instead hands
ILU(k) the unclaimed tail of the pool (`BumpAllocator` gains
`remaining()`/`consume()`) and takes back only the bytes it reports using. The
bound is then only needed by `syevx_buffer_size`, which a caller runs once and
amortizes over every solve.

Guards: `build_preconditioner` and `preconditioner` are mutually exclusive, both
still require `find_largest = false`, and `build_preconditioner` requires CSR
input.

### End-to-end, formation included

2D Laplacian, ILU(1), neigs=5, minimum over 5 runs:

| n | batch | base iters | prec iters | net vs unpreconditioned |
|---|---|---|---|---|
| 256 | 1 | 23 | 7 | 2.60x |
| 256 | 16 | 24 | 8 | 1.44x |
| 1024 | 1 | 52 | 11 | 2.46x |
| 1024 | 16 | 52 | 11 | 2.19x |
| 4096 | 1 | 103 | 19 | 2.62x |
| 4096 | 16 | 120 | 20 | 2.59x |

The in-solver path lands slightly *below* the same factor built separately
(1.92–3.25x). That gap is not algorithmic — iteration counts match exactly — but
that the host writes the factor into pool memory the device has just been using,
so it pays unified-memory page migration a standalone factorization does not.
That is the real cost of the factor living in the pool; removing it means
factorizing on the device.

Also exposed from Python as the `build_preconditioner`, `iluk_levels_of_fill`,
`iluk_drop_tolerance` and `iluk_fill_factor` syevx options.

## 5. Batch saturation, and where syevx beats a full syev

### The syevx workspace bug is fixed

syevx solves an `Nvecs x Nvecs` projected problem with `Nvecs = 2*block_vectors`
on restart iterations and `3*block_vectors` otherwise. Both the runtime allocation
and `syevx_buffer_size` sized only the `block_vectors` and `3*block_vectors`
shapes. Since `syev` picks its provider from the shape, workspace demand is *not*
monotone in `Nvecs` — the restart shape can need more than either sized one. That
is the `syev: insufficient workspace for chosen provider` failure reported above;
it hit `block_vectors` = 12, 13, 16. Sizing the restart shape in both places fixes
it and `syevx_tests` is now **5/5**. It had to be fixed here because it blocked
k = 16 in the sweep below.

### syevx vs a full dense eigendecomposition

2D Laplacian, `block width = k`, tol 1e-3, syevx values cross-checked against
syev's spectrum (max relative error 1e-5–3e-4 throughout, so the speedups come
with evidence the answer is right).

| n | batch | k | syev | LOBPCG | LOBPCG+ILU(1) |
|---|---|---|---|---|---|
| 256 | 1 | 1–32 | **wins** | 0.13–0.20x | 0.14–0.51x |
| 256 | 64–1024 | 1–32 | **wins** | 0.04–0.30x | 0.08–0.24x |
| 1024 | 1 | 1 | | 2.67x | **10.7x** |
| 1024 | 1 | 8 | | 4.22x | **12.5x** |
| 1024 | 1 | 32 | | 0.70x | **2.44x** |
| 1024 | 256 | 2 | | 13.1x | 11.3x |
| 1024 | 256 | 32 | | 1.63x | **3.10x** |
| 4096 | 1 | 1 | | 81x | **193x** |
| 4096 | 1 | 32 | | 11.1x | **68x** |
| 4096 | 16 | 8 | | 10.5x | **57x** |

**Thresholds.** At n = 256 a full `syev` wins outright at every k and batch — the
dense factorization is only ~7 ms and LOBPCG cannot amortize its iteration count
against that. The crossover is at **n ≈ 1024**, where syevx wins for k up to 16
unpreconditioned and up to at least 32 with ILU(1). By n = 4096 it is not close:
1–2 orders of magnitude, and ILU(1) roughly doubles-to-triples the margin.

The k dependence is the expected one — LOBPCG cost grows with block width while
syev does not care about k — so the advantage decays as k rises, and ILU(1)
consistently pushes the break-even k higher (at n=1024/batch=1, unpreconditioned
LOBPCG has already lost at k=32 while ILU(1) is still 2.4x ahead).

### Batch saturation: where ILU(k) stops paying for itself

Sweeping batch to 1024 (past the point where the GPU fills up) changes the earlier
conclusion:

| n | batch | net (separate factor) | net (in-solver) |
|---|---|---|---|
| 256 | 1 | 2.54x | 2.69x |
| 256 | 64 | 1.49x | 1.19x |
| 256 | 256 | 0.74x | **0.55x** |
| 256 | 1024 | 0.91x | **0.59x** |
| 1024 | 1 | 3.39x | 3.28x |
| 1024 | 64 | 2.51x | 1.58x |
| 1024 | 256 | 1.17x | **0.77x** |
| 4096 | 1 | 3.06x | 2.88x |
| 4096 | 64 | 2.96x | 2.01x |

The preconditioner pays for itself up to roughly **batch 64** and stops beyond it.
The cause is that formation is host work scaling linearly with batch, while the
solve is absorbed by the GPU — so the earlier "ILU(k) pays for itself" result is a
small-batch result.

## 6. Fixing the batch scaling: factorize on the device

Threading the host loop was a half-measure — 1.4–1.8x on a memory-bound phase.
The real fix is to stop doing the work on the host.

**The enabling observation:** the batch shares one sparsity pattern, so every
*index* the numeric phase needs — which slot each elimination reads, which slot it
updates, which rows may run concurrently — is fixed by that pattern and can be
precomputed once regardless of batch size. What runs on the device is the
arithmetic, which is the part that actually scales.

Two details make the schedule static:

- Dropped entries are set to zero, so applying their updates anyway is a no-op.
  The elimination map therefore does not depend on values.
- Row `i` depends only on rows `j < i` in its pattern — the same DAG the forward
  solve uses — so level scheduling applies. One kernel launch per level, a count
  set by the factor's depth rather than by the batch.

Working values are stored slot-major rather than batch-major: one work-item handles
one (row, batch element) pair, so adjacent work-items differ in the batch index and
slot-major makes those accesses contiguous. The final gather transposes into the
batch-major CSR the apply kernel wants. Compaction reduces keep-flags over the batch
on the device, leaving the host a scan over `sym_nnz`. The batch-sparsity check and
the U-diagonal usability check moved to the device too — both were host scans over
batch-proportional data.

**Formation time is now flat in batch.** At n=256 it is 3.9 ms at batch 64, 3.6 ms
at 256 and 4.3 ms at 1024 — against 0.4 ms to 15 ms across the same range on the
host.

The device path has a fixed per-call cost (one launch per level, a few host round
trips) that does not shrink for small problems, so the host path is kept and chosen
below batch 32, a crossover taken from measurement. `BATCHLAS_ILUK_DEVICE` forces
either side.

### Two implementations that must agree

That is a standing hazard, so `HostAndDeviceFactorizationsAgree` runs both over
cases that exercise the drop tolerance and the fill quota and compares the factors
entry by entry. It immediately caught one: the fill quota's ties were being resolved
by `std::sort`'s unspecified order on the host. Both sides now break ties by column
position, which also makes the host factor reproducible run to run.

### End-to-end, including formation

| n | batch | before | after |
|---|---|---|---|
| 256 | 1 | 2.69x | 2.68x |
| 256 | 64 | 1.19x | 1.26x |
| 256 | 256 | 0.55x | **0.73x** |
| 256 | 1024 | 0.59x | **1.17x** |
| 1024 | 64 | 1.58x | **2.36x** |
| 1024 | 256 | 0.77x | **1.45x** |
| 4096 | 64 | 2.01x | **3.24x** |

And against a full `syev`, the large-batch entries roughly double: n=1024 batch=256
with ILU(1) goes from 9.98x to **20.65x** at k=1 and from 11.3x to **29.8x** at k=2.

n=256 with batch 256 is still a net loss, but **no longer because of formation** —
the preconditioned solve itself is slower there (20.4 ms against a 17.0 ms
baseline, despite cutting iterations from 25 to 12). That is apply cost at small n,
a separate question from the one fixed here.

## Verification

- `iluk_tests`: **17/17** pass, and 17/17 with either numeric path forced via `BATCHLAS_ILUK_DEVICE` (was 11/14 with a core dump); two of the new tests cover the in-solver path — one asserting it reproduces a caller-built factor's eigenvalues and the analytic Laplacian minimum, one covering the three rejection guards.
- `syevx_tests`: **5/5** — the pre-existing `insufficient workspace` failure is fixed (see section 5).
- Both ILUK benchmarks and the Python bindings compile clean; the Python in-solver path was checked against the analytic Laplacian spectrum.

## Notes for reviewers

- A hand-built `ILUKPreconditioner` now needs `iluk_build_level_schedule()`; `iluk_apply` rejects one without a schedule rather than silently computing nothing.
- `iluk_apply` no longer syncs internally — the caller owns synchronization.
- Two disabled benchmarks added (`--gtest_also_run_disabled_tests`): amortization (now with in-solver columns) and factor level structure.
- Host was heavily loaded (load ~20 on 20 cores) during later timing runs; the end-to-end table above comes from a quieter period. Iteration counts are deterministic and load-independent.
- syevx's convergence criterion normalizes by `|lambda|`, so a 1e-6 relative target is unreachable in float32 for the smallest Laplacian eigenvalues; the benchmarks use 1e-3. Still worth a separate look.
- Timing caveat: the host was shared with unrelated jobs throughout (load 4–30 on 20 cores). Tables use minima or medians over repeated runs; the threshold table comes from the quietest window. Iteration counts are deterministic and load-independent, and the syevx-vs-syev margins span orders of magnitude, so the conclusions are not load-sensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRmrQguazQwcsYVMd855KW


