### PR TITLE
tests: cut ctest runtime and add labels for selective runs

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,6 +88,61 @@ elseif(NOT BATCHLAS_TEST_TARGET_SET STREQUAL "all")
     message(FATAL_ERROR "Unsupported BATCHLAS_TEST_TARGET_SET='${BATCHLAS_TEST_TARGET_SET}'. Expected one of: all, smoke")
 endif()
 
+# ---------------------------------------------------------------------------
+# Test labels, for selective runs during iteration.
+#
+#   ctest -L eig            # only the eigensolver tests
+#   ctest -LE slow          # everything except the known-expensive binaries
+#   ctest -L tridiag -LE slow
+#
+# COMPONENT: which part of the library a test covers. Pick the label matching
+# the subsystem you changed; if you touched a shared low-level piece (Queue,
+# Matrix, memory pool) run the whole suite.
+#
+# SLOW: binaries that dominate wall-clock. Keep this list honest — if a test
+# grows past ~15 s, label it here rather than letting it bloat the default run.
+# ---------------------------------------------------------------------------
+set(BATCHLAS_TEST_LABELS_util
+    sg_compat_tests util_span_tests util_vector_tests util_device_queue_tests
+    mempool_tests matrix_tests matrix_view_tests minibench_cli_tests)
+set(BATCHLAS_TEST_LABELS_blas
+    device_blas_tests gemm_tests gemv_tests symm_tests syrk_tests syr2k_tests
+    trmm_tests trsm_tests transpose_tests norm_tests cond_tests inverse_tests)
+set(BATCHLAS_TEST_LABELS_ortho
+    ortho_tests ormqr_tests ormqr_cta_tests ormqr_blocked_tests orgqr_tests)
+set(BATCHLAS_TEST_LABELS_tridiag
+    steqr_tests stedc_tests stebz_tests stein_tests
+    sytrd_sy2sb_tests sytrd_sb2st_tests sytrd_sb2st_hh_tests
+    sytrd_cta_tests sytrd_blocked_tests)
+set(BATCHLAS_TEST_LABELS_eig
+    syev_tests syevx_tests syev_cta_tests syev_jacobi_cta_tests
+    syev_cta_fused_tests syev_blocked_tests syev_two_stage_tests
+    lanczos_tests ritz_values_tests gesvd_tests)
+set(BATCHLAS_TEST_LABELS_sparse
+    iluk_tests)
+
+# Binaries that dominate the suite. Measured serially on this machine.
+set(BATCHLAS_SLOW_TESTS
+    stedc_tests            # heaviest: dense reference solves at n=512/1024
+    steqr_tests            # ~135 s, almost all in the NETLIB instantiations
+    sytrd_sb2st_tests      # ~70 s, launch-latency bound bulge chase
+    sytrd_sb2st_hh_tests   # 48-combo (n, kd) cross product
+    syevx_tests
+    iluk_tests
+    gesvd_tests)
+
+# Map a target to its component label.
+function(batchlas_test_component out_var test_name)
+    foreach(component util blas ortho tridiag eig sparse)
+        list(FIND BATCHLAS_TEST_LABELS_${component} ${test_name} _idx)
+        if(NOT _idx EQUAL -1)
+            set(${out_var} ${component} PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+    set(${out_var} "unlabelled" PARENT_SCOPE)
+endfunction()
+
 function(batchlas_add_test_target test_name)
     add_executable(${test_name} ${test_name}.cc)
     if(test_name STREQUAL "sg_compat_tests")
@@ -129,6 +184,15 @@ function(batchlas_add_test_target test_name)
         )
     endif()
     add_test(NAME ${test_name} COMMAND ${test_name})
