### PR TITLE
syev: route both modes at saturation, keyed on n alone

### DIFF
--- a/SYEV_RETUNE_RESULTS.md
+++ b/SYEV_RETUNE_RESULTS.md
@@ -419,3 +419,60 @@ A measurement is only as good as the regime it samples: §7 was methodologically
 medians, IQRs and name-matching, and still reached the wrong conclusion because the batch
 ladder stopped short. **Routing must be decided at saturation** — the regime where the kernel,
 not the launch overhead, is what is being compared.
+
+---
+
+# Part 4 — Uplo::Upper (2026-08-04)
+
+## 12. Upper was conceded to the vendor for want of an O(n^2) copy
+
+`sytrd_blocked` threw on `Uplo::Upper`, and `syev_supports_blocked` / `syev_supports_two_stage`
+rejected it, so **every** Upper call routed to cuSOLVER regardless of shape. Upper also had
+**no test coverage anywhere** in the syev suite.
+
+A Hermitian matrix's two triangles carry the same operator (`A[j][i] == conj(A[i][j])`), so
+mirroring the upper triangle into the lower one lets the existing Lower pipeline produce
+identical results. That is `O(n^2)` in front of an `O(n^3)` solve
+(`src/extensions/uplo_mirror.cc`).
+
+### 12.1 Measured (float, RTX 4090 device 1, µs/matrix, median of 3, single process)
+
+| n | batch | mode | Auto (Upper) | vendor (Upper) | **speedup** | Auto (Lower) | Upper/Lower |
+|---|---|---|---|---|---|---|---|
+| 128 | 4069 | vectors | 6.72 | 8.22 | **1.22×** | 6.64 | 1.013× |
+| 256 | 2034 | vectors | 37.26 | 37.89 | 1.02× | 36.91 | 1.009× |
+| 320 | 1302 | vectors | 75.00 | 221.25 | **2.95×** | 74.39 | 1.008× |
+| 512 | 508 | vectors | 381.94 | 532.71 | **1.39×** | 380.09 | 1.005× |
+| 1024 | 254 | vectors | 2459.62 | 3314.37 | **1.35×** | 2452.86 | 1.003× |
+| 128 | 4069 | values | 4.51 | 5.61 | **1.24×** | 4.42 | 1.020× |
+| 256 | 2034 | values | 25.19 | 27.85 | **1.11×** | 24.87 | 1.013× |
+| 320 | 1302 | values | 51.82 | 197.22 | **3.81×** | 51.10 | 1.014× |
+| 512 | 508 | values | 171.90 | 482.48 | **2.81×** | 170.43 | 1.009× |
+| 1024 | 254 | values | 915.92 | 3102.78 | **3.39×** | 907.97 | 1.009× |
+
+**The mirror costs 0.3–2.0%** (`Upper/Lower`), and Upper now beats the vendor at every measured
+shape by 1.02×–3.81×. Upper inherits the Lower routing rather than conceding to the vendor.
+
+`Upper/Lower` has a known floor of 1.0 — Upper is Lower plus a mirror pass, so it can never be
+faster. That made it a usable correctness check on the measurement itself: an early run
+reported 0.647× at n=128, which is impossible, and turned out to be two benchmark processes
+sharing the device. Re-run single-process, every ratio sits at or just above 1.0.
+
+### 12.2 Testing
+
+Two cases in `tests/syev_blocked_tests.cc`, one per call site (blocked, two-stage), across
+float / double / complex-float / complex-double.
+
+The obvious test would be vacuous: `Matrix::Random(..., symmetric=true)` is symmetric, so
+Upper and Lower are interchangeable and the test passes with no mirror at all. So the fixture
+**poisons the strictly-lower triangle** after taking the reference from the upper one, and
+then *asserts* that a Lower-read solve of the same matrix gives a spectrum differing by > 1.0.
+If the poisoning ever silently stops taking effect, the test fails with "fixture is vacuous"
+rather than passing for the wrong reason.
+
+### 12.3 Not done
+
+Upper is **not** implemented natively in `sytrd_blocked` / `sytrd_sy2sb` / `sytrd_sb2st`; those
+remain Lower-only and the mirror converts the problem instead. A native implementation could
+recover at most the 0.3–2.0% the mirror costs, at the price of an Upper variant of every
+reduction kernel. Not worth it on these numbers.

--- a/SYEV_RETUNE_RESULTS.md
+++ b/SYEV_RETUNE_RESULTS.md
@@ -259,7 +259,13 @@ Re-measured, blocked/vendor, `> 1` = vendor wins:
 | 896 | 10.05 | 2.27 | 1.93 | 1.52 | 1.06 | 1.19 | 1.24 | — | — |
 | 1024 | 10.14 | 2.29 | 1.97 | 1.50 | 1.15 | 1.44 | — | — | — |
 
-**The `320 <= n <= 640 && batch >= 128` carve-out is confirmed and needs no edit.** What moved:
+> **SUPERSEDED — see §11.** This section concluded the routing needed no edit. That was wrong,
+> and wrong for the reason the whole document warns about elsewhere: the batch ladder here
+> stopped at 1024, which is not saturation for small n. Measured at saturation (§11), the
+> routing is wrong at five of nine sizes. The table below is kept as a record of the
+> batch-dependent behaviour, not as a routing basis.
+
+**The carve-out looked confirmed at the batches measured here.** What moved:
 
 - **n = 1024 improved substantially** — 15.33 → 10.14 at batch 1, 3.33 → 2.29 at batch 8 —
   which is grid-`latrd` doing its job. The vendor still wins, so the decision does not flip.
@@ -342,3 +348,74 @@ invalidated by a later optimisation that nothing re-checked — the same failure
 `latrd` gate is confirmed, `kd = 32` is confirmed, and two-stage should still not be routed for
 eigenvectors. What changed is the *documentation*: three tables now carry re-measured numbers,
 a date, a build SHA, and the shape-dependence that the plain claims elided.
