### PR TITLE
Level-3 ops in place of GEMM in src/extensions: one win, two measured refusals

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -19,6 +19,7 @@ set(BENCHMARK_TARGETS
     gemm_128x32x32_family_benchmark
     gemm_128x64x32_family_benchmark
     gemm_transpose_benchmark
+    gemm_vs_level3_benchmark
     symm_benchmark
     hemm_benchmark
     herk_benchmark

--- a/benchmarks/gemm_vs_level3_benchmark.cc
+++ b/benchmarks/gemm_vs_level3_benchmark.cc
@@ -1,0 +1,257 @@
+// Head-to-head: the GEMM spellings that src/extensions actually uses, against
+// the specialised level-3 op that expresses the same thing.
+//
+// Every shape here is lifted from a real call site, not invented:
+//
+//   Gram      C = A^H A, k x k, from ortho.cc's chol/shift-chol/svqb paths.
+//             gemm(A, A, C, transA=inv_trans) vs syrk/herk(A, C, uplo=Lower).
+//             potrf and syev both default to Uplo::Lower, so a one-triangle
+//             syrk is what the consumer reads.
+//
+//   Trailing  A22 -= V W^H + W V^H, from sytrd_blocked.cc's blocked update.
+//             two gemms vs one syr2k. The syr2k writes one triangle, so the
+//             honest comparison charges it the symmetrize the non-legacy path
+//             needs afterwards; both variants are measured.
+//
+//   TW        W2 = T^H W1 with T upper triangular, from ormqr_blocked.cc and
+//             ormbr.cc's WY update. gemm reads T's zero half; trmm does not.
+//
+// Run one family at a time with --name Gram / Trailing / TW.
+
+#include <util/minibench.hh>
+#include <util/bench_structured.hh>
+
+#include <blas/linalg.hh>
+
+#include "bench_utils.hh"
+
+#include <batchlas/backend_config.h>
+
+#include <memory>
+
+using namespace batchlas;
+
+namespace {
+
+// ---------------------------------------------------------------- Gram sizes
+// (m, k, batch). k <= m always; ortho asserts it.
+inline void GramSizes(minibench::Benchmark* b) {
+    // LOBPCG/syevx shape: tall and very skinny (k = a few block vectors).
+    b->Args({256, 32, 2048});
+    b->Args({512, 32, 2048});
+    b->Args({512, 64, 1024});
+    b->Args({1024, 64, 1024});
+    b->Args({1024, 128, 512});
+    b->Args({2048, 128, 256});
+    // Squarer shapes, from ortho_benchmark's own grid.
+    b->Args({256, 256, 512});
+    b->Args({512, 512, 128});
+    b->Args({1024, 1024, 32});
+}
+inline void GramSizesNetlib(minibench::Benchmark* b) { GramSizes(b); }
+
+// ------------------------------------------------------------ Trailing sizes
+// (n2, ib, batch). A22 is n2 x n2; V and W are n2 x ib.
+inline void TrailingSizes(minibench::Benchmark* b) {
+    b->Args({256, 32, 1024});
+    b->Args({256, 64, 1024});
+    b->Args({512, 32, 512});
+    b->Args({512, 64, 512});
+    b->Args({1024, 32, 128});
+    b->Args({1024, 64, 128});
+    b->Args({2048, 64, 32});
+}
+inline void TrailingSizesNetlib(minibench::Benchmark* b) { TrailingSizes(b); }
+
+// ------------------------------------------------------------------ TW sizes
+// (ib, nC, batch). T is ib x ib upper triangular; W1 is ib x nC.
+inline void TWSizes(minibench::Benchmark* b) {
+    b->Args({32, 256, 2048});
+    b->Args({64, 256, 2048});
+    b->Args({64, 512, 1024});
+    b->Args({128, 512, 1024});
+    b->Args({128, 1024, 512});
+    b->Args({256, 1024, 256});
+}
+inline void TWSizesNetlib(minibench::Benchmark* b) { TWSizes(b); }
+
+template <typename T>
+constexpr Transpose conj_trans_for() {
+    return sycl::detail::is_complex<T>::value ? Transpose::ConjTrans : Transpose::Trans;
+}
+
+// Wires a prepared kernel into the state with event timing, the way
+// gemm_steady_benchmark does.
+template <typename F>
+void install(minibench::State& state,
+             std::shared_ptr<Queue> q,
+             bench::ManagedInputs& managed,
+             F kernel_once,
+             double flops,
+             size_t batch) {
+    state.SetPrepare(managed.make_prepare_once());
+    state.SetBeforeEachRun(managed.make_before_each_run());
+    state.SetKernel(std::function<void()>(kernel_once));
+    state.SetTimedKernelMs(bench::make_event_timed_kernel_ms(q, std::move(kernel_once)));
+    state.SetBatchEndWait(q);
+    state.SetMetric("GFLOPS", static_cast<double>(batch) * 1e-9 * flops, minibench::Rate);
+    state.SetMetric("Time (µs) / matrix",
+                    (1.0 / static_cast<double>(batch)) * 1e6,
+                    minibench::Reciprocal);
+}
+
+// ============================================================== Gram: C = A^H A
+
+template <typename T, Backend B, bool UseSpecialised>
+void configure_gram(minibench::State& state) {
+    const size_t m = state.range(0);
+    const size_t k = state.range(1);
+    const size_t batch = state.range(2);
+
+    auto q = std::make_shared<Queue>(Device(B == Backend::NETLIB ? "cpu" : "gpu"), B);
+    auto A = std::make_shared<Matrix<T>>(Matrix<T>::Random(m, k, false, batch));
+    auto C = std::make_shared<Matrix<T>>(Matrix<T>::Random(k, k, false, batch));
+
+    bench::ManagedInputs managed(q);
+    managed.prepare(*A);
+    managed.pristine(C);
+
+    // Both spellings charge the same k*k*m multiply-adds; syrk is allowed to do
+    // half of them, which is exactly what we are here to find out.
+    const double flops = 2.0 * static_cast<double>(k) * static_cast<double>(k) * static_cast<double>(m);
+
+    if constexpr (UseSpecialised) {
+        auto kernel = [q, A, C]() mutable {
+            if constexpr (sycl::detail::is_complex<T>::value) {
+                using Real = typename T::value_type;
+                herk<B, T>(*q, A->view(), C->view(), Real(1), Real(0),
+                           Uplo::Lower, Transpose::ConjTrans);
+            } else {
+                syrk<B, T>(*q, A->view(), C->view(), T(1), T(0),
+                           Uplo::Lower, Transpose::Trans);
+            }
+        };
+        install(state, q, managed, std::move(kernel), flops, batch);
+    } else {
+        auto kernel = [q, A, C]() mutable {
+            gemm<B>(*q, A->view(), A->view(), C->view(),
+                    {.alpha = T(1), .beta = T(0),
+                     .transA = conj_trans_for<T>(), .transB = Transpose::NoTrans});
+        };
+        install(state, q, managed, std::move(kernel), flops, batch);
+    }
+}
+
+template <typename T, Backend B>
+static void BM_Gram_gemm(minibench::State& state) { configure_gram<T, B, false>(state); }
+template <typename T, Backend B>
+static void BM_Gram_syrk(minibench::State& state) { configure_gram<T, B, true>(state); }
+
+// ================================== Trailing: A22 -= V W^H + W V^H  (sytrd)
+
+// 0 = two gemms, 1 = syr2k only, 2 = syr2k + symmetrize.
+template <typename T, Backend B, int Variant>
+void configure_trailing(minibench::State& state) {
+    const size_t n2 = state.range(0);
+    const size_t ib = state.range(1);
+    const size_t batch = state.range(2);
+
+    auto q = std::make_shared<Queue>(Device(B == Backend::NETLIB ? "cpu" : "gpu"), B);
+    auto V = std::make_shared<Matrix<T>>(Matrix<T>::Random(n2, ib, false, batch));
+    auto W = std::make_shared<Matrix<T>>(Matrix<T>::Random(n2, ib, false, batch));
+    auto A22 = std::make_shared<Matrix<T>>(Matrix<T>::Random(n2, n2, false, batch));
+
+    bench::ManagedInputs managed(q);
+    managed.prepare(*V);
+    managed.prepare(*W);
+    managed.pristine(A22);
+
+    // Two rank-ib updates of an n2 x n2 block.
+    const double flops = 2.0 * 2.0 * static_cast<double>(n2) * static_cast<double>(n2)
+                         * static_cast<double>(ib);
+
+    if constexpr (Variant == 0) {
+        auto kernel = [q, V, W, A22]() mutable {
+            gemm<B>(*q, V->view(), W->view(), A22->view(),
+                    {.alpha = T(-1), .beta = T(1), .transB = Transpose::ConjTrans});
+            gemm<B>(*q, W->view(), V->view(), A22->view(),
+                    {.alpha = T(-1), .beta = T(1), .transB = Transpose::ConjTrans});
+        };
+        install(state, q, managed, std::move(kernel), flops, batch);
+    } else {
+        auto kernel = [q, V, W, A22]() mutable {
+            syr2k<B, T>(*q, V->view(), W->view(), A22->view(), T(-1), T(1),
+                        Uplo::Lower, Transpose::NoTrans);
+            if constexpr (Variant == 2) {
+                A22->view().symmetrize(*q, Uplo::Lower);
+            }
+        };
+        install(state, q, managed, std::move(kernel), flops, batch);
+    }
+}
+
+template <typename T, Backend B>
+static void BM_Trailing_gemm2(minibench::State& state) { configure_trailing<T, B, 0>(state); }
+template <typename T, Backend B>
+static void BM_Trailing_syr2k(minibench::State& state) { configure_trailing<T, B, 1>(state); }
+template <typename T, Backend B>
+static void BM_Trailing_syr2k_sym(minibench::State& state) { configure_trailing<T, B, 2>(state); }
+
+// ============================ TW: W2 = T^H W1, T upper triangular (ormqr/ormbr)
+
+template <typename T, Backend B, bool UseTrmm>
+void configure_tw(minibench::State& state) {
+    const size_t ib = state.range(0);
+    const size_t nC = state.range(1);
+    const size_t batch = state.range(2);
+
+    auto q = std::make_shared<Queue>(Device(B == Backend::NETLIB ? "cpu" : "gpu"), B);
+    auto Tm = std::make_shared<Matrix<T>>(Matrix<T>::Random(ib, ib, false, batch));
+    auto W1 = std::make_shared<Matrix<T>>(Matrix<T>::Random(ib, nC, false, batch));
+    auto W2 = std::make_shared<Matrix<T>>(Matrix<T>::Random(ib, nC, false, batch));
+
+    bench::ManagedInputs managed(q);
+    managed.prepare(*Tm);
+    managed.prepare(*W1);
+    managed.pristine(W2);
+
+    const double flops = 2.0 * static_cast<double>(ib) * static_cast<double>(ib)
+                         * static_cast<double>(nC);
+
+    if constexpr (UseTrmm) {
+        // trmm accumulates into C with an implicit beta = 1, so W2 is charged a
+        // zeroing the gemm spelling gets for free from beta = 0. Left side,
+        // upper triangle, non-unit diagonal: larft's T exactly.
+        auto kernel = [q, Tm, W1, W2]() mutable {
+            W2->view().fill(*q, T(0));
+            trmm<B, T>(*q, Tm->view(), W1->view(), W2->view(), T(1),
+                       Side::Left, Uplo::Upper, conj_trans_for<T>(), Diag::NonUnit);
+        };
+        install(state, q, managed, std::move(kernel), flops, batch);
+    } else {
+        auto kernel = [q, Tm, W1, W2]() mutable {
+            gemm<B>(*q, Tm->view(), W1->view(), W2->view(),
+                    {.alpha = T(1), .beta = T(0), .transA = conj_trans_for<T>()});
+        };
+        install(state, q, managed, std::move(kernel), flops, batch);
+    }
+}
+
+template <typename T, Backend B>
+static void BM_TW_gemm(minibench::State& state) { configure_tw<T, B, false>(state); }
+template <typename T, Backend B>
+static void BM_TW_trmm(minibench::State& state) { configure_tw<T, B, true>(state); }
+
+}  // namespace
+
+BATCHLAS_REGISTER_BENCHMARK_ALL_TYPES(BM_Gram_gemm, GramSizes)
+BATCHLAS_REGISTER_BENCHMARK_ALL_TYPES(BM_Gram_syrk, GramSizes)
+
+BATCHLAS_REGISTER_BENCHMARK(BM_Trailing_gemm2, TrailingSizes)
+BATCHLAS_REGISTER_BENCHMARK(BM_Trailing_syr2k, TrailingSizes)
+BATCHLAS_REGISTER_BENCHMARK(BM_Trailing_syr2k_sym, TrailingSizes)
+
+BATCHLAS_REGISTER_BENCHMARK_ALL_TYPES(BM_TW_gemm, TWSizes)
+BATCHLAS_REGISTER_BENCHMARK_ALL_TYPES(BM_TW_trmm, TWSizes)
+
+MINI_BENCHMARK_MAIN();

--- a/experiments/GEMM_TO_LEVEL3_SURVEY.md
+++ b/experiments/GEMM_TO_LEVEL3_SURVEY.md
@@ -1,0 +1,213 @@
+# Can a specialised level-3 op replace a GEMM in `src/extensions`?
+
+Survey of all 73 `gemm` call sites under `src/extensions`, asking where `trmm`,
+`symm`, `hemm`, `syrk`, `syr2k`, `herk` or `her2k` expresses the same thing, and
+then measuring whether it is actually faster **at large batch**.
+
+One substitution survived measurement. It is the one that was already scaffolded
+and switched off.
+
+Hardware: RTX 4090 / sm_89, CUDA 13.2, `RelWithDebInfo`, one GPU, no other
+compute processes resident. Harness: `benchmarks/gemm_vs_level3_benchmark.cc`,
+whose shapes are lifted from the call sites rather than invented.
+
+---
+
+## The one change: `sytrd_blocked` trailing update -> `syr2k`
+
+`src/extensions/sytrd_blocked.cc` updates `A22 -= V W^H + W V^H` with two full
+`n2 x n2` GEMMs. That is one `syr2k`, and `syr2k` touches only the triangle the
+panel loop goes on to read.
+
+The route already existed behind `BATCHLAS_SYTRD_TRAILING_UPDATE=syr2k`,
+gated to CUDA + float, defaulting off. **This survey flips that default on.**
+
+The update in isolation (float, `n2 x ib` operands into `n2 x n2`):
+
+| n2 | ib | batch | 2x GEMM | syr2k | syr2k+symmetrize | speedup |
+|-----|-----|-------|---------|-------|------------------|---------|
+| 256 | 32 | 1024 | 1.476 ms | 0.427 | 0.886 | **1.66x** |
+| 256 | 64 | 1024 | 1.531 | 0.512 | 0.957 | **1.60x** |
+| 512 | 32 | 512 | 2.580 | 0.724 | 1.640 | **1.57x** |
+| 512 | 64 | 512 | 2.682 | 0.814 | 1.761 | **1.52x** |
+| 1024 | 32 | 128 | 2.482 | 0.693 | 1.749 | **1.42x** |
+| 1024 | 64 | 128 | 2.544 | 0.730 | 2.039 | **1.25x** |
+| 2048 | 64 | 32 | 2.504 | 0.692 | 1.682 | **1.49x** |
+
+The `syr2k` itself is 3.4-3.6x faster; the non-legacy `latrd` panel then needs
+the other triangle back, and that symmetrize is a bandwidth-bound `n^2` pass
+that eats over half the win. It still wins everywhere.
+
+End to end through `sytrd_blocked_benchmark`, at the batch sizes its own grid
+pairs with each `n`:
+
+| n | batch | nb | GEMM | syr2k | speedup |
+|---|-------|----|------|-------|---------|
+| 512 | 1024 | 16 | 263.97 ms | 227.51 | 1.16x |
+| 512 | 1024 | 24 | 253.05 | 227.32 | 1.11x |
+| 512 | 1024 | 32 | 248.30 | 231.64 | 1.07x |
+| 256 | 2048 | 16 | 34.347 | 27.040 | 1.27x |
+| 256 | 2048 | 24 | 34.641 | 30.612 | 1.13x |
+| 256 | 2048 | 32 | 36.995 | 34.028 | 1.09x |
+
+Best-configuration to best-configuration: 248.30 -> 227.32 ms at n=512, and
+34.35 -> 27.04 ms at n=256. Run-to-run stddev was 0.02-0.4 ms except one 2.3 ms
+outlier, so these are well clear of noise.
+
+### Test coverage this needed first
+
+The trailing update only runs when the trailing block is wider than 128;
+narrower and `sytrd_blocked` takes `update_vw_lower_small`. Every pre-existing
+case in `tests/sytrd_blocked_tests.cc` is `n <= 128`, so **the syr2k route had no
+test coverage at all** -- flipping the default on the strength of the benchmarks
+alone would have been flipping an unexercised branch.
+
+`SytrdBlockedTest.TrailingUpdateRoutesAgree` (n=320, nb=32, so `n2 = 288` on the
+first panel and above 128 for six of them) runs both routes and checks each
+against the netlib reference spectrum.
+
+It was checked for teeth rather than assumed to have them:
+
+- forcing `alpha = -0.5` in the syr2k call fails it loudly -- worst eigenvalue
+  error 2.777 against a 3.2e-3 bound, with the GEMM route reported at 2.6e-6.
+- the backward-error bound alone (`4 n eps ||A||` = 3.2e-3) is ~1000x looser
+  than the error either route actually incurs, so it would pass almost anything.
+  The assertion that does the work is the relative one: syr2k must land within
+  `4 * (GEMM route error) + 8 eps ||A||`.
+
+One loose end worth recording: **disabling the symmetrize did not fail the
+test.** That is either a genuinely unnecessary pass -- which would be worth a
+lot, since it is over half the cost of the syr2k route (3.4x becomes 1.25-1.66x
+once it is paid) -- or a gap in what this test reaches. It was left in place;
+establishing which it is means finding out whether the non-legacy
+`latrd_lower_panel` ever reads the upper triangle, and is a separate change from
+this one.
+
+### Why it stays CUDA + float only
+
+`syrk`/`syr2k` reach a batched kernel **only** through the custom float route
+added in PR 60. Every other type and backend falls through to
+`syr2k_vendor_impl` / `syrk_vendor_impl` in `src/backends/cublas.cc`, which is a
+host loop issuing one `cublasXsyr2k` per batch member -- there is no batched
+cuBLAS syrk. At large batch that inverts the result completely. Same shapes, in
+double:
+
+| n2 | ib | batch | 2x GEMM | syr2k | |
+|-----|-----|-------|---------|-------|---|
+| 256 | 32 | 1024 | 7.56 ms | 58.52 | **7.7x slower** |
+| 256 | 64 | 1024 | 14.34 | 106.79 | **7.4x slower** |
+| 512 | 64 | 512 | 28.57 | 53.61 | **1.9x slower** |
+| 2048 | 64 | 32 | 28.54 | 18.45 | 1.55x faster |
+
+Double only wins where the batch is small enough that the per-item launch cost
+amortises against a large per-item problem -- the opposite of the regime this
+survey cares about.
+
+---
+
+## Measured and rejected: `syrk`/`herk` for `ortho`'s Gram matrix
+
+`src/extensions/ortho.cc` builds `C = A^H A` three times (lines 129, 198, 232 --
+the Cholesky, shifted-Cholesky and SVQB paths) with
+`gemm(A, A, C, transA=inv_trans, transB=transA)`. This is textbook `syrk`/`herk`,
+and it is safe on the consumer side: `potrf`, `trsm` and `syev` all default to
+`Uplo::Lower`, so a one-triangle result is exactly what they read.
+
+It is still the wrong call, because of the shape `ortho` is given. `A` is
+`m x k`, `C` is `k x k`, and the win depends entirely on `k`:
+
+| m | k | batch | GEMM | syrk | |
+|---|---|-------|------|------|---|
+| 256 | 32 | 2048 | 0.350 ms | 33.73 | **96x slower** |
+| 512 | 32 | 2048 | 0.759 | 61.33 | **81x slower** |
+| 512 | 64 | 1024 | 0.411 | 32.07 | **78x slower** |
+| 1024 | 64 | 1024 | 0.742 | 60.67 | **82x slower** |
+| 1024 | 128 | 512 | 0.425 | 30.93 | **73x slower** |
+| 2048 | 128 | 256 | 0.400 | 29.76 | **74x slower** |
+| 256 | 256 | 512 | 0.443 | 0.462 | 0.96x |
+| 512 | 512 | 128 | 0.813 | 0.589 | 1.38x |
+| 512 | 512 | 512 | 2.888 | 2.508 | 1.15x |
+| 1024 | 1024 | 32 | 1.512 | 0.999 | 1.51x |
+| 1024 | 1024 | 128 | 5.671 | 3.393 | **1.67x** |
+
+The cliff is the same host loop as above. `syrk_use_cuda_custom` takes the
+batched route only if `syrk_prefer_triangular_tiles` (needs `n >= ~384` so the
+tile grid is at least three 128-wide tiles a side) or
+`syrk_prefer_cuda_custom_heuristic` (needs `min_dim * 2 >= max_dim`, i.e. an
+aspect ratio no worse than 2:1) says yes. A Gram matrix with `k = 32` and a
+reduction depth of `m = 256` fails both, and drops to one `cublasSsyrk` launch
+per batch member.
+
+The winning column is `k >= 512` and square-ish. `ortho`'s callers do not live
+there: `syevx_lobpcg`, `syevx_filtered` and `lanczos` all pass `k` = the block
+size, which is tens of vectors, not hundreds. The only caller that orthogonalises
+a wide square block is `src/extra/random_cond.cc`, a test-matrix generator.
+
+So at the batch sizes that matter, substituting `syrk` here is a 70-100x
+regression on the shapes that actually occur. Left as `gemm`.
+
+(`svqb_alg` has a second, independent problem: it scales the full `k x k` before
+handing it to `syev`, so a one-triangle `syrk` would leave it multiplying
+uninitialised workspace. Moot given the above, but it would need a mirror pass.)
+
+---
+
+## Measured and rejected: `trmm` for the WY block factor
+
+`ormqr_blocked.cc:442,458` and `ormbr.cc:549,559` compute `W2 = T^H W1` where `T`
+is the `ib x ib` upper-triangular factor from `larft`. The GEMM multiplies
+through `T`'s zero half.
+
+`trmm` loses at every shape (float, `T` is `ib x ib`, `W1` is `ib x nC`):
+
+| ib | nC | batch | GEMM | trmm |
+|----|-----|-------|------|------|
+| 32 | 256 | 2048 | 0.195 ms | 0.238 |
+| 64 | 256 | 2048 | 0.374 | 0.560 |
+| 64 | 512 | 1024 | 0.348 | 0.498 |
+| 128 | 512 | 1024 | 0.704 | 1.076 |
+| 128 | 1024 | 512 | 0.670 | 0.989 |
+| 256 | 1024 | 256 | 0.779 | 1.152 |
+
+This one is structural rather than a tuning accident. `src/extensions/trmm.cc`
+recurses only until `n <= recursion_stop_size = 256`, and then calls the very
+GEMM it was meant to replace. `ormqr`'s `nb` is one of {16, 32, 64, 128, 256}, so
+the triangular structure is *never* exploited at these sizes -- `trmm` is the
+same GEMM plus dispatch, plus a zeroing pass for the `beta = 1` accumulate.
+Left as `gemm`.
+
+---
+
+## Rejected on inspection, no measurement needed
+
+- **`syevx_lobpcg.cc:647,1225`, `syevx_filtered.cc:418`** -- `X^H A X`. The
+  result is symmetric but it is a product of two *different* matrices; no BLAS
+  op expresses it. `syr2k` is not this.
+- **`syevx_lobpcg.cc:624,638,1212`, `syevx_filtered.cc:241`, `lanczos.cc:112`,
+  `ritz_values.cc:59`** -- `A X` with symmetric `A`, nominally `symm`/`hemm`.
+  But `symm` in this tree *expands the triangle into scratch and then GEMMs*
+  (`src/extensions/symm.cc`, and the same shape in `symm_custom_dispatch`). `A`
+  is already stored full at these call sites, so `symm` would add a copy and a
+  symmetrize to reach the identical GEMM. Worse by construction, not by tuning.
+- **`gebrd_blocked.cc:364,365`** -- `a22 -= v2 y2^H; a22 -= x2 u2`. Looks like
+  `syr2k`, is not: this is bidiagonal reduction of a *general* matrix, and `a22`
+  is not symmetric.
+- **`stedc.cc:465,487,500`, `steqr_legacy.cc:412,463,512`, `ortho.cc:293,399,400`,
+  `ormqr_blocked.cc:439,444,455,460`, `ormbr.cc:548,550,558,560`** -- general
+  products of distinct matrices with no symmetry or triangularity to exploit.
+
+---
+
+## The recurring shape of the negative results
+
+Two of the three rejections have the same root cause, and it is worth stating
+plainly: **in this tree a specialised level-3 op is only faster than the GEMM it
+replaces when it reaches a batched custom kernel.** `syrk`, `syr2k`, `herk` and
+`her2k` have exactly one such path each -- CUDA, float, and only inside the shape
+window the PR 60 routers were tuned for. Outside that window they degrade to a
+host loop over the vendor call, which at batch 1024+ is one to two orders of
+magnitude off a batched GEMM.
+
+So the flop count is the wrong thing to reason from. "This does half the
+arithmetic" predicts nothing here; what predicts the result is whether the router
+takes the batched branch. Any future substitution should check that first.

--- a/experiments/GEMM_TO_LEVEL3_SURVEY.md
+++ b/experiments/GEMM_TO_LEVEL3_SURVEY.md
@@ -34,9 +34,11 @@ The update in isolation (float, `n2 x ib` operands into `n2 x n2`):
 | 1024 | 64 | 128 | 2.544 | 0.730 | 2.039 | **1.25x** |
 | 2048 | 64 | 32 | 2.504 | 0.692 | 1.682 | **1.49x** |
 
-The `syr2k` itself is 3.4-3.6x faster; the non-legacy `latrd` panel then needs
-the other triangle back, and that symmetrize is a bandwidth-bound `n^2` pass
-that eats over half the win. It still wins everywhere.
+The `syr2k` itself is 3.4-3.6x faster. The middle column is what it cost to hand
+the other triangle back afterwards -- a bandwidth-bound `n^2` pass that ate over
+half the win. **That symmetrize turned out to be unnecessary and is now gone**;
+see "Does anything read the upper triangle?" below. The 3.4-3.6x column is the
+one that applies.
 
 End to end through `sytrd_blocked_benchmark`, at the batch sizes its own grid
 pairs with each `n`:
@@ -75,13 +77,46 @@ It was checked for teeth rather than assumed to have them:
   The assertion that does the work is the relative one: syr2k must land within
   `4 * (GEMM route error) + 8 eps ||A||`.
 
-One loose end worth recording: **disabling the symmetrize did not fail the
-test.** That is either a genuinely unnecessary pass -- which would be worth a
-lot, since it is over half the cost of the syr2k route (3.4x becomes 1.25-1.66x
-once it is paid) -- or a gap in what this test reaches. It was left in place;
-establishing which it is means finding out whether the non-legacy
-`latrd_lower_panel` ever reads the upper triangle, and is a separate change from
-this one.
+## Does anything read the upper triangle?
+
+Disabling the symmetrize did not fail the test, which had two possible readings:
+the pass is unnecessary, or the test does not reach whatever needs it. Reading
+every consumer settles it -- **nothing in the `sytrd_blocked` pipeline reads A's
+upper triangle**, so the symmetrize is now removed.
+
+The symmetric matvec is the only place tempted to cross the diagonal, and all
+three `latrd_lower_panel` variants split it at `c == r`, taking `Ab(r,c)` for
+`c <= r` and `conj(Ab(c,r))` for `c > r`:
+
+| reader | how it stays below the diagonal |
+|---|---|
+| `latrd_lower_panel`, legacy | explicit split at `c == r`, documented in place |
+| `latrd_lower_panel`, grid | same split, same code shape |
+| `latrd_lower_panel`, device | `device::hemv<Uplo::Lower>`, which mirrors rather than reads across -- for `row < col` it loads `a(col,row)` and applies `symmetric_mirror`, in both the tiled and the generic path |
+| fused trailing update, legacy + grid | `if (r < c) continue` |
+| fused trailing update, device | `device::her2k<Uplo::Lower>` |
+| `restore_tridiag_lower` | reads the diagonal; the superdiagonal it touches is a *write* |
+
+The GEMM pair happened to leave a valid upper triangle behind as a side effect.
+Nothing depended on it, so that was never a contract -- which is exactly the kind
+of thing that is invisible until an op that respects the triangle replaces one
+that does not.
+
+Verified rather than argued: with the symmetrize removed, the suite passes on the
+legacy impl, on `BATCHLAS_SYTRD_IMPL=device`, and on the device impl with the
+grid variant forced (`BATCHLAS_LATRD_GRID_GROUPS=4`).
+
+The device impl was the only path that had been paying it, and it recovers the
+full win -- at n=512 batch=1024 it goes 243.8/239.5/239.8 ms -> 226.5/228.0/231.1
+at nb=16/24/32, landing on the legacy path's numbers to within noise (1.16x over
+the GEMM baseline, up from 1.08x).
+
+(One thing to know before forcing grid parameters while bisecting:
+`SytrdBlockedLatrdGridCudaTest.LargeNBatchOneMatchesNetlibReference` and
+`.GridMatchesLegacyTridiagonal` fail under an externally forced
+`BATCHLAS_LATRD_GRID_GROUPS`, at 4 and at 8, and they do so with the GEMM route
+and no syr2k anywhere. They pick their own grid parameters and an outer override
+collides with them. Unrelated to any of this, but it looks alarming.)
 
 ### Why it stays CUDA + float only
 