+
+    batchlas_test_component(_component ${test_name})
+    set(_labels ${_component})
+    list(FIND BATCHLAS_SLOW_TESTS ${test_name} _slow_idx)
+    if(NOT _slow_idx EQUAL -1)
+        list(APPEND _labels slow)
+    endif()
+    set_tests_properties(${test_name} PROPERTIES LABELS "${_labels}")
+
     if(BATCHLAS_OPENBLAS_CORETYPE)
         # The host BLAS was found to compute dgemm incorrectly with its
         # auto-detected kernel. OpenBLAS picks the kernel in its library

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,78 @@
+# Running the BatchLAS tests
+
+**Do not run the full suite on every edit.** It takes 15–20 minutes, and the
+time is extremely lopsided — a handful of binaries hold nearly all of it, so a
+scoped run gives you the same signal in seconds.
+
+Pick the narrowest scope that covers what you changed:
+
+| scope | command |
+|---|---|
+| one test case | `./build/tests/stedc_tests --gtest_filter='StedcTest/0.BatchedMatrices'` |
+| one binary | `ctest -R '^stedc_tests$'` |
+| one component | `ctest -L tridiag` |
+| everything quick | `ctest -LE slow` (38 of 45) |
+| everything | `ctest` |
+
+`ctest -R` takes a *substring* regex — `-R syev` matches seven binaries. Anchor
+it with `^...$` when you mean one.
+
+## Labels
+
+Component labels, one per binary (see `CMakeLists.txt`):
+
+`util`, `blas`, `ortho`, `tridiag`, `eig`, `sparse`
+
+Run `ctest -L <component>` for the subsystem you touched. **If you changed
+shared low-level code** — `Queue`, `Matrix`/`MatrixView`, the memory pool,
+`sg_compat`, anything under `include/util` — a component label is not enough;
+run the full suite.
+
+The `slow` label marks the binaries that dominate wall-clock. `ctest -LE slow`
+is the best default for a broad-but-quick check. Keep the list in
+`CMakeLists.txt` honest: if a test grows past ~15 s, label it `slow` rather
+than letting it bloat the default run.
+
+## Cutting runtime further
+
+Two runtime env filters (implemented in `test_utils.hh`) work on any binary:
+
+```bash
+BATCHLAS_TEST_BACKEND=CUDA   ./build/tests/steqr_tests   # skip NETLIB/CPU
+BATCHLAS_TEST_FLOAT_TYPE=float ./build/tests/steqr_tests # skip double/complex
+```
+
+`BATCHLAS_TEST_BACKEND=CUDA` is the single biggest no-code-change lever: the
+NETLIB instantiations run the host O(n^3) reference solves, and on `steqr_tests`
+they were 91% of the runtime. Both filters `GTEST_SKIP()` at runtime, so they
+cut compute, not process startup.
+
+## Writing tests that stay fast
+
+Two rules cover most of it:
+
+1. **Never combine large `n` with large `batch`.** `n` drives the algorithmic
+   depth you actually want to test (D&C merge levels, panel count, bulge-chase
+   sweeps). `batch` only multiplies that work. Cover them separately — large
+   `n` at small batch, large batch at small `n`. Their product is where cost
+   explodes for no added coverage.
+
+2. **Watch the reference solve.** A test that builds `Matrix::Zeros(n, n, batch)`
+   and runs `syev` / `ritz_values` / `netlib_ref_eigs_dense` over it pays
+   O(n^3)·batch, on the *host* for the NETLIB instantiations. That reference,
+   not the kernel under test, is usually what makes a test slow.
+
+Also: if every test body in a file starts with
+`using float_type = typename base_type<T>::type;` and computes only in
+`float_type`, the complex instantiations from `backend_types<Config>` are
+bit-identical re-runs of the real ones. Use
+`backend_types_filtered<Config, false>` instead and halve the file for free.
+
+## Note on the baseline
+
+The suite is **not green on `main`** (`lanczos`, `stedc`, `steqr` have failures;
+`syev_cta` is flaky under `-j4`). Double-precision *CPU-only* failures are
+usually the known-bad OpenBLAS Cooperlake `dgemm` kernel on this machine, not a
+BatchLAS bug — CMake detects this and sets `OPENBLAS_CORETYPE` for tests run
+through ctest. Always diff subtest *names* against a baseline rather than
+trusting a pass/fail count.

--- a/tests/stedc_tests.cc
+++ b/tests/stedc_tests.cc
@@ -171,7 +171,10 @@ struct StedcConfig {
     static constexpr Backend BackendVal = B;
 };
 