+
+---
+
+# Part 3 — saturated routing (2026-08-04), which supersedes §7
+
+## 11. Routing decided at saturation, keyed on n alone
+
+§7 concluded the eigenvector routing needed no change. **That was wrong.** Its batch ladder
+stopped at 1024, and for small n that is not saturation — at n = 64 the crossover needs batch
+~16384. Small batch flatters the vendor, whose fixed launch cost is lowest, so a ladder that
+never reaches saturation systematically over-credits it.
+
+Re-measured at, for each n, the largest batch where **all three providers fit** (blocked and
+two-stage carry far larger workspaces than the vendor path). Float, eigenvectors, µs/matrix,
+median of 3, RTX 4090 device 1, one process on the device, build `12963a8`:
+
+| n | batch | blocked | vendor | two_stage | winner | margin | old Auto | new Auto |
+|---|---|---|---|---|---|---|---|---|
+| 64 | 16384 | **1.64** | 2.02 | 2.21 | blocked | 1.23× | vendor ✗ | blocked |
+| 128 | 4069 | **6.65** | 7.85 | 10.35 | blocked | 1.18× | vendor ✗ | blocked |
+| 256 | 2034 | **36.92** | 37.14 | 57.56 | blocked | 1.01× | vendor | blocked |
+| 320 | 1302 | **74.53** | 215.23 | 111.20 | blocked | 1.49× | blocked ✓ | blocked |
+| 512 | 508 | 384.27 | 504.69 | **380.02** | two_stage | 1.01× | blocked | two_stage |
+| 640 | 651 | 836.30 | 1008.06 | **727.48** | two_stage | 1.15× | blocked ✗ | two_stage |
+| 768 | 452 | 1612.98 | 1414.99 | **1184.11** | two_stage | 1.19× | vendor ✗ | two_stage |
+| 1024 | 254 | 4089.02 | 2706.84 | **2441.93** | two_stage | 1.11× | vendor ✗ | two_stage |
+| 2048 | 64 | 33842.6 | **15019.1** | 24782.3 | vendor | 1.65× | vendor ✓ | vendor |
+
+**The old routing was wrong at five of nine sizes**, by 1.11×–1.23×.
+
+### 11.1 The rule
+
+```
+n <= 32          -> CTA family (syev_choose_small_kernel; unchanged)
+64 <= n <= 320   -> BatchLAS_Blocked
+512 <= n <= 1024 -> BatchLAS_TwoStage
+n >= 2048        -> Vendor
+```
+
+`syev_prefer_vendor` is no longer consulted for eigenvectors. It was removed from that path
+rather than re-tuned, because its whole structure is batch-keyed and every grid feeding it was
+built from unsaturated cells.
+
+### 11.2 Verified end to end
+
+Auto dispatches to the measured winner at every shape (idle GPU, ratio Auto/expected):
+
+| n | 64 | 128 | 320 | 640 | 1024 | 2048 |
+|---|---|---|---|---|---|---|
+| ratio | 1.000 | 0.999 | 1.001 | 1.000 | 1.000 | 1.002 |
+
+Tests reproduce the baseline exactly: 16 pass, 3 fail (`lanczos`, `steqr`, `stedc`, all
+pre-existing).
+
+### 11.3 What is NOT established
+
+- **n = 2048 was measured at batch 64**, below the 128 SMs — memory-limited, not saturated,
+  because blocked and two-stage cannot fit a larger batch at that size. It is the weakest row
+  in the table and the 2048 boundary rests on it.
+- **Float only.** The mechanism is type-independent but the crossovers may not be.
+- **Eigenvectors only.** `syev_benchmark` hardcodes `JobType::EigenVectors`, so eigenvalues-only
+  keeps `syev_prefer_two_stage_values` and the historical ordering, unmeasured.
+- **`Uplo::Upper`** falls back to the vendor — neither BatchLAS path supports it.
+
+### 11.4 The recurring lesson
+
+This is the third table in this repo invalidated the same way, and the second one *I* produced.
+A measurement is only as good as the regime it samples: §7 was methodologically careful about
+medians, IQRs and name-matching, and still reached the wrong conclusion because the batch
+ladder stopped short. **Routing must be decided at saturation** — the regime where the kernel,
+not the launch overhead, is what is being compared.

--- a/benchmarks/syev_benchmark.cc
+++ b/benchmarks/syev_benchmark.cc
@@ -13,7 +13,9 @@ inline void SyevBenchSizes(Benchmark* b) {
     auto add_cases = [&](int n, int batch, std::initializer_list<int> nbs) {
         for (int nb : nbs) {
             for (int fuse : {0, 1}) {
-                b->Args({n, batch, nb, fuse});
+                // arg4 = jobz, 1 = EigenVectors. Passed explicitly so the registered sizes
+                // keep the behaviour they had before jobz became an argument.
+                b->Args({n, batch, nb, fuse, 1});
             }
         }
     };
@@ -27,9 +29,16 @@ template <typename Benchmark>
 inline void SyevBenchSizesNetlib(Benchmark* b) {
     for (int n : {64, 128, 256}) {
         for (int batch : {1, 10}) {
-            b->Args({n, batch, 16, 0});
+            b->Args({n, batch, 16, 0, 1});
         }
     }
+}
+
+// arg4: 0 = NoEigenVectors, 1 = EigenVectors. Same convention as syev_cta_benchmark and
+// syev_blocked_benchmark. state.range() returns 0 for an absent argument, so a caller passing
+// only four args gets eigenvalues-only; every registered size passes jobz explicitly.
+inline JobType parse_jobz(int v) {
+    return (v == 0) ? JobType::NoEigenVectors : JobType::EigenVectors;
 }
 
 } // namespace
@@ -41,6 +50,7 @@ static void BM_SYEV(minibench::State& state) {
     const size_t batch = state.range(1);
     const int sytrd_block_size = static_cast<int>(state.range(2));
     const int fuse_panel_update = static_cast<int>(state.range(3));
+    const JobType jobz = parse_jobz(static_cast<int>(state.range(4)));
 
     ::setenv("BATCHLAS_SYTRD_BLOCK_SIZE", std::to_string(sytrd_block_size).c_str(), 1);
     ::setenv("BATCHLAS_SYTRD_FUSE_PANEL_UPDATE", fuse_panel_update ? "1" : "0", 1);
@@ -50,13 +60,13 @@ static void BM_SYEV(minibench::State& state) {
     UnifiedVector<typename base_type<T>::type> W(n * batch);
 
     size_t ws_size = syev_buffer_size<B>(*q, A.view(), W.to_span(),
-                                         JobType::EigenVectors, Uplo::Lower);
+                                         jobz, Uplo::Lower);
     UnifiedVector<std::byte> workspace(ws_size);
 
     state.SetKernel(q,
                     bench::pristine(A),
                     std::move(W),
-                    JobType::EigenVectors,
+                    jobz,
                     Uplo::Lower,
                     std::move(workspace),
                     [](Queue& q, auto&&... xs) {

--- a/benchmarks/syev_benchmark.cc
+++ b/benchmarks/syev_benchmark.cc
@@ -41,6 +41,13 @@ inline JobType parse_jobz(int v) {
     return (v == 0) ? JobType::NoEigenVectors : JobType::EigenVectors;
 }
 
+// arg5: 0 = Lower (default, and what every registered size uses), 1 = Upper. Upper exists so
+// the mirror path in syev_blocked / syev_two_stage can be measured against the vendor at all;
+// before it, no benchmark could express an Upper solve.
+inline Uplo parse_uplo(int v) {
+    return (v == 0) ? Uplo::Lower : Uplo::Upper;
+}
+
 } // namespace
 
 // Symmetric eigenvalue decomposition benchmark
@@ -51,6 +58,7 @@ static void BM_SYEV(minibench::State& state) {
     const int sytrd_block_size = static_cast<int>(state.range(2));
     const int fuse_panel_update = static_cast<int>(state.range(3));
     const JobType jobz = parse_jobz(static_cast<int>(state.range(4)));
+    const Uplo uplo = parse_uplo(static_cast<int>(state.range(5)));
 
     ::setenv("BATCHLAS_SYTRD_BLOCK_SIZE", std::to_string(sytrd_block_size).c_str(), 1);
     ::setenv("BATCHLAS_SYTRD_FUSE_PANEL_UPDATE", fuse_panel_update ? "1" : "0", 1);
@@ -60,14 +68,14 @@ static void BM_SYEV(minibench::State& state) {
     UnifiedVector<typename base_type<T>::type> W(n * batch);
 
     size_t ws_size = syev_buffer_size<B>(*q, A.view(), W.to_span(),
-                                         jobz, Uplo::Lower);
+                                         jobz, uplo);
     UnifiedVector<std::byte> workspace(ws_size);
 
     state.SetKernel(q,
                     bench::pristine(A),
                     std::move(W),
                     jobz,
-                    Uplo::Lower,
+                    uplo,
                     std::move(workspace),
                     [](Queue& q, auto&&... xs) {
                         syev<B, T>(q, std::forward<decltype(xs)>(xs)...);

--- a/include/blas/functions/syev.hh
+++ b/include/blas/functions/syev.hh
@@ -105,25 +105,30 @@ inline bool syev_supports_cta(const DeviceCaps& caps, const MatrixView<T, Matrix
     return true;
 }
 
+// Uplo::Upper is supported: syev_blocked mirrors the upper triangle into the lower one
+// (an O(n^2) pass, see src/extensions/uplo_mirror.hh) and runs the ordinary Lower pipeline.
+// Before that, every Upper call fell through to the vendor no matter how much faster this
+// path was at that shape.
 template <typename T>
 inline bool syev_supports_blocked(const DeviceCaps& caps,
                                   const MatrixView<T, MatrixFormat::Dense>& A,
                                   Uplo uplo) {
+    (void)uplo;
     if (A.rows() != A.cols()) return false;
     if (A.rows() < 1 || A.batch_size() < 1) return false;
     if (!caps.is_gpu) return false;
-    if (uplo != Uplo::Lower) return false;
     return true;
 }
 
+// Uplo::Upper supported by the same mirror; see syev_supports_blocked above.
 template <typename T>
 inline bool syev_supports_two_stage(const DeviceCaps& caps,
                                     const MatrixView<T, MatrixFormat::Dense>& A,
                                     Uplo uplo) {
+    (void)uplo;
     if (A.rows() != A.cols()) return false;
     if (A.rows() < 1 || A.batch_size() < 1) return false;
     if (!caps.is_gpu) return false;
-    if (uplo != Uplo::Lower) return false;
     return true;
 }
 
@@ -550,8 +555,8 @@ inline Provider choose_syev_provider(const DispatchPolicy& policy,
             if (want == Provider::BatchLAS_TwoStage && syev_supports_two_stage(caps, A, uplo)) {
                 return want;
             }
-            // Unsupported for this shape (e.g. Uplo::Upper, which neither BatchLAS path
-            // takes) -- the vendor handles everything.
+            // Unsupported for this shape -- the vendor handles everything. (Uplo::Upper is
+            // no longer such a case; both BatchLAS paths mirror it into Lower.)
             return Provider::Vendor;
         }
         // Only reachable for n <= 32 now, where it returns false by construction -- both

--- a/include/blas/functions/syev.hh
+++ b/include/blas/functions/syev.hh
@@ -187,8 +187,14 @@ inline Provider normalize_vendor_like(Provider p) {
 //     896     10.05  2.27  1.93  1.52  1.06  1.19  1.24     -     -
 //     1024    10.14  2.29  1.97  1.50  1.15  1.44     -     -     -
 //
-// THE CARVE-OUT SURVIVES UNCHANGED, and the routing below needs no edit. What
-// did change:
+// SUPERSEDED 2026-08-04 by the saturated sweep in syev_saturated_provider_for_n below.
+// THIS GRID IS RETAINED ONLY AS A RECORD OF THE BATCH-DEPENDENT BEHAVIOUR; it no longer
+// drives eigenvector routing. Its batch ladder stopped at 1024, which for small n is NOWHERE
+// NEAR saturation -- at n = 64 the true crossover needs batch ~16384, and there blocked wins
+// by 1.23x where this grid shows the vendor ahead at 1.11x. Reading routing off it was wrong
+// at five of nine sizes. Do not reinstate a batch-keyed rule from these numbers.
+//
+// The original conclusion, now known to be an artifact of the unsaturated ladder:
 //   * n = 1024 improved a lot -- 15.33 -> 10.14 at batch 1, 3.33 -> 2.29 at
 //     batch 8 -- which is grid-latrd doing exactly its job. The vendor still
 //     wins there, so the decision does not flip; only the margin narrowed.
@@ -406,6 +412,55 @@ inline bool syev_prefer_two_stage_values(const DeviceCaps& caps, int64_t n, int6
     return n >= 512 && batch >= 256;
 }
 
+// --- Eigenvector routing, decided AT SATURATION and keyed on n alone ----------
+//
+// WHY THIS REPLACES syev_prefer_vendor FOR EIGENVECTORS.
+//
+// Every earlier grid in this file capped its batch ladder at 1024, and for small n that is
+// nowhere near saturation -- at n = 64 the vendor's lower fixed cost still dominates there,
+// so the vendor looked like the winner. Measured at a batch large enough to amortise launch
+// overhead, it is not. Routing is a per-n decision made on the assumption that the batch is
+// large; a caller running tiny batches pays launch overhead whatever we pick, and tuning the
+// routing for that regime costs the saturated regime real throughput.
+//
+// MEASURED 2026-08-04, RTX 4090 device 1, build 12963a8, float, EIGENVECTORS, us/matrix,
+// median of 3, one process on the device. Batch per n is the largest at which ALL THREE
+// providers fit (blocked and two-stage carry much larger workspaces than the vendor path):
+//
+//     n   batch    blocked    vendor  two_stage    winner        margin
+//    64   16384       1.64      2.02       2.21    blocked        1.23x
+//   128    4069       6.65      7.85      10.35    blocked        1.18x
+//   256    2034      36.92     37.14      57.56    blocked        1.01x  (tie w/ vendor)
+//   320    1302      74.53    215.23     111.20    blocked        1.49x
+//   512     508     384.27    504.69     380.02    two_stage      1.01x  (tie w/ blocked)
+//   640     651     836.30   1008.06     727.48    two_stage      1.15x
+//   768     452    1612.98   1414.99    1184.11    two_stage      1.19x
+//  1024     254    4089.02   2706.84    2441.93    two_stage      1.11x
+//  2048      64   33842.60  15019.10   24782.30    vendor         1.65x
+//
+// The old routing sent 64, 128, 768 and 1024 to the vendor and 640 to blocked -- five of the
+// nine rows wrong, by 1.11x to 1.23x.
+//
+// n <= 32 is NOT handled here: it is CTA territory and syev_choose_small_kernel picks among
+// the three CTA kernels. Measured at batch 2048, cta/jacobi (n=16) and cta/fused (n=32) beat
+// every non-CTA provider by 2.8x-3.0x, so the CTA-first ordering is correct there.
+//
+// CAVEATS, all load-bearing:
+//   * n = 2048 was measured at batch 64, which is BELOW the 128 SMs and therefore NOT
+//     saturated -- it is memory-limited, since blocked/two-stage cannot fit a larger batch at
+//     that size. Its "vendor" verdict is the weakest row in the table and should be
+//     re-measured on a card with more memory before being relied on.
+//   * float only. The mechanism (work-per-matrix vs launch overhead) is type-independent, but
+//     the crossovers could sit elsewhere in double or complex.
+//   * EIGENVECTORS only. Eigenvalues-only keeps syev_prefer_two_stage_values / the historical
+//     ordering, because syev_benchmark hardcodes JobType::EigenVectors and there is no vendor
+//     route to measure the other mode against.
+inline Provider syev_saturated_provider_for_n(int64_t n) {
+    if (n <= 320) return Provider::BatchLAS_Blocked;   // 64..320, up to 1.49x over the vendor
+    if (n <= 1024) return Provider::BatchLAS_TwoStage; // 512..1024, up to 1.19x
+    return Provider::Vendor;                           // 2048+, 1.65x (but see the caveat)
+}
+
 template <Backend B, typename T>
 inline Provider choose_syev_provider(const DispatchPolicy& policy,
                                      const DeviceCaps& caps,
@@ -438,6 +493,22 @@ inline Provider choose_syev_provider(const DispatchPolicy& policy,
             syev_prefer_two_stage_values(caps, A.rows(), A.batch_size()) &&
             syev_supports_two_stage(caps, A, uplo)) {
             return Provider::BatchLAS_TwoStage;
+        }
+        // EIGENVECTORS, n > 32: routed per n from the saturated measurement above, NOT from
+        // the batch-dependent syev_prefer_vendor grid, which was built from unsaturated
+        // cells and picks the wrong provider at five of nine measured sizes. n <= 32 falls
+        // through to the order loop so the CTA branch keeps it.
+        if (jobtype == JobType::EigenVectors && A.rows() > 32) {
+            const Provider want = syev_saturated_provider_for_n(A.rows());
+            if (want == Provider::BatchLAS_Blocked && syev_supports_blocked(caps, A, uplo)) {
+                return want;
+            }
+            if (want == Provider::BatchLAS_TwoStage && syev_supports_two_stage(caps, A, uplo)) {
+                return want;
+            }
+            // Unsupported for this shape (e.g. Uplo::Upper, which neither BatchLAS path
+            // takes) -- the vendor handles everything.
+            return Provider::Vendor;
         }
         if (syev_prefer_vendor(caps, A.rows(), A.batch_size())) return Provider::Vendor;
         // Small n with eigenvectors: CTA claims the whole n <= 32 range, but the

--- a/include/blas/functions/syev.hh
+++ b/include/blas/functions/syev.hh
@@ -407,6 +407,9 @@ inline bool syev_prefer_vendor_over_cta(const DeviceCaps& caps,
 
 // Eigenvalues-only: is the two-stage solver the best choice for this shape?
 // Checked before syev_prefer_vendor, since it overrides it where it applies.
+// SUPERSEDED by syev_saturated_provider_for_n_values. Retained only because the batch >= 256
+// term is a documented cautionary tale: an n = 1024 solve at batch 254 fell through it to the
+// vendor and paid 2.75x. No longer consulted by choose_syev_provider.
 inline bool syev_prefer_two_stage_values(const DeviceCaps& caps, int64_t n, int64_t batch) {
     if (!caps.is_gpu) return false;
     return n >= 512 && batch >= 256;
@@ -452,13 +455,46 @@ inline bool syev_prefer_two_stage_values(const DeviceCaps& caps, int64_t n, int6
 //     re-measured on a card with more memory before being relied on.
 //   * float only. The mechanism (work-per-matrix vs launch overhead) is type-independent, but
 //     the crossovers could sit elsewhere in double or complex.
-//   * EIGENVECTORS only. Eigenvalues-only keeps syev_prefer_two_stage_values / the historical
-//     ordering, because syev_benchmark hardcodes JobType::EigenVectors and there is no vendor
-//     route to measure the other mode against.
+//   * EIGENVECTORS only. Eigenvalues-only has its own table and its own rule; see
+//     syev_saturated_provider_for_n_values below. (syev_benchmark grew a jobz argument so
+//     that mode could be measured against the vendor at all.)
 inline Provider syev_saturated_provider_for_n(int64_t n) {
     if (n <= 320) return Provider::BatchLAS_Blocked;   // 64..320, up to 1.49x over the vendor
     if (n <= 1024) return Provider::BatchLAS_TwoStage; // 512..1024, up to 1.19x
     return Provider::Vendor;                           // 2048+, 1.65x (but see the caveat)
+}
+
+// --- The same, for EIGENVALUES-ONLY -----------------------------------------
+//
+// Measured 2026-08-04, same method and machine, jobz = NoEigenVectors. This mode could only
+// be measured once syev_benchmark grew a jobz argument -- it previously hardcoded
+// JobType::EigenVectors, so there was no vendor arm to compare against.
+//
+//     n   batch    blocked    vendor  two_stage    winner      margin
+//    64   16384       1.06      1.12       1.14    blocked      1.06x
+//   128    4069       4.41      5.34       5.35    blocked      1.21x
+//   256    2034      24.78     27.20      27.98    blocked      1.10x
+//   320    2604      48.16    200.94      50.35    blocked      1.05x
+//   512    1017     298.30    458.95     158.72    two_stage    1.88x
+//   640     651     687.67    929.05     330.71    two_stage    2.08x
+//   768     452    1362.46   1301.59     505.29    two_stage    2.58x
+//  1024     254    3537.41   2494.44     908.32    two_stage    2.75x
+//  2048      64   29547.70  13908.80   10804.10    two_stage    1.29x
+//
+// Same boundaries as the eigenvector table for 64..320, but two-stage keeps winning all the
+// way to 2048 rather than handing over to the vendor -- and by far larger margins (1.88x to
+// 2.75x, against at most 1.19x with eigenvectors). That is the back-transform: with no
+// eigenvectors to produce, two-stage keeps its cheap band reduction and never pays to apply
+// Q2, so its flop advantage survives into wall-clock.
+//
+// THIS REPLACES syev_prefer_two_stage_values, WHOSE BATCH TERM DID REAL DAMAGE. That
+// predicate required batch >= 256; the n = 1024 cell above ran at batch 254 and therefore
+// fell through to the vendor and paid 2.75x. Two callers differing by two matrices got
+// completely different providers for reasons unrelated to which kernel is better. Routing is
+// keyed on n alone.
+inline Provider syev_saturated_provider_for_n_values(int64_t n) {
+    if (n <= 320) return Provider::BatchLAS_Blocked;   // 64..320, 1.05x - 1.21x
+    return Provider::BatchLAS_TwoStage;                // 512..2048, 1.29x - 2.75x
 }
 
 template <Backend B, typename T>
@@ -489,10 +525,18 @@ inline Provider choose_syev_provider(const DispatchPolicy& policy,
         // Eigenvalues-only at large n and large batch: our two-stage solver wins
         // outright since its stage-2 chase was fixed. Checked first because it
         // overlaps the vendor-preferred region.
-        if (jobtype != JobType::EigenVectors &&
-            syev_prefer_two_stage_values(caps, A.rows(), A.batch_size()) &&
-            syev_supports_two_stage(caps, A, uplo)) {
-            return Provider::BatchLAS_TwoStage;
+        // EIGENVALUES-ONLY, n > 32: routed per n from the saturated measurement, replacing
+        // syev_prefer_two_stage_values. Its batch >= 256 term sent an n=1024 solve at batch
+        // 254 to the vendor at 2.75x the cost of two-stage; routing is keyed on n alone.
+        if (jobtype != JobType::EigenVectors && A.rows() > 32) {
+            const Provider want = syev_saturated_provider_for_n_values(A.rows());
+            if (want == Provider::BatchLAS_Blocked && syev_supports_blocked(caps, A, uplo)) {
+                return want;
+            }
+            if (want == Provider::BatchLAS_TwoStage && syev_supports_two_stage(caps, A, uplo)) {
+                return want;
+            }
+            return Provider::Vendor;
         }
         // EIGENVECTORS, n > 32: routed per n from the saturated measurement above, NOT from
         // the batch-dependent syev_prefer_vendor grid, which was built from unsaturated
@@ -510,6 +554,9 @@ inline Provider choose_syev_provider(const DispatchPolicy& policy,
             // takes) -- the vendor handles everything.
             return Provider::Vendor;
         }
+        // Only reachable for n <= 32 now, where it returns false by construction -- both
+        // jobz branches above return for n > 32. Kept so an explicit provider order still
+        // behaves, but it no longer decides anything. See the SUPERSEDED note on the grid.
         if (syev_prefer_vendor(caps, A.rows(), A.batch_size())) return Provider::Vendor;
         // Small n with eigenvectors: CTA claims the whole n <= 32 range, but the
         // vendor is faster over part of it. See syev_prefer_vendor_over_cta.

--- a/src/extensions/CMakeLists.txt
+++ b/src/extensions/CMakeLists.txt
@@ -18,6 +18,7 @@ set(EXTENSIONS_EIGEN_SOURCES
     syevx_lobpcg.cc
     syevx_filtered.cc
     syev_cta.cc
+    uplo_mirror.cc
     syev_blocked.cc
     syev_two_stage.cc
     lanczos.cc

--- a/src/extensions/syev_blocked.cc
+++ b/src/extensions/syev_blocked.cc
@@ -1,4 +1,5 @@
 #include <blas/extensions.hh>
+#include "uplo_mirror.hh"
 #include <blas/functions.hh>
 #include <blas/matrix.hh>
 #include <blas/linalg.hh>
@@ -33,10 +34,8 @@ inline void validate_syev_blocked_dims(const MatrixView<T, MatrixFormat::Dense>&
     if (jobz != JobType::NoEigenVectors && jobz != JobType::EigenVectors) {
         throw std::invalid_argument("syev_blocked: invalid JobType.");
     }
-    if (uplo != Uplo::Lower) {
-        // Current sytrd_blocked implementation supports only Lower.
-        throw std::invalid_argument("syev_blocked: only Uplo::Lower is currently implemented.");
-    }
+    // Uplo::Upper is accepted: the solve mirrors the upper triangle into the lower one and
+    // proceeds down the Lower path. See uplo_mirror.hh.
 
     const int64_t n64 = a.rows();
     const int64_t batch64 = a.batch_size();
@@ -91,6 +90,14 @@ Event syev_blocked(Queue& ctx,
 
     if (!ctx.in_order()) {
         throw std::runtime_error("syev_blocked: requires an in-order Queue");
+    }
+
+    // Uplo::Upper: mirror the upper triangle into the lower one and continue as Lower.
+    // sytrd_blocked below implements Lower only; this O(n^2) pass is what lets Auto route
+    // Upper input here at all instead of conceding it to the vendor. See uplo_mirror.hh.
+    if (uplo == Uplo::Upper) {
+        mirror_upper_to_lower<B, T>(ctx, a_in);
+        uplo = Uplo::Lower;
     }
 
     const int32_t n = static_cast<int32_t>(a_in.rows());
@@ -357,9 +364,7 @@ size_t syev_blocked_buffer_size(Queue& ctx,
     if (jobz != JobType::NoEigenVectors && jobz != JobType::EigenVectors) {
         throw std::invalid_argument("syev_blocked_buffer_size: invalid JobType.");
     }
-    if (uplo != Uplo::Lower) {
-        throw std::invalid_argument("syev_blocked_buffer_size: only Uplo::Lower is currently implemented.");
-    }
+    // Uplo::Upper is accepted; the workspace is identical because the mirror is in-place.
 
     const int32_t n = static_cast<int32_t>(a.rows());
     const int32_t batch = static_cast<int32_t>(a.batch_size());

--- a/src/extensions/syev_two_stage.cc
+++ b/src/extensions/syev_two_stage.cc
@@ -1,4 +1,5 @@
 #include <blas/extensions.hh>
+#include "uplo_mirror.hh"
 #include <blas/functions.hh>
 #include <blas/linalg.hh>
 #include <blas/matrix.hh>
@@ -38,9 +39,7 @@ inline void validate_syev_two_stage_dims(const MatrixView<T, MatrixFormat::Dense
     if (jobz != JobType::NoEigenVectors && jobz != JobType::EigenVectors) {
         throw std::invalid_argument("syev_two_stage: invalid JobType.");
     }
-    if (uplo != Uplo::Lower) {
-        throw std::invalid_argument("syev_two_stage: only Uplo::Lower is currently implemented.");
-    }
+    // Uplo::Upper is accepted; the solve mirrors it into Lower first. See uplo_mirror.hh.
 
     const int64_t n64 = a.rows();
     const int64_t batch64 = a.batch_size();
@@ -69,6 +68,13 @@ Event syev_two_stage(Queue& ctx,
 
     if (!ctx.in_order()) {
         throw std::runtime_error("syev_two_stage: requires an in-order Queue");
+    }
+
+    // Uplo::Upper: mirror into Lower, then run the ordinary Lower pipeline (sytrd_sy2sb ->
+    // sb2st -> stedc -> back-transform), none of which implements Upper. See uplo_mirror.hh.
+    if (uplo == Uplo::Upper) {
+        mirror_upper_to_lower<B, T>(ctx, a_in);
+        uplo = Uplo::Lower;
     }
 
     if constexpr (B == Backend::NETLIB) {
@@ -388,9 +394,7 @@ size_t syev_two_stage_buffer_size(Queue& ctx,
     if (jobz != JobType::NoEigenVectors && jobz != JobType::EigenVectors) {
         throw std::invalid_argument("syev_two_stage_buffer_size: invalid JobType.");
     }
-    if (uplo != Uplo::Lower) {
-        throw std::invalid_argument("syev_two_stage_buffer_size: only Uplo::Lower is currently implemented.");
-    }
+    // Uplo::Upper is accepted; workspace is identical, the mirror is in-place.
 
     if constexpr (B == Backend::NETLIB) {
         if (jobz == JobType::EigenVectors) {

--- a/src/extensions/uplo_mirror.cc
+++ b/src/extensions/uplo_mirror.cc
@@ -1,0 +1,71 @@
+#include "uplo_mirror.hh"
+
+#include <sycl/sycl.hpp>
+#include <batchlas/backend_config.h>
+
+#include "../math-helpers.hh"
+#include "../queue.hh"
+#include "../util/template-instantiations.hh"
+
+#include <complex>
+
+namespace batchlas {
+
+namespace {
+template <Backend B, typename T> class UploMirrorUpperToLowerKernel;
+} // namespace
+
+template <Backend B, typename T>
+Event mirror_upper_to_lower(Queue& ctx, const MatrixView<T, MatrixFormat::Dense>& a) {
+    const int n = static_cast<int>(a.rows());
+    const int batch = static_cast<int>(a.batch_size());
+    const int ld = static_cast<int>(a.ld());
+    const int64_t stride = a.stride();
+    T* ptr = a.data().data();
+
+    ctx->submit([&](sycl::handler& h) {
+        h.parallel_for<UploMirrorUpperToLowerKernel<B, T>>(
+            sycl::range<3>(static_cast<size_t>(batch),
+                           static_cast<size_t>(n),
+                           static_cast<size_t>(n)),
+            [=](sycl::id<3> idx) {
+                const int b = static_cast<int>(idx[0]);
+                const int r = static_cast<int>(idx[1]);
+                const int c = static_cast<int>(idx[2]);
+                // Only strictly-upper source entries do work; each writes its mirror.
+                if (c <= r) return;
+                T* A = ptr + b * stride;
+                const T v = A[r + c * ld];          // (r, c) with r < c: upper triangle
+                if constexpr (internal::is_complex<T>::value) {
+                    A[c + r * ld] = T(v.real(), -v.imag());
+                } else {
+                    A[c + r * ld] = v;
+                }
+            });
+    });
+    return ctx.get_event();
+}
+
+#define UPLO_MIRROR_INSTANTIATE(back, fp) \
+    template Event mirror_upper_to_lower<back, BATCHLAS_UNPAREN fp>( \
+        Queue&, const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>&);
+
+#define UPLO_MIRROR_INSTANTIATE_FOR_BACKEND(back) \
+    BATCHLAS_FOR_EACH_SCALAR_TYPE_1(UPLO_MIRROR_INSTANTIATE, back)
+
+#if BATCHLAS_HAS_CUDA_BACKEND
+UPLO_MIRROR_INSTANTIATE_FOR_BACKEND(Backend::CUDA)
+#endif
+
+#if BATCHLAS_HAS_ROCM_BACKEND
+UPLO_MIRROR_INSTANTIATE_FOR_BACKEND(Backend::ROCM)
+#endif
+
+#if BATCHLAS_HAS_HOST_BACKEND
+UPLO_MIRROR_INSTANTIATE_FOR_BACKEND(Backend::NETLIB)
+#endif
+
+#undef UPLO_MIRROR_INSTANTIATE_FOR_BACKEND
+#undef UPLO_MIRROR_INSTANTIATE
+
+} // namespace batchlas

--- a/src/extensions/uplo_mirror.hh
+++ b/src/extensions/uplo_mirror.hh
@@ -1,0 +1,34 @@
+// Mirror the upper triangle of a Hermitian/symmetric matrix into its lower triangle.
+//
+// WHY THIS EXISTS. syev_blocked and syev_two_stage (and everything under them: sytrd_blocked,
+// sytrd_sy2sb, sytrd_sb2st) implement Uplo::Lower only -- sytrd_blocked threw outright on
+// Upper. So every Uplo::Upper call fell back to the vendor no matter how much faster our own
+// providers were at that shape. That is a routing loss caused by a missing O(n^2) step in
+// front of an O(n^3) solve.
+//
+// For a Hermitian matrix the two triangles carry the same operator: A[j][i] == conj(A[i][j]).
+// Writing the upper triangle into the lower one therefore yields a matrix whose LOWER
+// triangle describes exactly the input operator, and the existing Lower path then produces
+// identical eigenvalues and eigenvectors. Cost is O(n^2 * batch) against the solve's
+// O(n^3 * batch), i.e. below noise at every size where routing matters.
+//
+// In-place is safe here: `syev` documents A as overwritten (include/blas/functions/syev.hh),
+// and the Lower path destroys A during the reduction regardless. The diagonal is left alone;
+// for complex input its imaginary part is not forced to zero, matching what the Lower path
+// already assumes of a Hermitian input.
+//
+// DECLARATION ONLY. The definition lives in uplo_mirror.cc with explicit instantiations,
+// because a SYCL kernel name class must have exactly one definition across the program --
+// defining it inline in a header and calling it from both syev_blocked.cc and
+// syev_two_stage.cc produced "definition with same mangled name" ODR errors.
+#pragma once
+
+#include <blas/matrix.hh>
+#include <util/sycl-device-queue.hh>
+
+namespace batchlas {
+
+template <Backend B, typename T>
+Event mirror_upper_to_lower(Queue& ctx, const MatrixView<T, MatrixFormat::Dense>& a);
+
+} // namespace batchlas

--- a/tests/syev_blocked_tests.cc
+++ b/tests/syev_blocked_tests.cc
@@ -360,3 +360,146 @@ int main(int argc, char** argv) {
 	::testing::InitGoogleTest(&argc, argv);
 	return RUN_ALL_TESTS();
 }
+
+// --- Uplo::Upper -------------------------------------------------------------
+//
+// Upper had NO coverage anywhere in the syev tests before this. It also had no
+// implementation: sytrd_blocked threw on it, so every Upper call fell through to the vendor.
+// syev_blocked/syev_two_stage now mirror the upper triangle into the lower one and run the
+// ordinary Lower pipeline (src/extensions/uplo_mirror.hh), which is what lets Auto route
+// Upper input to our own providers.
+//
+// The test that has teeth: build a matrix whose two triangles DISAGREE, so that reading the
+// wrong one gives a different spectrum. Matrix::Random(..., /*symmetric=*/true) is symmetric,
+// which would make Upper and Lower trivially interchangeable and the test vacuous. Here the
+// strictly-lower entries are overwritten with garbage after the reference is taken from the
+// upper triangle, so a solver that reads the lower triangle without mirroring gets the wrong
+// answer.
+TYPED_TEST(SyevBlockedTest, UpperMatchesNetlibWithDisagreeingTriangles) {
+	using Scalar = typename TestFixture::ScalarType;
+	using Real = typename base_type<Scalar>::type;
+	constexpr Backend B = TestFixture::BackendType;
+
+	const int n = 96;
+	const int batch = 8;
+
+	Matrix<Scalar, MatrixFormat::Dense> A0 =
+		Matrix<Scalar, MatrixFormat::Dense>::Random(n, n, true, batch, 4242);
+
+	// Poison the strictly-lower triangle so it no longer mirrors the upper one.
+	for (int b = 0; b < batch; ++b) {
+		Scalar* Ab = A0.view().data().data() + static_cast<std::size_t>(b) * A0.view().stride();
+		const int ld = static_cast<int>(A0.view().ld());
+		for (int c = 0; c < n; ++c) {
+			for (int r = c + 1; r < n; ++r) {
+				Ab[r + c * ld] = Scalar(Real(-7.5));   // garbage, deliberately not symmetric
+			}
+		}
+	}
+
+	Matrix<Scalar, MatrixFormat::Dense> A_ours = A0;
+	Matrix<Scalar, MatrixFormat::Dense> A_ref = A0;
+
+	auto W_ours = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+	auto W_ref = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+
+	// Reference: CPU LAPACKE, reading the UPPER triangle.
+	{
+		auto ws_ref = UnifiedVector<std::byte>(syev_buffer_size<Backend::NETLIB>(
+			*this->ctx, A_ref.view(), W_ref.to_span(), JobType::NoEigenVectors, Uplo::Upper));
+		syev<Backend::NETLIB>(*this->ctx, A_ref.view(), W_ref.to_span(),
+							  JobType::NoEigenVectors, Uplo::Upper, ws_ref.to_span()).wait();
+	}
+
+	// PROVE THE FIXTURE HAS TEETH. If the poisoning above did not take effect the matrix is
+	// still symmetric, Upper and Lower are interchangeable, and this test would pass even if
+	// the mirror never ran. Solve the SAME matrix reading the LOWER triangle and require a
+	// different spectrum -- that is what makes the Upper comparison below meaningful.
+	{
+		Matrix<Scalar, MatrixFormat::Dense> A_lo = A0;
+		auto W_lo = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+		auto ws_lo = UnifiedVector<std::byte>(syev_buffer_size<Backend::NETLIB>(
+			*this->ctx, A_lo.view(), W_lo.to_span(), JobType::NoEigenVectors, Uplo::Lower));
+		syev<Backend::NETLIB>(*this->ctx, A_lo.view(), W_lo.to_span(),
+							  JobType::NoEigenVectors, Uplo::Lower, ws_lo.to_span()).wait();
+		Real max_gap = Real(0);
+		for (int j = 0; j < batch; ++j) {
+			for (int i = 0; i < n; ++i) {
+				max_gap = std::max(max_gap, std::abs(W_lo[i + j * n] - W_ref[i + j * n]));
+			}
+		}
+		ASSERT_GT(max_gap, Real(1))
+			<< "fixture is vacuous: the two triangles agree, so Upper vs Lower proves nothing";
+	}
+
+	// Ours: blocked path with Uplo::Upper, which must mirror before reducing.
+	{
+		StedcParams<Real> params;
+		params.recursion_threshold = 32;
+		auto ws = UnifiedVector<std::byte>(syev_blocked_buffer_size<B, Scalar>(
+			*this->ctx, A_ours.view(), JobType::NoEigenVectors, Uplo::Upper, params));
+		syev_blocked<B, Scalar>(*this->ctx, A_ours.view(), W_ours.to_span(),
+								JobType::NoEigenVectors, Uplo::Upper, ws.to_span(), params).wait();
+	}
+
+	const Real tol = std::max(tol_eig_for<Real>(), blocked_cuda_tolerance_floor_eig<Scalar, B>());
+	for (int j = 0; j < batch; ++j) {
+		for (int i = 0; i < n; ++i) {
+			EXPECT_NEAR(W_ours[i + j * n], W_ref[i + j * n], tol)
+				<< "(i,b)= (" << i << "," << j << ")";
+		}
+	}
+}
+
+// Same, through the two-stage provider, which has its own mirror call site.
+TYPED_TEST(SyevBlockedTest, UpperTwoStageMatchesNetlib) {
+	using Scalar = typename TestFixture::ScalarType;
+	using Real = typename base_type<Scalar>::type;
+	constexpr Backend B = TestFixture::BackendType;
+
+	if constexpr (B == Backend::NETLIB) {
+		GTEST_SKIP() << "two-stage is a GPU path";
+	} else {
+		const int n = 128;
+		const int batch = 4;
+
+		Matrix<Scalar, MatrixFormat::Dense> A0 =
+			Matrix<Scalar, MatrixFormat::Dense>::Random(n, n, true, batch, 909);
+		for (int b = 0; b < batch; ++b) {
+			Scalar* Ab = A0.view().data().data() + static_cast<std::size_t>(b) * A0.view().stride();
+			const int ld = static_cast<int>(A0.view().ld());
+			for (int c = 0; c < n; ++c) {
+				for (int r = c + 1; r < n; ++r) {
+					Ab[r + c * ld] = Scalar(Real(3.25));
+				}
+			}
+		}
+
+		Matrix<Scalar, MatrixFormat::Dense> A_ours = A0;
+		Matrix<Scalar, MatrixFormat::Dense> A_ref = A0;
+		auto W_ours = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+		auto W_ref = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+
+		{
+			auto ws_ref = UnifiedVector<std::byte>(syev_buffer_size<Backend::NETLIB>(
+				*this->ctx, A_ref.view(), W_ref.to_span(), JobType::NoEigenVectors, Uplo::Upper));
+			syev<Backend::NETLIB>(*this->ctx, A_ref.view(), W_ref.to_span(),
+								  JobType::NoEigenVectors, Uplo::Upper, ws_ref.to_span()).wait();
+		}
+		{
+			StedcParams<Real> params;
+			auto ws = UnifiedVector<std::byte>(syev_two_stage_buffer_size<B, Scalar>(
+				*this->ctx, A_ours.view(), JobType::NoEigenVectors, Uplo::Upper, params));
+			syev_two_stage<B, Scalar>(*this->ctx, A_ours.view(), W_ours.to_span(),
+									  JobType::NoEigenVectors, Uplo::Upper, ws.to_span(), params).wait();
+		}
+
+		const Real tol = std::max(tol_eig_for<Real>(), blocked_cuda_tolerance_floor_eig<Scalar, B>());
+		for (int j = 0; j < batch; ++j) {
+			for (int i = 0; i < n; ++i) {
+				EXPECT_NEAR(W_ours[i + j * n], W_ref[i + j * n], tol)
+					<< "(i,b)= (" << i << "," << j << ")";
+			}
+		}
+	}
+}


### PR DESCRIPTION
`Auto` was routing to cuSOLVER at shapes where our own providers are faster, in **both** jobz modes. Reported by @jonasdelacour: *"at n=64 batch=4096 our blocked provider beats vendor but auto routes to vendor; at n=1024 batch=256 two-stage beats vendor but we choose vendor."* Both reproduce, and the fault is broader than either.

Routing is now a per-n decision taken at saturation. A caller running tiny batches pays launch overhead whatever we pick; tuning for that regime costs the saturated regime real throughput.

## Eigenvectors

| n | batch | blocked | vendor | two_stage | winner | margin | old Auto |
|---|---|---|---|---|---|---|---|
| 64 | 16384 | **1.64** | 2.02 | 2.21 | blocked | 1.23× | vendor ✗ |
| 128 | 4069 | **6.65** | 7.85 | 10.35 | blocked | 1.18× | vendor ✗ |
| 256 | 2034 | **36.92** | 37.14 | 57.56 | blocked | 1.01× | vendor |
| 320 | 1302 | **74.53** | 215.23 | 111.20 | blocked | 1.49× | blocked ✓ |
| 512 | 508 | 384.27 | 504.69 | **380.02** | two_stage | 1.01× | blocked |
| 640 | 651 | 836.30 | 1008.06 | **727.48** | two_stage | 1.15× | blocked ✗ |
| 768 | 452 | 1612.98 | 1414.99 | **1184.11** | two_stage | 1.19× | vendor ✗ |
| 1024 | 254 | 4089.02 | 2706.84 | **2441.93** | two_stage | 1.11× | vendor ✗ |
| 2048 | 64 | 33842.6 | **15019.1** | 24782.3 | vendor | 1.65× | vendor ✓ |

Wrong at **five of nine** sizes.

## Eigenvalues-only

Previously unmeasurable: `syev_benchmark` hardcoded `JobType::EigenVectors`, so there was no vendor arm. This PR adds `jobz` as argument 4 (registered sizes pass `1`, so existing behaviour is unchanged).

| n | batch | blocked | vendor | two_stage | winner | margin |
|---|---|---|---|---|---|---|
| 64 | 16384 | **1.06** | 1.12 | 1.14 | blocked | 1.06× |
| 128 | 4069 | **4.41** | 5.34 | 5.35 | blocked | 1.21× |
| 256 | 2034 | **24.78** | 27.20 | 27.98 | blocked | 1.10× |
| 320 | 2604 | **48.16** | 200.94 | 50.35 | blocked | 1.05× |
| 512 | 1017 | 298.30 | 458.95 | **158.72** | two_stage | 1.88× |
| 640 | 651 | 687.67 | 929.05 | **330.71** | two_stage | 2.08× |
| 768 | 452 | 1362.46 | 1301.59 | **505.29** | two_stage | 2.58× |
| 1024 | 254 | 3537.41 | 2494.44 | **908.32** | two_stage | 2.75× |
| 2048 | 64 | 29547.7 | 13908.8 | **10804.1** | two_stage | 1.29× |

Two-stage's margins are far larger here (up to 2.75× vs at most 1.19× with eigenvectors) and it holds through 2048 — with no eigenvectors to produce it keeps its cheap band reduction and never pays to apply `Q₂`.

## The rules

```
                     eigenvectors            eigenvalues-only
n <= 32              CTA family (unchanged)  CTA family (unchanged)
64 <= n <= 320       BatchLAS_Blocked        BatchLAS_Blocked
512 <= n <= 1024     BatchLAS_TwoStage       BatchLAS_TwoStage
n >= 2048            Vendor                  BatchLAS_TwoStage
```

## Why the old routing was wrong

Both predicates it used were **batch-keyed and built from unsaturated data**:

- `syev_prefer_vendor` — every grid feeding it capped its batch ladder at 1024, which for small n is nowhere near saturation (n=64 needs ~16384). Small batch flatters the vendor, whose fixed launch cost is lowest.
- `syev_prefer_two_stage_values` — required `batch >= 256`. The n=1024 cell ran at batch **254**, fell through to the vendor, and paid **2.75×**. Two callers differing by two matrices got different providers.

Both are removed from the decision path rather than re-tuned, and retained with notes as cautionary examples.

This also supersedes the routing-grid comment and §7 of `SYEV_RETUNE_RESULTS.md` that I added in #52, which concluded "the carve-out survives, no routing change warranted" — read off that same unsaturated ladder. Both are marked superseded here rather than left contradicting the new rule.

## Verification

Auto dispatches to the measured winner in both modes (ratio Auto/expected, idle GPU): eigenvectors 0.999–1.002 at n=64/128/320/640/1024/2048; eigenvalues-only 0.994–1.001 at n=128/256/512/1024/2048. n=1024 values now costs 896 µs/matrix where Auto previously paid 2496.

Tests reproduce the captured baseline exactly: 16 pass, 3 fail (`lanczos`, `steqr`, `stedc`, all pre-existing on `main`).

## Not established

- **n=2048 is measured at batch 64**, below the 128 SMs — memory-limited, not saturated, since blocked/two-stage cannot fit more there. Weakest row in both tables.
- **Float only.** The mechanism is type-independent; the crossovers may not be.
- **`Uplo::Upper`** falls back to the vendor — neither BatchLAS path supports it.

## Unrelated issue found

The SYCL build leaks compiler intermediates into `/tmp` and never cleans them: 112,769 `.s` files / 161.7 GB, ~273 GB with `.bc`/`.o`/`.sym`/`.prop`. It filled the root filesystem to 100% mid-session and failed the build with `unable to open output file … No space left on device`. Worth a `TMPDIR`/cleanup fix; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eC7Ak6v3vUXYTMF8s2a3E