--- a/src/extensions/sytrd_blocked.cc
+++ b/src/extensions/sytrd_blocked.cc
@@ -44,17 +44,24 @@ inline bool use_device_sytrd() {
 enum class SytrdTrailingUpdateMode {
     Gemm,
     Syr2k,
+    Default,
 };
 
+// Override for the trailing update; unset means the per-backend default below.
+// Kept in both directions so a regression can be bisected against either route
+// without a rebuild.
 inline SytrdTrailingUpdateMode sytrd_trailing_update_mode() {
     const char* v = std::getenv("BATCHLAS_SYTRD_TRAILING_UPDATE");
-    if (!v) return SytrdTrailingUpdateMode::Gemm;
+    if (!v) return SytrdTrailingUpdateMode::Default;
 
     const std::string s(v);
     if (s == "syr2k" || s == "SYR2K") {
         return SytrdTrailingUpdateMode::Syr2k;
     }
-    return SytrdTrailingUpdateMode::Gemm;
+    if (s == "gemm" || s == "GEMM") {
+        return SytrdTrailingUpdateMode::Gemm;
+    }
+    return SytrdTrailingUpdateMode::Default;
 }
 
 // Used by the device sytrd_blocked_impl to allow per-run WG hint overrides.
@@ -759,9 +766,26 @@ Event sytrd_blocked_impl(Queue& ctx,
         ? ((B == Backend::CUDA) && (n == 256))
         : tuning::sytrd_fuse_panel_update_for_n(n);
     const bool enable_fused_panel_update = fuse_override_on || (!fuse_override_off && fuse_default);
-    constexpr bool allow_syr2k_experiment = (B == Backend::CUDA) && std::is_same_v<T, float>;
-    const bool use_syr2k_trailing_update = allow_syr2k_experiment &&
-                                           (sytrd_trailing_update_mode() == SytrdTrailingUpdateMode::Syr2k);
+    // A22 -= V W^H + W V^H is one syr2k, and syr2k touches only the triangle
+    // the panel loop goes on to read. Measured on RTX 4090 / sm_89, float,
+    // against the two full n2 x n2 GEMMs it replaces:
+    //
+    //   the update alone, over the shapes the panel loop produces, is 3.4-3.6x
+    //   faster, and still 1.25-1.66x after paying the symmetrize the non-legacy
+    //   latrd panel needs;
+    //   end to end, n=512 batch=1024 went 264/253/248 ms -> 228/227/232 at
+    //   nb=16/24/32, and n=256 batch=2048 went 34.3/34.6/37.0 -> 27.0/30.6/34.0.
+    //
+    // CUDA and float only, and that is not conservatism: syrk/syr2k reach a
+    // batched kernel only through the custom float route. Everything else falls
+    // to syr2k_vendor_impl, which is a host loop issuing one cublasXsyr2k per
+    // batch member -- in double that measured 7.8x *slower* than the GEMM pair
+    // at n=256 batch=1024, i.e. the whole win inverts.
+    constexpr bool syr2k_trailing_update_supported =
+        (B == Backend::CUDA) && std::is_same_v<T, float>;
+    const bool use_syr2k_trailing_update =
+        syr2k_trailing_update_supported &&
+        (sytrd_trailing_update_mode() != SytrdTrailingUpdateMode::Gemm);
     const int32_t latrd_wg_hint = is_legacy
         ? tuning::latrd_lower_panel_wg_hint()
         : latrd_lower_panel_wg_hint_override(n, batch);
@@ -797,7 +821,7 @@ Event sytrd_blocked_impl(Queue& ctx,
                 else
                     (void)update_vw_lower_small_device<T>(ctx, V2, W2, A22);
             } else {
-                if constexpr (allow_syr2k_experiment) {
+                if constexpr (syr2k_trailing_update_supported) {
                     if (use_syr2k_trailing_update) {
                         {
                             BATCHLAS_KERNEL_TRACE_SCOPE("sytrd_blocked.update_vw_syr2k");

--- a/src/extensions/sytrd_blocked.cc
+++ b/src/extensions/sytrd_blocked.cc
@@ -771,8 +771,7 @@ Event sytrd_blocked_impl(Queue& ctx,
     // against the two full n2 x n2 GEMMs it replaces:
     //
     //   the update alone, over the shapes the panel loop produces, is 3.4-3.6x
-    //   faster, and still 1.25-1.66x after paying the symmetrize the non-legacy
-    //   latrd panel needs;
+    //   faster;
     //   end to end, n=512 batch=1024 went 264/253/248 ms -> 228/227/232 at
     //   nb=16/24/32, and n=256 batch=2048 went 34.3/34.6/37.0 -> 27.0/30.6/34.0.
     //
@@ -827,10 +826,23 @@ Event sytrd_blocked_impl(Queue& ctx,
                             BATCHLAS_KERNEL_TRACE_SCOPE("sytrd_blocked.update_vw_syr2k");
                             syr2k<B>(ctx, V2, W2, A22, {.alpha = T(-1), .beta = T(1)});
                         }
-                        if (!is_legacy) {
-                            BATCHLAS_KERNEL_TRACE_SCOPE("sytrd_blocked.update_vw_syr2k_symmetrize");
-                            A22.symmetrize(ctx, Uplo::Lower);
-                        }
+                        // No symmetrize: nothing downstream reads A's upper
+                        // triangle, so leaving it stale is not observable.
+                        // Checked across every reader, not assumed --
+                        //   latrd_lower_panel, all three variants: the symmetric
+                        //     matvec is the only place tempted to cross the
+                        //     diagonal, and all three split it at c == r, taking
+                        //     Ab(r,c) for c <= r and conj(Ab(c,r)) for c > r. The
+                        //     device variant reaches it through
+                        //     device::hemv<Uplo::Lower>, which mirrors the same
+                        //     way. The fused trailing update guards with
+                        //     `if (r < c) continue` (legacy, grid) or
+                        //     device::her2k<Uplo::Lower>.
+                        //   restore_tridiag_lower: reads the diagonal, and only
+                        //     writes the superdiagonal.
+                        // The GEMM pair happened to leave a valid upper triangle
+                        // as a side effect; that was never a contract anything
+                        // depended on.
                     } else {
                         {
                             BATCHLAS_KERNEL_TRACE_SCOPE("sytrd_blocked.update_vw_gemm_vw");

--- a/tests/sytrd_blocked_tests.cc
+++ b/tests/sytrd_blocked_tests.cc
@@ -156,6 +156,95 @@ TYPED_TEST(SytrdBlockedTest, RandomSymmetricLower) {
 #endif
 }
 
+// The blocked trailing update (A22 -= V W^H + W V^H) only runs when the trailing
+// block is wider than 128; below that sytrd_blocked takes update_vw_lower_small
+// instead. Every other case in this file is n <= 128, so none of them reach it --
+// which matters now that the trailing update defaults to syr2k rather than the
+// GEMM pair on CUDA/float.
+//
+// n = 320 with nb = 32 leaves n2 = 288 on the first panel and stays above 128 for
+// six of them. Both routes are run against each other as well as against the
+// reference, so a divergence points at the route rather than at sytrd generally.
+TYPED_TEST(SytrdBlockedTest, TrailingUpdateRoutesAgree) {
+    using Real = typename TestFixture::ScalarType;
+    constexpr Backend B = TestFixture::BackendType;
+
+    const int n = 320;
+    const int batch = 8;
+    const int nb = 32;
+    const double eig_tol = (std::is_same_v<Real, float> ? 10000.0 : 100.0) * test_utils::tolerance<double>();
+
+    Matrix<Real, MatrixFormat::Dense> A0 =
+        Matrix<Real, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/20260806);
+
+    // Returns the tridiagonal (d, e) produced under the given trailing-update route.
+    auto run_route = [&](const char* route) {
+        ScopedEnvVar mode("BATCHLAS_SYTRD_TRAILING_UPDATE", route);
+
+        Matrix<Real, MatrixFormat::Dense> A = A0;
+        Vector<Real> d(n, batch);
+        Vector<Real> e(n - 1, batch);
+        Vector<Real> tau(n - 1, batch);
+
+        const size_t ws_bytes =
+            sytrd_blocked_buffer_size<B, Real>(*this->ctx, A.view(), d, e, tau, Uplo::Lower, nb);
+        UnifiedVector<std::byte> ws(ws_bytes, std::byte{0});
+
+        sytrd_blocked<B, Real>(*this->ctx, A.view(), d, e, tau, Uplo::Lower, ws.to_span(), nb).wait();
+
+        Matrix<Real, MatrixFormat::Dense> Tmat = Matrix<Real, MatrixFormat::Dense>::Zeros(n, n, batch);
+        Tmat.view().fill_tridiag(*this->ctx, e, d, e).wait();
+        return Tmat;
+    };
+
+    Matrix<Real, MatrixFormat::Dense> T_gemm = run_route("gemm");
+    Matrix<Real, MatrixFormat::Dense> T_syr2k = run_route("syr2k");
+
+#if BATCHLAS_HAS_HOST_BACKEND
+    const auto eig_ref = netlib_ref_eigs_dense(A0.view());
+    const auto eig_gemm = netlib_ref_eigs_dense(T_gemm.view());
+    const auto eig_syr2k = netlib_ref_eigs_dense(T_syr2k.view());
+
+    // Both routes perform the same rank-2 update, but sum it in a different
+    // order, so they agree only to rounding. Judge them by how far each lands
+    // from the reference spectrum rather than from each other: the question is
+    // whether syr2k is as accurate as the GEMM pair, not whether it is
+    // bit-identical to it.
+    double worst_gemm = 0.0;
+    double worst_syr2k = 0.0;
+    double spectral_radius = 0.0;
+    for (int b = 0; b < batch; ++b) {
+        const std::size_t base = static_cast<std::size_t>(b) * static_cast<std::size_t>(n);
+        for (int i = 0; i < n; ++i) {
+            const std::size_t ix = base + static_cast<std::size_t>(i);
+            spectral_radius = std::max(spectral_radius, std::abs(eig_ref[ix]));
+            worst_gemm = std::max(worst_gemm, std::abs(eig_gemm[ix] - eig_ref[ix]));
+            worst_syr2k = std::max(worst_syr2k, std::abs(eig_syr2k[ix] - eig_ref[ix]));
+        }
+    }
+
+    // Backward error of a Householder tridiagonalisation is O(n * eps * ||A||).
+    const double eps = static_cast<double>(std::numeric_limits<Real>::epsilon());
+    const double backward_err_tol = 4.0 * static_cast<double>(n) * eps * spectral_radius;
+    const double err_tol = std::max(eig_tol * std::max(1.0, spectral_radius), backward_err_tol);
+
+    EXPECT_LT(worst_syr2k, err_tol)
+        << "syr2k trailing update lost accuracy: worst eigenvalue error " << worst_syr2k
+        << " (GEMM route: " << worst_gemm << ", spectral radius " << spectral_radius << ")";
+
+    // The substitution is only justified if it is no worse than what it
+    // replaced. This is the assertion with the teeth: the backward-error bound
+    // above is ~1000x looser than the error either route actually incurs
+    // (measured 2.6e-6 against a 3.2e-3 bound at n=320, float), so on its own it
+    // would pass almost anything. A factor of 4 plus a few ulps of the spectrum
+    // leaves room for the different summation order and nothing else.
+    const double route_tol = 4.0 * worst_gemm + 8.0 * eps * spectral_radius;
+    EXPECT_LT(worst_syr2k, route_tol)
+        << "syr2k route is materially less accurate than the GEMM pair: "
+        << worst_syr2k << " vs " << worst_gemm;
+#endif
+}
+
 TYPED_TEST(SytrdBlockedTest, RandomSymmetricLower33) {
     using Real = typename TestFixture::ScalarType;
     constexpr Backend B = TestFixture::BackendType;


### PR DESCRIPTION
## What was asked, and what survived

Go through `src/extensions`, find where `trmm`, `symm`, `hemm`, `syrk`, `syr2k`, `herk` or `her2k` can replace a GEMM, and replace it **only where that is faster at large batch**.

All 73 GEMM call sites were surveyed. Three were plausible enough to measure. **One survived.** The two rejections are the more useful result, so they are documented rather than silently dropped.

Hardware: RTX 4090 / sm_89, CUDA 13.2, RelWithDebInfo, one GPU, no other compute processes resident. Harness is `benchmarks/gemm_vs_level3_benchmark.cc`, whose shapes are lifted from the call sites rather than invented; it reproduces PR #60's own documented syrk crossover numbers, which is the check that it measures what it claims to.

## The change: `sytrd_blocked`'s trailing update becomes a `syr2k`

`A22 -= V W^H + W V^H` was two full `n2 x n2` GEMMs. That is one `syr2k`, and `syr2k` touches only the triangle the panel loop goes on to read.

The route already existed behind `BATCHLAS_SYTRD_TRAILING_UPDATE=syr2k`, gated to CUDA/float, defaulting **off**. It should not have been off.

The update in isolation, over the shapes the panel loop produces:

| n2 | ib | batch | 2x GEMM | syr2k | speedup |
|-----|-----|-------|---------|-------|---------|
| 256 | 32 | 1024 | 1.476 ms | 0.427 | 3.5x |
| 512 | 64 | 512 | 2.682 | 0.814 | 3.3x |
| 1024 | 64 | 128 | 2.544 | 0.730 | 3.5x |
| 2048 | 64 | 32 | 2.504 | 0.692 | 3.6x |

End to end through `sytrd_blocked_benchmark`, at the batch sizes its own grid pairs with each `n`:

| n | batch | nb | GEMM | syr2k | |
|---|-------|----|------|-------|---|
| 512 | 1024 | 16 | 263.97 ms | 227.51 | 1.16x |
| 512 | 1024 | 24 | 253.05 | 227.32 | 1.11x |
| 512 | 1024 | 32 | 248.30 | 231.64 | 1.07x |
| 256 | 2048 | 16 | 34.347 | 27.040 | 1.27x |
| 256 | 2048 | 24 | 34.641 | 30.612 | 1.13x |
| 256 | 2048 | 32 | 36.995 | 34.028 | 1.09x |

Best-config to best-config: 248.30 -> 227.32 ms at n=512, 34.35 -> 27.04 at n=256. Stddev was 0.02-0.4 ms except one 2.3 ms outlier.

### It stays CUDA + float, and that is not conservatism

`syrk`/`syr2k` reach a batched kernel **only** through the custom float route added in PR #60. Everything else falls to `syr2k_vendor_impl` in `src/backends/cublas.cc`, which is a host loop issuing one `cublasXsyr2k` per batch member — there is no batched cuBLAS syrk. At large batch that inverts the result completely:

| n2 | ib | batch | 2x GEMM | syr2k (double) | |
|-----|-----|-------|---------|-------|---|
| 256 | 32 | 1024 | 7.56 ms | 58.52 | **7.7x slower** |
| 512 | 64 | 512 | 28.57 | 53.61 | **1.9x slower** |
| 2048 | 64 | 32 | 28.54 | 18.45 | 1.55x faster |

Double only wins where the batch is small enough that per-item launch cost amortises against a large per-item problem — the opposite of the regime this targets.

### The branch had no test coverage

The trailing update only runs when the trailing block is wider than 128; narrower and `sytrd_blocked` takes `update_vw_lower_small`. Every pre-existing case in `tests/sytrd_blocked_tests.cc` is `n <= 128`, so **the syr2k branch was never executed by any test**. Flipping the default on benchmark evidence alone would have been flipping an unexercised branch.

`SytrdBlockedTest.TrailingUpdateRoutesAgree` (n=320, nb=32) runs both routes against the netlib reference. It was checked for teeth rather than assumed to have them:

- forcing `alpha = -0.5` fails it loudly — worst eigenvalue error 2.777 against a 3.2e-3 bound, with the GEMM route reported at 2.6e-6.
- the backward-error bound alone (`4 n eps ||A||`) is ~1000x looser than the error either route actually incurs, so on its own it would pass almost anything. The assertion doing the work is the relative one: syr2k must land within `4 x (GEMM route error) + 8 eps ||A||`.

### Second commit: the symmetrize was unnecessary

Handing the other triangle back after a one-triangle `syr2k` cost a bandwidth-bound `n^2` pass — over half the win. **Nothing in the pipeline reads A's upper triangle**, checked across every reader:

| reader | how it stays below the diagonal |
|---|---|
| `latrd_lower_panel`, legacy | explicit split at `c == r`, documented in place |
| `latrd_lower_panel`, grid | same split, same code shape |
| `latrd_lower_panel`, device | `device::hemv<Uplo::Lower>` — for `row < col` it loads `a(col,row)` and mirrors, in both tiled and generic paths |
| fused trailing update, legacy + grid | `if (r < c) continue` |
| fused trailing update, device | `device::her2k<Uplo::Lower>` |
| `restore_tridiag_lower` | reads the diagonal; the superdiagonal it touches is a *write* |

The GEMM pair left a valid upper triangle behind as a side effect. Nothing depended on it, so it was never a contract — the kind of thing that stays invisible until an op respecting the triangle replaces one that does not.

Only the device impl had been paying it (`!is_legacy`, and `use_device_sytrd` defaults false), and it recovers the full win: n=512 batch=1024 goes 243.8/239.5/239.8 -> 226.5/228.0/231.1 ms at nb=16/24/32, landing on the legacy path's numbers to within noise — 1.16x over GEMM where it was 1.08x.

Correction carried in that commit: the first commit's end-to-end numbers were measured on the legacy default, which never paid the symmetrize. The original wording implied they included it.

## Measured and rejected: `syrk`/`herk` for `ortho`'s Gram matrix

`ortho.cc` builds `C = A^H A` three times (lines 129, 198, 232). Textbook `syrk`, and safe on the consumer side — `potrf`, `trsm` and `syev` all default to `Uplo::Lower`.

Still wrong, because of the shape `ortho` is given. `A` is `m x k`, `C` is `k x k`, and it turns entirely on `k`:

| m | k | batch | GEMM | syrk | |
|---|---|-------|------|------|---|
| 256 | 32 | 2048 | 0.350 ms | 33.73 | **96x slower** |
| 1024 | 64 | 1024 | 0.742 | 60.67 | **82x slower** |
| 2048 | 128 | 256 | 0.400 | 29.76 | **74x slower** |
| 512 | 512 | 128 | 0.813 | 0.589 | 1.38x |
| 1024 | 1024 | 128 | 5.671 | 3.393 | 1.67x |

Same cliff. `syrk_use_cuda_custom` takes the batched route only if `syrk_prefer_triangular_tiles` (`n >= ~384`, three 128-wide tiles a side) or `syrk_prefer_cuda_custom_heuristic` (`min_dim * 2 >= max_dim`) says yes. A Gram matrix with `k = 32` and reduction depth `m = 256` fails both and drops to one `cublasSsyrk` launch per batch member.

The winning column is `k >= 512` and square-ish. `ortho`'s callers do not live there — `syevx_lobpcg`, `syevx_filtered` and `lanczos` all pass `k` = the block size, tens of vectors. The only caller that orthogonalises a wide square block is `src/extra/random_cond.cc`, a test-matrix generator. **Left as GEMM.**

(`svqb_alg` has a second independent problem: it scales the full `k x k` before handing it to `syev`, so a one-triangle `syrk` would leave it multiplying uninitialised workspace. Moot given the above.)

## Measured and rejected: `trmm` for the WY block factor

`ormqr_blocked.cc:442,458` and `ormbr.cc:549,559` compute `W2 = T^H W1` with `T` upper triangular from `larft`. The GEMM multiplies through `T`'s zero half.

`trmm` loses at every shape (0.195 -> 0.238 ms at ib=32/nC=256/batch=2048; 0.779 -> 1.152 at ib=256/nC=1024/batch=256). Structural, not a tuning accident: `src/extensions/trmm.cc` recurses only until `n <= recursion_stop_size = 256`, then calls the very GEMM it would replace. `ormqr`'s `nb` is one of {16,32,64,128,256}, so the triangular structure is **never** exploited at these sizes — `trmm` is the same GEMM plus dispatch, plus a zeroing pass for the `beta = 1` accumulate. **Left as GEMM.**

## Rejected on inspection

- `syevx_lobpcg.cc:647,1225`, `syevx_filtered.cc:418` — `X^H A X`. Symmetric *result*, but a product of two different matrices; no BLAS op expresses it.
- `syevx_lobpcg.cc:624,638,1212`, `syevx_filtered.cc:241`, `lanczos.cc:112`, `ritz_values.cc:59` — `A X` with symmetric `A`, nominally `symm`/`hemm`. But `symm` here *expands the triangle into scratch and then GEMMs*, and `A` is already stored full at these sites, so it would add a copy and a symmetrize to reach the identical GEMM. Worse by construction.
- `gebrd_blocked.cc:364,365` — looks like `syr2k`, is not: bidiagonal reduction of a *general* matrix, `a22` is not symmetric.
- `stedc.cc`, `steqr_legacy.cc`, `ortho.cc:293,399,400`, and the remaining `ormqr`/`ormbr` sites — general products with no symmetry or triangularity to exploit.

## The recurring lesson

Flop count predicted nothing here. "This does half the arithmetic" was true of all three candidates and right about one. What predicts the result is **whether the router reaches a batched custom kernel** — in this tree that means CUDA, float, and inside the window PR #60's routers were tuned for. Outside it, the vendor host loop is one to two orders of magnitude off a batched GEMM. Any future substitution should check that first.

## Testing

Green on the legacy impl (default), on `BATCHLAS_SYTRD_IMPL=device`, and on the device impl with the grid variant forced:

- `sytrd_blocked_tests` 14/14 (12 pre-existing + 2 new)
- `syev_blocked_tests` 24/24
- `syev_tests` 4/4

One thing to know before forcing grid parameters while bisecting: `SytrdBlockedLatrdGridCudaTest.LargeNBatchOneMatchesNetlibReference` and `.GridMatchesLegacyTridiagonal` fail under an externally forced `BATCHLAS_LATRD_GRID_GROUPS`, at 4 and at 8 — and they do so with the GEMM route and no syr2k anywhere. They pick their own grid parameters and an outer override collides. Pre-existing and unrelated, but it looks alarming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QywXek1tSRhCF6LAQeVEAC