-using StedcTestTypes = typename test_utils::backend_types<StedcConfig>::type;
+// Every STEDC test body operates purely on `base_type<T>::type` (the real
+// scalar), so the complex instantiations re-ran the real ones bit-for-bit.
+// Drop them: they doubled the file's runtime for zero extra coverage.
+using StedcTestTypes = typename test_utils::backend_types_filtered<StedcConfig, false>::type;
 
 template <typename Config>
 class StedcTest : public test_utils::BatchLASTest<Config> {
@@ -185,7 +188,10 @@ TYPED_TEST(StedcTest, BatchedMatrices) {
     using T = typename TestFixture::ScalarType;
     constexpr Backend B = TestFixture::BackendType;
     const int n = 512;
-    const int batch = 128;
+    // Large-batch behaviour is covered by the n=64/batch=128 fused-CTA tests
+    // below; here `n` is what drives the divide-and-conquer merge depth, and
+    // the batch dimension only multiplies the dense reference solve.
+    const int batch = 8;
     using float_type = typename base_type<T>::type;
 
     auto a = Vector<float_type>::ones(n, batch);
@@ -225,7 +231,10 @@ TYPED_TEST(StedcTest, BatchedRandomMatrices) {
     using T = typename TestFixture::ScalarType;
     constexpr Backend B = TestFixture::BackendType;
     const int n = 1024;
-    const int batch = 128;
+    // This case builds a dense n x n x batch reference (537 MB at batch=128 in
+    // float) and runs a full SYEV over it. Keep the deep recursion that n=1024
+    // exercises; drop the batch multiplicity, which added no coverage.
+    const int batch = 8;
     using float_type = typename base_type<T>::type;
 
     auto a = Vector<float_type>::random(n, batch);

--- a/tests/stedc_tests.cc
+++ b/tests/stedc_tests.cc
@@ -232,9 +232,12 @@ TYPED_TEST(StedcTest, BatchedRandomMatrices) {
     constexpr Backend B = TestFixture::BackendType;
     const int n = 1024;
     // This case builds a dense n x n x batch reference (537 MB at batch=128 in
-    // float) and runs a full SYEV over it. Keep the deep recursion that n=1024
-    // exercises; drop the batch multiplicity, which added no coverage.
-    const int batch = 8;
+    // float) and runs a full SYEV over it -- on the host for the NETLIB
+    // instantiations, where it dominates this whole binary. Keep the deep
+    // recursion that n=1024 exercises (6 merge levels at recursion_threshold
+    // =16); drop the batch multiplicity, which added no coverage. Batched
+    // behaviour at large n is still covered by BatchedMatrices above.
+    const int batch = 4;
     using float_type = typename base_type<T>::type;
 
     auto a = Vector<float_type>::random(n, batch);

--- a/tests/steqr_tests.cc
+++ b/tests/steqr_tests.cc
@@ -107,7 +107,10 @@ TYPED_TEST(SteqrTest, BatchedMatrices) {
     using T = typename TestFixture::ScalarType;
     constexpr Backend B = TestFixture::BackendType;
     const int n = 512;
-    const int batch = 32;
+    // n=512 with eigenvectors plus a dense 512x512xbatch ritz_values check is
+    // an O(n^3)*batch job that runs on the host for the NETLIB instantiations.
+    // The closed-form Toeplitz spectrum is verified just as well at batch=8.
+    const int batch = 8;
     using float_type = typename base_type<T>::type;
 
     auto a = Vector<float_type>::ones(n, batch);
@@ -151,7 +154,8 @@ TYPED_TEST(SteqrTest, BatchedRandomMatrices) {
     using T = typename TestFixture::ScalarType;
     constexpr Backend B = TestFixture::BackendType;
     const int n = 128;
-    const int batch = 128;
+    // netlib_ref_eigs_dense() below is a host O(n^3) solve per batch item.
+    const int batch = 16;
     using float_type = typename base_type<T>::type;
 
     Vector<float_type> diag = Vector<float_type>::random(n, batch);
@@ -385,7 +389,11 @@ TYPED_TEST(SteqrTest, SteqrRandomMatrices) {
     using T = typename TestFixture::ScalarType;
     using float_type = typename base_type<T>::type;
     constexpr Backend B = TestFixture::BackendType;
-    const int batch = 1280;
+    // Each size runs a host LAPACK reference over the whole batch, so cost is
+    // linear in `batch` x 29 sizes. Large-batch dispatch stays covered by
+    // SteqrBatchedMatricesWithSchemes (batch=1280); keep the full size sweep,
+    // which is what actually exercises the block/tail boundaries.
+    const int batch = 64;
     for (int n = 4; n <= 32; ++n) {
         Vector<float_type> diag = Vector<float_type>::random(n, batch);
         Vector<float_type> sub_diag = Vector<float_type>::random(n - 1, batch);


### PR DESCRIPTION
The suite took 15–20 minutes, which landed on every iteration. Nearly all of it sat in two binaries, for reasons that added no coverage.

## What was slow, and why

Measured serially: tests 1–32 of 45 total ~246 s combined. `stedc_tests` alone exceeded 13 minutes; `steqr_tests` was next. Everything outside the eigensolver/tridiagonal family runs in 1–4 s.

Two cost patterns explain it:

1. **Large `n` combined with large `batch`, feeding a dense host reference solve.** `stedc_tests` `BatchedRandomMatrices` ran n=1024 at batch=128, building a dense `Matrix::Zeros(1024, 1024, 128)` (537 MB in float) and running a full `syev` over it — on the *host* for the NETLIB instantiations. `n` drives the divide-and-conquer merge depth; `batch` only multiplies the reference cost.
2. **Accidental complex duplication.** Every `stedc_tests` body starts with `using float_type = typename base_type<T>::type;` and computes only in `float_type`, so the four complex instantiations from `backend_types` re-ran the real ones bit-for-bit — 52 of 104 cases doing zero extra work.

The NETLIB/CPU instantiations dominate generally: on `steqr_tests` they were 115 s of 126 s (91%); both CUDA instantiations together were 11 s.

## Changes

**`stedc_tests.cc`** — switched to `backend_types_filtered<StedcConfig, false>`, dropping the provably-duplicate complex instantiations (104 → 52 cases). Reduced batch on the two tests that build a dense reference: n=512 at 128 → 8, n=1024 at 128 → 4. `n` unchanged in both, so recursion depth is preserved; large-batch behaviour remains covered by the n=64/batch=128 fused-CTA tests in the same file.

**`steqr_tests.cc`** — n=512 with eigenvectors plus a dense `ritz_values` check: batch 32 → 8. The n=128 case feeding a host LAPACK reference per batch item: 128 → 16. The 29-size random sweep: batch 1280 → 64, keeping the full size sweep since that is what exercises block/tail boundaries. Large-batch dispatch stays covered by `SteqrBatchedMatricesWithSchemes`, which stays at batch=1280 and costs 386 ms.

**`tests/CMakeLists.txt`** — component labels (`util`, `blas`, `ortho`, `tridiag`, `eig`, `sparse`) plus `slow` on the binaries that dominate wall-clock, so `ctest -L tridiag` and `ctest -LE slow` work. Previously there were no labels at all — one ctest entry per binary and no way to select a subset.

**`tests/README.md`** — documents the scoped-run workflow and the two cost patterns above, so new tests do not reintroduce them.

## Measurements

`steqr_tests`, full binary, quiet machine, `OPENBLAS_CORETYPE=SKYLAKEX` in both:

| | old | new |
|---|---|---|
| total | 52.5 s | **14.5 s** |

`stedc_tests`, the two dominant tests, old and new binaries run back-to-back under identical load:

| test | old | new | ratio |
|---|---|---|---|
| `StedcTest/0.BatchedMatrices` | 209.3 s | 16.8 s | 12.5× |
| `StedcTest/0.BatchedRandomMatrices` | 627.9 s | 155.5 s | 4.0× |
| **combined** | **837.2 s** | **172.3 s** | **4.9×** |

`BatchedMatrices` independently measured 9.44 s → 0.72 s (13×) on a quiet machine, agreeing with the 12.5× above. Running old and new back-to-back matters here: this machine is shared, and absolute timings drift by an order of magnitude with load — one earlier measurement showed 334 s for a binary that ran in 34.5 s when quiet, and was discarded.

`BatchedRandomMatrices` yields only 4× from a 32× batch cut. Fitting `cost = fixed + batch·k` gives k ≈ 3.8 s and a **~140 s batch-independent floor** at n=1024 — that residual is the STEDC solve itself, not the reference. Going further there would mean lowering `n`, which is the recursion-depth coverage this PR deliberately keeps.

## Coverage

Failure sets are unchanged **by test name**:

- `stedc`: the four `FlatTraceCollapsesByDepth[Ragged]` CUDA failures are pre-existing — verified the old binary fails them on *all* CUDA instantiations (0 passed). The count drops 8 → 4 only because the duplicate complex instantiations that also failed are gone.
- `steqr`: `StressExtremeMagnitudesN32` on NETLIB float and double, identical before and after.

Note the instantiation suffixes shift in `stedc` (CUDA float/double are now `/2`,`/3`; they were `/4`,`/5`), so diff by name, not by index.

## Deliberately not changed

`sytrd_sb2st_tests` (~70 s) is launch-latency bound — n=256 with kd=6 is ~680 sequential kernel launches. Shrinking `n` would help, but these bulge-chase kernels have a history of subtle size-dependent bugs, so it is labelled `slow` rather than altered.

Also left alone: `test_utils.hh` builds a fresh SYCL `Queue` for every test case (there is no `SetUpTestSuite` anywhere). For the many small binaries that per-test setup plus first-kernel JIT is essentially the entire runtime. That is a real further lever, but a riskier and separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJfXyEwkXFjYosX4NMc7z1
