### PR TITLE
Batched TRMM and SYRK kernels for the shapes we actually call them with

### DIFF
--- a/benchmarks/gemm_vs_level3_benchmark.cc
+++ b/benchmarks/gemm_vs_level3_benchmark.cc
@@ -75,6 +75,22 @@ inline void TWSizes(minibench::Benchmark* b) {
 }
 inline void TWSizesNetlib(minibench::Benchmark* b) { TWSizes(b); }
 
+// ------------------------------------------------------------- Square sizes
+// (m, nC, batch), m the triangular side. The TW shapes above are the regime
+// where trmm cannot win and the roofline says so: m is in the tens, so B and C
+// dominate the traffic, the GEMM being replaced is already bandwidth bound at
+// ~800 GB/s, and halving its arithmetic buys nothing it can spend. Halving the
+// arithmetic only pays once the GEMM is compute bound, which needs m past
+// ~160 -- intensity is m/4 flop per byte against a ridge near 40. These are
+// those shapes, at batches that still saturate.
+inline void SquareSizes(minibench::Benchmark* b) {
+    b->Args({256, 256, 512});
+    b->Args({512, 512, 128});
+    b->Args({512, 1024, 64});
+    b->Args({1024, 1024, 32});
+}
+inline void SquareSizesNetlib(minibench::Benchmark* b) { SquareSizes(b); }
+
 template <typename T>
 constexpr Transpose conj_trans_for() {
     return sycl::detail::is_complex<T>::value ? Transpose::ConjTrans : Transpose::Trans;
@@ -219,11 +235,15 @@ void configure_tw(minibench::State& state) {
                          * static_cast<double>(nC);
 
     if constexpr (UseTrmm) {
-        // trmm accumulates into C with an implicit beta = 1, so W2 is charged a
-        // zeroing the gemm spelling gets for free from beta = 0. Left side,
-        // upper triangle, non-unit diagonal: larft's T exactly.
+        // Left side, upper triangle, non-unit diagonal: larft's T exactly.
+        //
+        // The CUDA and ROCm paths overwrite C (beta = 0); only the MKL fallback
+        // in src/extensions accumulates into it. PR #61 charged trmm a zeroing
+        // pass here to be safe against that, which on a GPU is pure overhead --
+        // at ib = 32, nC = 256, batch 2048 the fill alone is ~70 us of a 189 us
+        // measurement, and it inflated every trmm row in that report. The GPU
+        // spelling is what these shapes are here to measure, so it is gone.
         auto kernel = [q, Tm, W1, W2]() mutable {
-            W2->view().fill(*q, T(0));
             trmm<B, T>(*q, Tm->view(), W1->view(), W2->view(), T(1),
                        Side::Left, Uplo::Upper, conj_trans_for<T>(), Diag::NonUnit);
         };
@@ -242,6 +262,12 @@ static void BM_TW_gemm(minibench::State& state) { configure_tw<T, B, false>(stat
 template <typename T, Backend B>
 static void BM_TW_trmm(minibench::State& state) { configure_tw<T, B, true>(state); }
 
+// Same operation, same code, shapes chosen from the other side of the ridge.
+template <typename T, Backend B>
+static void BM_Square_gemm(minibench::State& state) { configure_tw<T, B, false>(state); }
+template <typename T, Backend B>
+static void BM_Square_trmm(minibench::State& state) { configure_tw<T, B, true>(state); }
+
 }  // namespace
 
 BATCHLAS_REGISTER_BENCHMARK_ALL_TYPES(BM_Gram_gemm, GramSizes)
@@ -253,5 +279,8 @@ BATCHLAS_REGISTER_BENCHMARK(BM_Trailing_syr2k_sym, TrailingSizes)
 
 BATCHLAS_REGISTER_BENCHMARK_ALL_TYPES(BM_TW_gemm, TWSizes)
 BATCHLAS_REGISTER_BENCHMARK_ALL_TYPES(BM_TW_trmm, TWSizes)
+
+BATCHLAS_REGISTER_BENCHMARK_ALL_TYPES(BM_Square_gemm, SquareSizes)
+BATCHLAS_REGISTER_BENCHMARK_ALL_TYPES(BM_Square_trmm, SquareSizes)
 
 MINI_BENCHMARK_MAIN();

--- a/experiments/TRMM_SYRK_BATCHED_KERNELS.md
+++ b/experiments/TRMM_SYRK_BATCHED_KERNELS.md
@@ -86,17 +86,68 @@ GEMM), measured in the same session.
 | 512 | 1024 | 64 | 0.754 | 0.838 | **0.690** | 1.22x | 1.09x |
 | 1024 | 1024 | 32 | 1.514 | 1.662 | **1.146** | 1.45x | 1.32x |
 
-Faster than the route it replaces at 9 of 10 shapes. Against the *GEMM
-spelling* it wins at `m <= 64` and `m >= 512` and loses in between, and the
-reason is structural rather than a tuning miss:
+### Beating the GEMM in every dtype: what it took
 
-- `m <= 64` is one row tile, so there is no k-range to skip and the arithmetic
-  is a GEMM's. It wins anyway on fusion -- no `k x k x batch` expansion written
-  and read back.
-- `m >= 512` is four or more row tiles, so the k-range removes 1.6x-1.8x of the
-  arithmetic, enough to cover this kernel running at ~70% of cuBLAS's per-flop
-  rate.
-- Between, one or two row tiles buys at most 1.33x, and that same 70% eats it.
+The first version was float-only and lost to the GEMM at m = 128..256. Both
+facts had the same cause and one fix.
+
+**The tile width is the whole game, and the scalar type picks it.** R = m/TileM
+row tiles shrink the reduction to (R+1)/2R, so R = 1 saves *nothing* -- and the
+original rule used one tile for all m <= 128, which is exactly why it could
+never beat a GEMM there. Cutting m into more tiles also re-reads B, up to
+(R+1)/2 times. Which side wins is decided by precision, not shape: float is
+bandwidth bound at these sizes (intensity m/4 against a ridge near 40) so the
+re-read is expensive; double runs at 1/64 rate, putting the ridge near 1.4, so
+the arithmetic is everything and B's re-read is nearly free. Measured, float,
+m = 128 nC = 512 batch 1024 -- TileM 32/64/128 gives 0.663 / **0.658** / 0.699
+against a GEMM's 0.674. So 64 for float, 32-64 for the wide types, and 128 only
+for float past m = 512.
+
+**Three float-only assumptions had to go**, the same three the Gram SYRK kernel
+hit: the `alignas(4*sizeof(T))` packet (undefined for anything but float),
+`std::complex::operator*` (the `__mulsc3` libcall), and register pressure (an
+8x8 thread tile is 256 registers in `complex<double>`; forcing TileM = 128 there
+measured 15.06 ms against 2.18 -- pure spill).
+
+**And one that was not float-specific at all.** Factoring the inner loop into
+helpers, the accumulator update was first written as `void accumulate(T& acc,
+...)`. Taking the address of an element of the accumulator array is enough for
+the compiler to stop keeping it in registers; it went to local memory and cost
+**43%** on float at m = 512 (0.659 -> 0.944 ms) with no other change. Both
+helpers now return by value.
+
+### Where it lands, by dtype
+
+Ratios are trmm against the GEMM spelling of the same product; **bold** is a win.
+
+| m | nC | batch | float | double | complex&lt;float&gt; | complex&lt;double&gt; |
+|---|---|---|---|---|---|---|
+| 32 | 256 | 2048 | **1.13x** | **1.29x** | 0.88x | **1.05x** |
+| 64 | 256 | 2048 | **1.07x** | **1.45x** | 0.88x | **1.41x** |
+| 64 | 512 | 1024 | **1.04x** | **1.45x** | 0.84x | **1.41x** |
+| 128 | 512 | 1024 | **1.03x** | **1.48x** | 0.69x | **1.42x** |
+| 128 | 1024 | 512 | 1.00x | **1.48x** | 0.69x | **1.42x** |
+| 256 | 1024 | 256 | 0.91x | **1.77x** | 0.93x | **1.71x** |
+| 256 | 256 | 512 | 0.93x | **1.72x** | 0.89x | **1.66x** |
+| 512 | 512 | 128 | **1.15x** | **1.91x** | **1.10x** | **1.85x** |
+| 512 | 1024 | 64 | **1.16x** | **1.91x** | **1.10x** | **1.84x** |
+| 1024 | 1024 | 32 | **1.26x** | **2.02x** | **1.23x** | **1.95x** |
+
+**double and complex&lt;double&gt; win at every shape measured**, 1.05x to 2.02x --
+essentially the theoretical ceiling, because FP64 is compute bound at 1/64 rate
+so the halved arithmetic lands in full and grows with m.
+
+**float wins at 8 of 10**, the exceptions being m = 256, where cuBLAS's SGEMM is
+running at its 45 TFLOP/s peak and this kernel reaches ~57% of that; a 1.6x
+arithmetic saving does not cover a 1.75x rate deficit.
+
+**complex&lt;float&gt; is the one dtype that loses below m = 512**, and it is the
+worst case of the same story: cuBLAS's cgemm is at ~100% of the FP32 FMA peak
+on these shapes, while a complex accumulator costs twice the registers, so the
+thread tile that would give this kernel a competitive fragment-to-FMA ratio does
+not fit at a usable occupancy. Widening the column tile from 8 to 16 (halving
+the lane count) is what recovers m >= 512; going further to a 128-row tile
+spills. It is a register-file ceiling, not a tuning miss.
 
 ### A routing mistake worth recording
 

--- a/experiments/TRMM_SYRK_BATCHED_KERNELS.md
+++ b/experiments/TRMM_SYRK_BATCHED_KERNELS.md
@@ -132,16 +132,129 @@ kernel's three tile widths. `SyrkTest.NarrowShapesMatchGemmReference` now sweeps
 n in {24, 32, 48, 64, 96, 128} x trans x uplo with k = 200 (deliberately not a
 multiple of the k chunk), so each tile width and each partial tile is exercised.
 
+## Double and complex
+
+The Gram kernel is templated, so extending it was mostly a matter of finding the
+three things that were secretly float-only:
+
+1. **The 128-bit packet.** `TileVec4<T>` is `alignas(4*sizeof(T))`, which for
+   double is 32 bytes and for `complex<double>` 64 -- an alignment
+   `sycl::local_accessor` never promises, since it aligns to `T`. The
+   reinterpret was undefined for every type but float. `tile_load4` now
+   vectorises only at `sizeof(T) == 4` and stays scalar above it.
+2. **Register pressure.** A 4-wide thread tile puts 544 threads on the 128-wide
+   case, which float wants. Complex doubles every accumulator: 205 registers per
+   work-item x 544 is past the 65536 a work-group gets, and the runtime rejects
+   the launch outright rather than spilling. Complex takes an 8-wide thread tile
+   and 160 threads instead.
+3. **`std::complex::operator*`.** It lowers to the `__mulsc3` libcall -- C99
+   Annex G, a branch on Inf and NaN around every multiply. In this inner loop it
+   cost **18x**: n = 128 took 38 ms where a cuBLAS GEMM took 1.5. Writing the
+   four real multiplies out by hand fixed it. Nothing in the source hints at it.
+
+Double, against the GEMM spelling and against the host loop it replaces:
+
+| m | n | batch | gemm | syrk before | syrk now | vs gemm | vs before |
+|---|---|---|---|---|---|---|---|
+| 256 | 32 | 2048 | 0.901 | 115.40 | **0.837** | 1.08x | 138x |
+| 512 | 64 | 1024 | 3.444 | 112.45 | **1.934** | 1.78x | 58x |
+| 1024 | 128 | 512 | 13.72 | 110.91 | **6.521** | 2.10x | 17x |
+
+The win *grows* with n in double and shrinks in float, and that is the FP64 rate:
+this part runs double at 1/64, so the Gram product is squarely compute bound and
+halving the arithmetic lands in full, where float at n = 128 is already against
+both roofs.
+
+**Complex is measured and rejected.** In complex float the tile kernel loses to
+the existing GEMM-plus-Hermitian-fold at every Gram shape (0.217 vs 0.206 ms at
+n=32/batch 2048; 2.08 vs 1.57 at n=128/batch 512): a complex multiply is four
+real ones, so herk is compute bound where real syrk is bandwidth bound, and
+cuBLAS's cgemm is better at compute than this kernel. `herk` keeps its route.
+The conjugating path stays reachable as `BATCHLAS_SYRK_VARIANT=gram` so it stays
+measurable and under test.
+
+### The herk test that could not have failed
+
+`HerkTest` checked that the unreferenced triangle stays untouched and that the
+two uplo runs agree. Neither can catch conjugating the wrong operand: doing so
+returns `conj(C)` instead of `C`, which is still Hermitian and still consistent
+across both triangles. `MatchesGemmReference` compares against a GEMM and was
+confirmed to fail when the conjugation is flipped.
+
+## Wired into ortho
+
+Both Cholesky Gram sites (`chol_alg`, `shift_chol_alg`) now call `syrk`. Only
+the lower triangle is produced, which is all anything downstream reads -- `potrf`
+and `trsm` both default to `Uplo::Lower` and the shift kernel touches only the
+diagonal. `svqb_alg` keeps its GEMM: it scales the whole `k x k` before handing
+it to `syev`, so a half-written C would leave it multiplying uninitialised
+workspace.
+
+End to end, m = 1024, batch 512 (`BATCHLAS_ORTHO_GRAM=gemm` pins the old
+spelling so this is one binary, not two builds):
+
+| k | algo | float gemm | float syrk | | double gemm | double syrk | |
+|---|---|---|---|---|---|---|---|
+| 32 | Chol2 | 1.450 | **0.895** | 1.62x | 6.689 | 6.580 | 1.02x |
+| 32 | ShiftChol3 | 1.998 | **1.298** | 1.54x | | | |
+| 64 | Chol2 | 4.061 | **3.614** | 1.12x | 17.98 | **14.95** | 1.20x |
+| 64 | ShiftChol3 | 6.078 | **5.404** | 1.12x | | | |
+| 128 | Chol2 | 8.813 | 9.156 | 0.96x | 57.39 | **42.94** | 1.34x |
+
+The float k = 128 loss is why the threshold is `k <= 64` for float and
+`k <= 128` for double rather than one number for both.
+
+## Impact on syev: none, and the trace says why
+
+Asked directly. The answer is that **neither new kernel is in syev's path**, and
+that is not an oversight in the wiring -- syev does not call `ortho` at all.
+Kernel tracing a run is what settles it, and it also shows syev taking two
+completely different routes:
+
+| n | route | level-3 triangular ops used |
+|---|---|---|
+| 256 | `sytrd_blocked` | `syr2k_cuda_custom.triangular_tiles` (PR #61) |
+| 512 | `syev_two_stage` | none at all |
+
+So the only level-3 kernel that touches syev is the syr2k PR #61 already landed,
+and it only touches the shapes that take the blocked route:
+
+| n | batch | nb | jobz | gemm | syr2k | |
+|---|---|---|---|---|---|---|
+| 256 | 1024 | 16 | evals | 25.37 | **21.93** | 1.16x |
+| 256 | 1024 | 32 | evals | 26.49 | **25.02** | 1.06x |
+| 256 | 1024 | 32 | vectors | 39.17 | **37.41** | 1.05x |
+| 512 | 1024 | 16 | evals | 162.7 | 162.8 | 1.00x |
+| 512 | 1024 | 32 | evals | 162.7 | 162.5 | 1.00x |
+
+n = 512 is exactly 1.00x because the two-stage path never calls syr2k.
+
+Where its time does go, from the same trace (n=512, batch 1024, nb=16):
+
+| kernel | share |
+|---|---|
+| `syev_two_stage.sb2st_hh` | 62.4% |
+| `ormqr_blocked.larft` | 9.2% |
+| `syev_two_stage.stebz_evals` | 7.1% |
+| `ormqr_blocked.pack_v_panel` | 4.0% |
+| `syev_two_stage.sy2sb` | 1.1% |
+
+**The conclusion for anyone chasing syev is that level-3 substitution is not the
+lever.** Nearly two thirds of it is one band-to-tridiagonal Householder kernel,
+and no triangular BLAS-3 op appears anywhere in that route. The ~9% in
+`ormqr_blocked.larft` is the one place trmm could be wired -- see below -- and
+even a perfect result there is bounded by that 9%.
+
 ## What is not done
 
-- **Neither op is wired into `ortho` yet, and that is deliberate.** `syrk` is
-  now 1.8x-4.3x faster than the GEMM spelling at ortho's Gram shapes in
-  **CUDA float**. In double and complex there is still no batched kernel --
-  those fall to the per-batch host loop -- so switching the call sites today
-  would trade a 2x float win for a ~100x double loss. The batched double/complex
-  route is the prerequisite.
+- **`trmm` is still not wired into `ormqr_blocked`/`ormbr`.** The shape is right
+  (`m = ib <= 64` is where the tile kernel wins, 1.04x-1.12x) and syev spends
+  ~9% there, so the bound on the whole substitution is about 1%. Worth doing,
+  not worth doing carelessly.
 - `trmm`'s tile kernel is `Side::Left` only. `ormqr`/`ormbr` use both sides;
   the right-side branch still takes the expansion.
+- The two-stage path's `sy2sb` trailing update has no syr2k, and n >= 512 syev
+  goes through it. That is a separate, larger piece of work than this one.
 - The tile kernel runs at ~70% of cuBLAS's per-flop rate. Closing that would
   turn the `m = 128..256` band from a loss into a ~1.2x win.
 - SYRK at n = 256 (0.89x, `syrk_triangular_tiles`) is a pre-existing loss and

--- a/experiments/TRMM_SYRK_BATCHED_KERNELS.md
+++ b/experiments/TRMM_SYRK_BATCHED_KERNELS.md
@@ -1,0 +1,148 @@
+# Batched TRMM and SYRK kernels for the shapes we actually call them with
+
+PR #61 declined to use `trmm` or `syrk` anywhere in `src/extensions`, and was
+right to on the evidence it had: neither op reached a batched kernel at the
+shapes its callers produce. This is the other half of that result -- writing the
+kernels that were missing, and re-measuring.
+
+Hardware: RTX 4090 / sm_89, CUDA 13.2, RelWithDebInfo, one GPU, no other compute
+processes resident. All figures float, `--warmup=5 --min_iters=20`, run-to-run
+stddev under 1% except where noted. Harness is `benchmarks/gemm_vs_level3_benchmark.cc`.
+Every shape is paired with a batch large enough to saturate; batch = 1 is not
+measured and is not a design target.
+
+## What was missing
+
+**SYRK.** `syrk_triangular_tiles` (PR #60) is a 128x128 tile-masked kernel and
+its router requires at least three tiles a side, i.e. `n >= 257`. Below that
+there is nothing for a triangular *grid* to skip, so the router correctly
+refused it and every Gram matrix fell to `syrk_vendor_impl` -- a host loop
+issuing one `cublasSsyrk` per batch member. At batch 2048 that is 33 ms against
+a 0.33 ms GEMM.
+
+**TRMM.** Nothing in the tree exploited triangularity. `src/extensions/trmm.cc`
+recurses only until the block is 256 wide and then calls the GEMM it is meant to
+replace, so for every `ib` in {16,32,64,128,256} the structure was never used.
+On CUDA the op does not even reach that recursion: `trmm_vendor_impl` expands
+the triangle into a `k x k x batch` scratch buffer and hands it to a full GEMM.
+
+## SYRK: `syrk_gram_tiles.hh`
+
+Sizes the tile to `n` rather than fixing it at 128, so one tile is the whole of
+C. Both operands of `A^T A` are then the same columns of A, so there is one
+shared tile instead of two and A crosses the bus exactly once -- which is what
+matters, because arithmetic intensity here is `n/4` flop per byte, 8 at n = 32
+against the 4090's ridge near 40.
+
+The triangle is taken at *thread-tile* granularity: only the 136 of 256 thread
+tiles that meet the requested half are carried, so 160 threads instead of 256.
+Masking only the epilogue leaves the block doing exactly a GEMM's arithmetic,
+which is why the first cut could match a GEMM at n = 128 and never beat one.
+
+`gemm` and `syrk before` are one paired run on `main`; `syrk now` is this branch.
+
+| m (reduction) | n | batch | gemm | syrk before | syrk now | vs gemm | vs before |
+|---|---|---|---|---|---|---|---|
+| 256 | 32 | 2048 | 0.334 | 33.588 | **0.0780** | 4.29x | 431x |
+| 512 | 32 | 2048 | 0.711 | 61.075 | **0.1711** | 4.16x | 357x |
+| 512 | 64 | 1024 | 0.345 | 31.911 | **0.1875** | 1.84x | 170x |
+| 1024 | 64 | 1024 | 0.668 | 60.397 | **0.3326** | 2.01x | 182x |
+| 1024 | 128 | 512 | 0.409 | 30.296 | 0.4146 | 0.99x | 73x |
+| 2048 | 128 | 256 | 0.404 | 29.370 | **0.3820** | 1.06x | 77x |
+
+At n = 32 the kernel reads 71 MB in 78 us -- 933 GB/s, so it is at the memory
+roofline and there is nothing further to get. At n = 128 it is at parity with
+GEMM, and that is close to the ceiling too: reading A once costs 298 us against
+GEMM's measured 409, so the whole prize there was 1.37x, not 2x.
+
+n >= 256 is untouched and still on `syrk_triangular_tiles`: 0.89x at n = 256,
+1.28x at 512, 1.57x at 1024. The n = 256 cell is a pre-existing loss.
+
+## TRMM: `trmm_triangular_tiles.hh`
+
+The structure worth exploiting is the k-loop bound, not a mask. An output tile
+rooted at row `m0` only ever touches `op(A)_{i,p}` for `p >= i`, so it can start
+its reduction at `m0` -- the arithmetic is not done and then discarded. `uplo`
+and `trans` collapse into one flag, `lower_eff`, because transposing an upper
+triangle gives a lower one.
+
+How much that saves is worth stating precisely, because it is **not** the
+textbook 2x: with `R` row tiles the reduction shrinks to `(R+1)/2R` of the
+square -- 1.0x at R = 1, 1.33x at R = 2, only 1.78x by R = 8.
+
+`before` is `BATCHLAS_TRMM_VARIANT=vendor` on this branch (the expansion plus
+GEMM), measured in the same session.
+
+| m | nC | batch | gemm | trmm before | trmm now | vs before | vs gemm |
+|---|---|---|---|---|---|---|---|
+| 32 | 256 | 2048 | 0.187 | 0.186 | **0.167** | 1.11x | 1.12x |
+| 64 | 256 | 2048 | 0.352 | 0.399 | **0.333** | 1.20x | 1.06x |
+| 64 | 512 | 1024 | 0.333 | 0.351 | **0.320** | 1.10x | 1.04x |
+| 128 | 512 | 1024 | 0.674 | 0.784 | 0.699 | 1.12x | 0.97x |
+| 128 | 1024 | 512 | 0.637 | 0.687 | 0.686 | 1.00x | 0.93x |
+| 256 | 1024 | 256 | 0.758 | 0.852 | 0.915 | 0.93x | 0.83x |
+| 256 | 256 | 512 | 0.467 | 0.690 | **0.536** | 1.29x | 0.87x |
+| 512 | 512 | 128 | 0.762 | 0.961 | **0.713** | 1.35x | 1.07x |
+| 512 | 1024 | 64 | 0.754 | 0.838 | **0.690** | 1.22x | 1.09x |
+| 1024 | 1024 | 32 | 1.514 | 1.662 | **1.146** | 1.45x | 1.32x |
+
+Faster than the route it replaces at 9 of 10 shapes. Against the *GEMM
+spelling* it wins at `m <= 64` and `m >= 512` and loses in between, and the
+reason is structural rather than a tuning miss:
+
+- `m <= 64` is one row tile, so there is no k-range to skip and the arithmetic
+  is a GEMM's. It wins anyway on fusion -- no `k x k x batch` expansion written
+  and read back.
+- `m >= 512` is four or more row tiles, so the k-range removes 1.6x-1.8x of the
+  arithmetic, enough to cover this kernel running at ~70% of cuBLAS's per-flop
+  rate.
+- Between, one or two row tiles buys at most 1.33x, and that same 70% eats it.
+
+### A routing mistake worth recording
+
+The first version of the router gated the tile kernel to `m <= 64 || m >= 512`,
+picked straight off the "vs gemm" column above. That is the wrong comparison:
+the router chooses between the tile kernel and the *vendor*, not between trmm
+and gemm. The gate sent `m = 128..256` back to the expansion and cost up to
+1.29x on exactly the shapes it was meant to protect. There is now no threshold.
+
+## Two measurement corrections to PR #61
+
+1. **The TW benchmark charged trmm a zeroing pass it does not need.** The CUDA
+   and ROCm paths overwrite C (`beta = 0`); only the MKL fallback in
+   `src/extensions` accumulates. At ib = 32, nC = 256, batch 2048 that fill is
+   ~70 us of a 189 us measurement. Removed.
+2. **The TW shapes cannot show a trmm win and the roofline says so in advance.**
+   With m in the tens, B and C dominate the traffic and the GEMM is already
+   bandwidth bound near 800 GB/s, so halving its arithmetic buys nothing it can
+   spend. `BM_Square_*` was added for shapes on the other side of the ridge.
+
+## A bug this found, and the test that now covers it
+
+The 128-wide SYRK tile initially split each thread's 8 rows into two 4-wide
+bands 64 apart -- what the square 128x128 kernels do to spread shared-memory
+banks. That is incompatible with taking the triangle at thread-tile
+granularity, which decides a whole thread tile is inside the requested half
+from its tile indices alone. Thread (0,1) then owns element (64,4), which is in
+the lower triangle while its tile is not, so nothing wrote it.
+
+It failed quietly and only at `n > 64`. `syrk_tests` pinned exactly one shape,
+n = 96, which happened to catch it -- but that shape reaches only one of the
+kernel's three tile widths. `SyrkTest.NarrowShapesMatchGemmReference` now sweeps
+n in {24, 32, 48, 64, 96, 128} x trans x uplo with k = 200 (deliberately not a
+multiple of the k chunk), so each tile width and each partial tile is exercised.
+
+## What is not done
+
+- **Neither op is wired into `ortho` yet, and that is deliberate.** `syrk` is
+  now 1.8x-4.3x faster than the GEMM spelling at ortho's Gram shapes in
+  **CUDA float**. In double and complex there is still no batched kernel --
+  those fall to the per-batch host loop -- so switching the call sites today
+  would trade a 2x float win for a ~100x double loss. The batched double/complex
+  route is the prerequisite.
+- `trmm`'s tile kernel is `Side::Left` only. `ormqr`/`ormbr` use both sides;
+  the right-side branch still takes the expansion.
+- The tile kernel runs at ~70% of cuBLAS's per-flop rate. Closing that would
+  turn the `m = 128..256` band from a loss into a ~1.2x win.
+- SYRK at n = 256 (0.89x, `syrk_triangular_tiles`) is a pre-existing loss and
+  was not touched.

--- a/experiments/TRMM_SYRK_BATCHED_KERNELS.md
+++ b/experiments/TRMM_SYRK_BATCHED_KERNELS.md
@@ -241,18 +241,51 @@ Where its time does go, from the same trace (n=512, batch 1024, nb=16):
 
 **The conclusion for anyone chasing syev is that level-3 substitution is not the
 lever.** Nearly two thirds of it is one band-to-tridiagonal Householder kernel,
-and no triangular BLAS-3 op appears anywhere in that route. The ~9% in
-`ormqr_blocked.larft` is the one place trmm could be wired -- see below -- and
-even a perfect result there is bounded by that 9%.
+and no triangular BLAS-3 op appears anywhere in that route.
+
+## trmm in ormqr_blocked's WY update, and what it is worth
+
+`W2 = op(T) W1` with `T` upper triangular from `larft` is now a trmm. Both syev
+paths call `ormqr_blocked` with `Side::Left`, which is the side the tile kernel
+serves, and every block size syev uses is inside the `ib <= 64` window where it
+beats the GEMM. Guarded to CUDA float, because anything else takes
+`trmm_vendor_impl` -- which expands the triangle into scratch and then runs the
+very GEMM being replaced. `BATCHLAS_ORMQR_WY=gemm` pins the old spelling.
+
+Then measured rather than assumed, and the honest answer is **it barely moves
+syev** (float, batch as shown, eigenvectors, stddev 0.01-0.55 ms):
+
+| n | batch | nb | gemm | trmm | |
+|---|---|---|---|---|---|
+| 64 | 2048 | 16 | 3.657 | **3.528** | 1.036x |
+| 64 | 4096 | 16 | 7.292 | **7.092** | 1.028x |
+| 128 | 2048 | 16 | 14.07 | **13.78** | 1.021x |
+| 128 | 4096 | 16 | 27.72 | **27.36** | 1.013x |
+| 256 | 1024 | 16 | 33.90 | **33.50** | 1.012x |
+| 256 | 1024 | 32 | 37.41 | **36.98** | 1.012x |
+| 512 | 1024 | 16 | 366.6 | **365.2** | 1.004x |
+| 512 | 1024 | 32 | 367.2 | **366.0** | 1.003x |
+
+Consistent in direction across all eight cells and several times the stddev, so
+it is a real effect and not noise -- but it is 3.6% at best and 0.3% at n = 512.
+
+The trace says exactly why, and said so before the measurement: with the kernel
+wired, `trmm_cuda_custom.triangular_tiles` is **1.0%** of traced syev time at
+n = 512 (8.58 ms of 868, over 240 calls). A substitution that makes that op
+~10% faster cannot return more than 0.1% there, and that is what it returns.
+The earlier ~9% figure was `ormqr_blocked.larft`, which is a different kernel
+and not the one trmm replaces.
+
+At n = 512 with eigenvectors the time is `backtransform_q2` 46.4%, `sb2st_hh`
+25.5%, `stedc_eigvecs` 10.6%. Those three are 82% and none is a level-3
+triangular op.
 
 ## What is not done
 
-- **`trmm` is still not wired into `ormqr_blocked`/`ormbr`.** The shape is right
-  (`m = ib <= 64` is where the tile kernel wins, 1.04x-1.12x) and syev spends
-  ~9% there, so the bound on the whole substitution is about 1%. Worth doing,
-  not worth doing carelessly.
 - `trmm`'s tile kernel is `Side::Left` only. `ormqr`/`ormbr` use both sides;
-  the right-side branch still takes the expansion.
+  the right-side branch still takes the expansion. syev only uses Left, so this
+  costs syev nothing.
+- `ormbr` has the same WY update and is not wired; it feeds gesvd, not syev.
 - The two-stage path's `sy2sb` trailing update has no syr2k, and n >= 512 syev
   goes through it. That is a separate, larger piece of work than this one.
 - The tile kernel runs at ~70% of cuBLAS's per-flop rate. Closing that would

--- a/src/backends/cublas.cc
+++ b/src/backends/cublas.cc
@@ -20,6 +20,8 @@
 #include "symm_custom_dispatch.hh"
 #include "syr2k_custom_dispatch.hh"
 #include "syrk_custom_dispatch.hh"
+#include "syrk_gram_tiles.hh"
+#include "cublasdx_dispatch_common.hh"
 #include "trmm_custom_dispatch.hh"
 #include "triangular_expand.hh"
 #include "../sycl/gemm_kernels.hh"
@@ -531,6 +533,19 @@ namespace batchlas {
             throw std::runtime_error("HERK: incompatible matrix dimensions");
         }
 
+        // The same single-tile Gram kernel as syrk, with the ^H conjugating
+        // whichever operand carries it. Opt-in only: see syrk_route_requests_gram
+        // for the measurement that keeps it off the automatic path -- a complex
+        // multiply is four real ones, so this shape is compute bound for herk
+        // where it is bandwidth bound for syrk, and the GEMM-plus-fold below
+        // wins on every Gram shape measured.
+        if constexpr (Back == Backend::CUDA) {
+            if (detail::is_gpu_queue(ctx) && syrk_route_requests_gram() &&
+                detail::syrk_gram_supported(A, C, transA, /*conjugated=*/true)) {
+                return detail::syrk_gram_tiles<T, true>(ctx, A, C, T(alpha), T(beta), uplo, transA);
+            }
+        }
+
         const std::size_t product_bytes = detail::expanded_workspace_bytes<T>(ctx, n, batch);
         if (herk_gemm_preferred(n, batch) && detail::expansion_fits(ctx, n, batch, product_bytes)) {
             const int ld = detail::expanded_ld<T>(n);
@@ -759,6 +774,19 @@ namespace batchlas {
             if constexpr (std::is_same_v<T, float>) {
                 if (syrk_use_cuda_custom(ctx, A, C, uplo, transA)) {
                     return syrk_cuda_custom(ctx, A, C, alpha, beta, uplo, transA);
+                }
+            } else {
+                // Everything that is not float reaches the single-tile Gram
+                // kernel only. It is the one route here whose staging and
+                // fragment loads are not written around a 128-bit packet, so it
+                // is the one that generalises; the 128x128 triangular kernel
+                // stays float. Below kGramMaxTile the alternative is
+                // syrk_vendor_impl's host loop over one cublasXsyrk per batch
+                // member, which at large batch is two orders of magnitude off
+                // anything batched, so there is no threshold to tune.
+                if (detail::is_gpu_queue(ctx) && !syrk_route_prefers_vendor() &&
+                    detail::syrk_gram_supported(A, C, transA, /*conjugated=*/false)) {
+                    return detail::syrk_gram_tiles<T, false>(ctx, A, C, alpha, beta, uplo, transA);
                 }
             }
         }

--- a/src/backends/cublas.cc
+++ b/src/backends/cublas.cc
@@ -23,6 +23,7 @@
 #include "syrk_gram_tiles.hh"
 #include "cublasdx_dispatch_common.hh"
 #include "trmm_custom_dispatch.hh"
+#include "trmm_triangular_tiles.hh"
 #include "triangular_expand.hh"
 #include "../sycl/gemm_kernels.hh"
 
@@ -1016,6 +1017,15 @@ namespace batchlas {
             if constexpr (std::is_same_v<T, float>) {
                 if (trmm_use_cuda_custom(ctx, A, B, C, side, uplo, transA, diag)) {
                     return trmm_cuda_custom(ctx, A, B, C, alpha, side, uplo, transA, diag);
+                }
+            } else {
+                // The tile kernel is type-generic; only its routing was ever
+                // float. The alternative for double and complex is the same
+                // expansion-plus-GEMM as for float, which is strictly more work
+                // than the GEMM it wraps, so there is nothing to weigh here.
+                if (detail::is_gpu_queue(ctx) && !trmm_route_prefers_vendor() &&
+                    detail::trmm_tiles_supported(A, B, C, side)) {
+                    return detail::trmm_triangular_tiles(ctx, A, B, C, alpha, uplo, transA, diag);
                 }
             }
         }

--- a/src/backends/syrk_custom_dispatch.cc
+++ b/src/backends/syrk_custom_dispatch.cc
@@ -168,6 +168,14 @@ Event syrk_cublasdx_fallback_gemm(Queue& ctx,
 
 } // namespace
 
+bool syrk_route_prefers_vendor() {
+    return syrk_route_request() == SyrkRoute::Vendor;
+}
+
+bool syrk_route_requests_gram() {
+    return syrk_route_request() == SyrkRoute::Gram;
+}
+
 bool syrk_use_cuda_custom(const Queue& ctx,
                           const MatrixView<float, MatrixFormat::Dense>& A,
                           const MatrixView<float, MatrixFormat::Dense>& C,

--- a/src/backends/syrk_custom_dispatch.cc
+++ b/src/backends/syrk_custom_dispatch.cc
@@ -3,6 +3,7 @@
 #include "gemm_cublasdx_dispatch.hh"
 #include "gemm_variant.hh"
 #include "syrk_cublasdx_fused.hh"
+#include "syrk_gram_tiles.hh"
 #include "syrk_triangular_tiles.hh"
 #include "cublasdx_dispatch_common.hh"
 
@@ -20,9 +21,10 @@ namespace {
 
 constexpr int kSyrkCublasDxTile = 32;
 
-// BATCHLAS_SYRK_VARIANT selects a route. The two custom routes are named
+// BATCHLAS_SYRK_VARIANT selects a route. The custom routes are named
 // separately so each stays independently measurable and testable: `triangular`
-// is the tile-masked kernel that computes only the requested half of C,
+// is the tile-masked kernel that computes only the requested half of a wide C,
+// `gram` the single-tile kernel for a narrow C over a long reduction,
 // `cublasdx` the fused kernel, and `gemm` the full n x n batched GEMM the
 // triangular route replaces.
 //
@@ -35,6 +37,7 @@ enum class SyrkRoute {
     Vendor,
     Fused,
     Triangular,
+    Gram,
     Gemm,
 };
 
@@ -57,6 +60,9 @@ SyrkRoute syrk_route_request() {
     }
     if (value == "triangular" || value == "tiles") {
         return SyrkRoute::Triangular;
+    }
+    if (value == "gram" || value == "narrow") {
+        return SyrkRoute::Gram;
     }
     if (value == "gemm") {
         return SyrkRoute::Gemm;
@@ -123,6 +129,15 @@ bool syrk_prefer_triangular_tiles(const MatrixView<float, MatrixFormat::Dense>& 
     return static_cast<long long>(A.batch_size()) * detail::triangular_tile_count(n) >= 160;
 }
 
+// The single-tile kernel's whole premise is that the tile is sized to n, so it
+// serves exactly the range the triangular grid cannot: n no wider than one
+// tile. Inside that range it is not a close call and there is no threshold to
+// tune -- the alternative is a host loop over cublasSsyrk, which at large batch
+// is one to two orders of magnitude off anything batched.
+bool syrk_prefer_gram_tiles(const MatrixView<float, MatrixFormat::Dense>& C) {
+    return C.rows() <= detail::kGramMaxTile;
+}
+
 bool syrk_prefer_cuda_custom_heuristic(const MatrixView<float, MatrixFormat::Dense>& A,
                                        const MatrixView<float, MatrixFormat::Dense>& C,
                                        Transpose transA) {
@@ -166,14 +181,17 @@ bool syrk_use_cuda_custom(const Queue& ctx,
         !syrk_problem_supported(A, C, transA) || !syrk_triangular_supported(A, C)) {
         return false;
     }
-    // The tile-masked kernel is the only custom route that respects the
-    // triangle, so it is the only one the automatic choice may leave the vendor
-    // for. Its own threshold says where it beats the full n x n GEMM; below
-    // that the question is instead whether it beats a host loop over
-    // cublasSsyrk, which the cuBLASDx heuristic already answers -- one launch
-    // per batch member costs about 9 us, so anything with a batch at all is
-    // better off here even where the tile grid is half diagonal.
-    return syrk_prefer_triangular_tiles(A, C, transA) ||
+    // The two tile-masked kernels are the only custom routes that respect the
+    // triangle, so they are the only ones the automatic choice may leave the
+    // vendor for. Between them they cover the range: `gram` below one tile,
+    // `triangular` from three tiles a side up. Its own threshold says where it
+    // beats the full n x n GEMM; below that the question is instead whether it
+    // beats a host loop over cublasSsyrk, which the cuBLASDx heuristic already
+    // answers -- one launch per batch member costs about 9 us, so anything with
+    // a batch at all is better off here even where the tile grid is half
+    // diagonal.
+    return syrk_prefer_gram_tiles(C) ||
+        syrk_prefer_triangular_tiles(A, C, transA) ||
         syrk_prefer_cuda_custom_heuristic(A, C, transA);
 }
 
@@ -192,9 +210,18 @@ Event syrk_cuda_custom(Queue& ctx,
     if (route == SyrkRoute::Gemm) {
         return syrk_cublasdx_fallback_gemm(ctx, A, C, alpha, beta, transA);
     }
-    const bool triangular = route == SyrkRoute::Triangular || route == SyrkRoute::Auto;
-    if (triangular && syrk_triangular_supported(A, C)) {
-        return detail::syrk_triangular_tiles(ctx, A, C, alpha, beta, uplo, transA);
+    if (syrk_triangular_supported(A, C)) {
+        // A narrow C is one tile wide, so the triangular grid has nothing to
+        // skip and would charge a full 128-wide tile for it. Auto splits the
+        // range at that point; either kernel can still be pinned by name.
+        const bool gram = route == SyrkRoute::Gram ||
+            (route == SyrkRoute::Auto && syrk_prefer_gram_tiles(C));
+        if (gram) {
+            return detail::syrk_gram_tiles(ctx, A, C, alpha, beta, uplo, transA);
+        }
+        if (route == SyrkRoute::Triangular || route == SyrkRoute::Auto) {
+            return detail::syrk_triangular_tiles(ctx, A, C, alpha, beta, uplo, transA);
+        }
     }
     if (route == SyrkRoute::Auto) {
         return syrk_vendor_cuda_raw(ctx, A, C, alpha, beta, uplo, transA);

--- a/src/backends/syrk_custom_dispatch.hh
+++ b/src/backends/syrk_custom_dispatch.hh
@@ -7,6 +7,22 @@
 
 namespace batchlas::backend {
 
+// True unless BATCHLAS_SYRK_VARIANT pins the vendor. The float router reads the
+// variable through its own enum; double and complex reach only the single-tile
+// Gram kernel, so they need just this one bit of it -- but they do need it, or
+// `=vendor` would silently measure the new route and report it as the old one.
+bool syrk_route_prefers_vendor();
+
+// True only when BATCHLAS_SYRK_VARIANT names the Gram kernel outright. HERK
+// does not take it automatically: measured on RTX 4090 / sm_89 in complex float
+// against the GEMM-plus-Hermitian-fold route it would replace, the tile kernel
+// loses at every Gram shape -- 0.217 vs 0.206 ms at n=32/batch 2048, 2.08 vs
+// 1.57 at n=128/batch 512. A complex multiply is four real ones, so herk is
+// compute bound where real syrk is bandwidth bound, and cuBLAS's cgemm is
+// simply better at compute than this kernel is. The route stays reachable so it
+// remains measurable and so the conjugation stays under test.
+bool syrk_route_requests_gram();
+
 bool syrk_use_cuda_custom(const Queue& ctx,
                           const MatrixView<float, MatrixFormat::Dense>& A,
                           const MatrixView<float, MatrixFormat::Dense>& C,

--- a/src/backends/syrk_gram_tiles.hh
+++ b/src/backends/syrk_gram_tiles.hh
@@ -1,0 +1,308 @@
+#pragma once
+
+// A single-tile batched SYRK for the shape ortho actually hands it: a tall,
+// skinny A and a small square C.
+//
+// The 128x128 triangular-tile kernel next door is built for the other end of
+// the range -- n in the hundreds, where the tile grid is many tiles wide and
+// skipping the ones outside the triangle is the whole point. It cannot serve
+// n <= 128 at all: one tile is the entire matrix, so the grid has nothing to
+// skip, and a 128-wide tile spends 128*128*k arithmetic on an n*n/2 answer. At
+// n = 32 that is a 32x overcharge, and the router (correctly) refused it, which
+// is why every Gram matrix in ortho fell through to a host loop over
+// cublasSsyrk and lost by up to two orders of magnitude at large batch.
+//
+// This kernel sizes the tile to n instead, and takes the triangle one level
+// further down -- at thread-tile granularity rather than block granularity:
+//
+//   * One tile covers the whole of C, so the two operands of A^T A are the
+//     same columns of A. There is one shared tile, not two, and A crosses the
+//     bus exactly once. That is the thing worth optimising at the skinny end,
+//     where arithmetic intensity is n/4 flop per byte -- 8 at n = 32 against
+//     the 4090's ridge of ~40, so the kernel is bandwidth bound by 5x and the
+//     measured 933 GB/s is the whole story.
+//   * Only the Lanes*(Lanes+1)/2 thread tiles that meet the requested triangle
+//     are carried -- 136 of 256 at n = 128, so 160 threads instead of 256.
+//     Merely masking the epilogue would leave the block doing exactly a GEMM's
+//     arithmetic, which is why the first cut of this kernel could match a GEMM
+//     at n = 128 and never beat one. The tail of the last warp stages and
+//     reaches every barrier but computes nothing.
+//   * The shared tile is stored [k][n] with the stride exactly n, so the
+//     fragment loads keep 16-byte alignment and issue as LDS.128. That matters
+//     more here than anywhere: an 8x8 thread tile reads 16 floats per k-step
+//     and issues 64 FFMAs, and the SM's 32-floats-per-clock shared path against
+//     its 128-FFMA-per-clock math path puts that ratio exactly on the balance
+//     point. There is no headroom to give away to a padded stride.
+//
+// Staging then has to reach that aligned layout without either giving up
+// coalescing on the global side or colliding on the shared side, and the two
+// transpose modes need opposite assignments to do it:
+//
+//   Trans    A is k x n, contiguous down k. One thread takes four adjacent
+//            reduction rows of one column, so eight lanes span a 128-byte
+//            run of it.
+//   NoTrans  A is n x k, contiguous across n. One thread takes four adjacent
+//            columns of one reduction row: a float4 either side.
+
+#include "triangular_tiles.hh"
+
+#include "../queue.hh"
+#include "../util/kernel-trace.hh"
+
+#include <blas/enums.hh>
+#include <blas/matrix.hh>
+
+#include <sycl/sycl.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace batchlas::backend::detail {
+
+// The output tile is the whole matrix, so this is also the largest n the
+// kernel can serve.
+inline constexpr int kGramMaxTile = 128;
+
+template <typename T, int NTile, int ThreadTile, int KC, bool TransOperand>
+class SyrkGramTilesKernel;
+
+template <typename T, int NTile, int ThreadTile, int KC, bool TransOperand>
+Event launch_syrk_gram_tiles(Queue& ctx,
+                             const MatrixView<T, MatrixFormat::Dense>& A,
+                             const MatrixView<T, MatrixFormat::Dense>& C,
+                             T alpha,
+                             T beta,
+                             Uplo uplo) {
+    BATCHLAS_KERNEL_TRACE_SCOPE("syrk_cuda_custom.gram_tiles");
+
+    static_assert(NTile % ThreadTile == 0, "the thread grid has to tile the output exactly");
+    static_assert(ThreadTile % 4 == 0, "fragments are loaded as 4-wide bands");
+    static_assert(KC % 4 == 0, "staging moves whole packets");
+
+    constexpr int Lanes = NTile / ThreadTile;          // thread tiles per side
+    constexpr int TriTiles = Lanes * (Lanes + 1) / 2;  // ... that meet the triangle
+    constexpr int Threads = ((TriTiles + 31) / 32) * 32;
+    constexpr int SPad = NTile;                        // aligned: LDS.128 fragments
+    constexpr int Bands = ThreadTile / 4;              // vectorized bands per thread
+    constexpr int Packs = NTile / 4;                   // 4-wide packets per row
+    constexpr int SwizzleMask = Packs - 1;
+    constexpr int Packets = KC * Packs;
+    static_assert((Packs & SwizzleMask) == 0, "the swizzle needs a power-of-two packet count");
+
+    const int n = static_cast<int>(C.rows());
+    const int k = TransOperand ? static_cast<int>(A.rows()) : static_cast<int>(A.cols());
+    const int batch = A.batch_size();
+
+    // Taking a staging thread's four elements as one 128-bit load was tried and
+    // measured slower everywhere (n = 64 batch 1024: 0.333 -> 0.384 ms). The
+    // four predicated scalar loads land in one cache line, so the merge saves
+    // no traffic, and the branch it needs costs more than the instructions it
+    // removes. Left as four loads deliberately.
+
+    const sycl::range<2> local(1, static_cast<size_t>(Threads));
+    const sycl::range<2> global(static_cast<size_t>(batch), static_cast<size_t>(Threads));
+
+    ctx->submit([&](sycl::handler& h) {
+        sycl::local_accessor<T, 1> tile(sycl::range<1>(KC * SPad), h);
+
+        const T* a_ptr = A.data_ptr();
+        T* c_ptr = C.data_ptr();
+        const int lda = A.ld();
+        const int ldc = C.ld();
+        const int stride_a = A.stride();
+        const int stride_c = C.stride();
+        const bool lower = uplo == Uplo::Lower;
+
+        h.parallel_for<SyrkGramTilesKernel<T, NTile, ThreadTile, KC, TransOperand>>(
+            sycl::nd_range<2>(global, local), [=](sycl::nd_item<2> item) {
+                const int bid = static_cast<int>(item.get_group(0));
+                if (bid >= batch) {
+                    return;
+                }
+                const int tid = static_cast<int>(item.get_local_id(1));
+                const bool active = tid < TriTiles;
+
+                int bi = 0;
+                int bj = 0;
+                triangular_tile_decode(active ? tid : 0, bi, bj);
+                const int tr = lower ? bi : bj;   // row tile
+                const int tc = lower ? bj : bi;   // column tile
+
+                const T* Ab = a_ptr + static_cast<std::ptrdiff_t>(bid) * stride_a;
+                T* Cb = c_ptr + static_cast<std::ptrdiff_t>(bid) * stride_c;
+                T* sh = tile.template get_multi_ptr<sycl::access::decorated::no>().get();
+
+                // Packet q of reduction row kk lives at q ^ (kk / 4) instead of
+                // q. An aligned stride alone would put every lane of a staging
+                // write in the same bank -- the rows a lane writes are 4 apart
+                // and the stride is a multiple of 32, so the row index drops out
+                // and only the column is left to separate them. Rotating the
+                // packet by the row group puts it back, and because the rotation
+                // is by whole 4-wide packets the fragment loads stay 16-byte
+                // aligned and stay LDS.128. Both sides come out conflict-free.
+                auto swizzle = [](int packet, int kk) {
+                    return packet ^ ((kk >> 2) & SwizzleMask);
+                };
+
+                T accum[ThreadTile][ThreadTile];
+#pragma unroll
+                for (int i = 0; i < ThreadTile; ++i) {
+#pragma unroll
+                    for (int j = 0; j < ThreadTile; ++j) {
+                        accum[i][j] = T(0);
+                    }
+                }
+
+                for (int k0 = 0; k0 < k; k0 += KC) {
+                    // The tile is always filled to its full KC x NTile, with
+                    // zeros for anything off the end of A, so the inner loop
+                    // below carries no bounds checks and a short n or k simply
+                    // contributes nothing.
+                    if constexpr (TransOperand) {
+                        // Four adjacent reduction rows of one column. Eight
+                        // lanes cover a column's whole 128-byte run, so the
+                        // global side stays coalesced; the shared side pays a
+                        // bank conflict for it, which is the cheaper half --
+                        // the tile is written once and read KC times over.
+                        for (int flat = tid; flat < Packets; flat += Threads) {
+                            const int col = flat / (KC / 4);
+                            const int kk0 = (flat % (KC / 4)) * 4;
+                            const bool col_ok = col < n;
+                            const int phys = (swizzle(col >> 2, kk0) << 2) | (col & 3);
+#pragma unroll
+                            for (int i = 0; i < 4; ++i) {
+                                const int gk = k0 + kk0 + i;
+                                sh[(kk0 + i) * SPad + phys] =
+                                    (col_ok && gk < k)
+                                    ? Ab[gk + static_cast<std::ptrdiff_t>(col) * lda]
+                                    : T(0);
+                            }
+                        }
+                    } else {
+                        for (int flat = tid; flat < Packets; flat += Threads) {
+                            const int kk = flat / Packs;
+                            const int col0 = (flat % Packs) * 4;
+                            const int gk = k0 + kk;
+                            const bool k_ok = gk < k;
+                            const int phys = swizzle(col0 >> 2, kk) << 2;
+#pragma unroll
+                            for (int i = 0; i < 4; ++i) {
+                                const int col = col0 + i;
+                                sh[kk * SPad + phys + i] =
+                                    (k_ok && col < n)
+                                    ? Ab[col + static_cast<std::ptrdiff_t>(gk) * lda]
+                                    : T(0);
+                            }
+                        }
+                    }
+                    item.barrier(sycl::access::fence_space::local_space);
+
+                    if (active) {
+#pragma unroll 4
+                        for (int p = 0; p < KC; ++p) {
+                            const T* row = &sh[p * SPad];
+                            T af[ThreadTile];
+                            T bf[ThreadTile];
+#pragma unroll
+                            for (int b = 0; b < Bands; ++b) {
+                                // A thread's rows and columns are contiguous,
+                                // and have to be: the triangular decode below
+                                // decides a whole thread tile is inside the
+                                // requested half from its tile indices alone.
+                                // Splitting the 8 into two bands 64 apart --
+                                // which is what the square 128x128 kernels do
+                                // to spread shared-memory banks -- makes that
+                                // false, and it fails quietly: thread (0,1)
+                                // then owns element (64,4), which is in the
+                                // lower triangle while its tile is not, so
+                                // nothing writes it.
+                                const int qa = swizzle(tr * Bands + b, p);
+                                const int qb = swizzle(tc * Bands + b, p);
+                                const TileVec4<T> va = tile_vec4(row + qa * 4);
+                                const TileVec4<T> vb = tile_vec4(row + qb * 4);
+#pragma unroll
+                                for (int e = 0; e < 4; ++e) {
+                                    af[b * 4 + e] = va.v[e];
+                                    bf[b * 4 + e] = vb.v[e];
+                                }
+                            }
+#pragma unroll
+                            for (int i = 0; i < ThreadTile; ++i) {
+#pragma unroll
+                                for (int j = 0; j < ThreadTile; ++j) {
+                                    accum[i][j] += af[i] * bf[j];
+                                }
+                            }
+                        }
+                    }
+                    item.barrier(sycl::access::fence_space::local_space);
+                }
+
+                if (!active) {
+                    return;
+                }
+
+                // Only the requested triangle is written. BLAS forbids touching
+                // the other half, and with beta != 0 it forbids reading it too.
+                // Off-diagonal thread tiles lie wholly inside it; the ones on
+                // the diagonal are the only ones the element mask trims.
+                const bool on_diagonal = bi == bj;
+#pragma unroll
+                for (int j = 0; j < ThreadTile; ++j) {
+                    const int col = tc * ThreadTile + j;
+                    if (col >= n) {
+                        continue;
+                    }
+#pragma unroll
+                    for (int i = 0; i < ThreadTile; ++i) {
+                        const int row = tr * ThreadTile + i;
+                        if (row >= n) {
+                            continue;
+                        }
+                        if (on_diagonal && (lower ? row < col : row > col)) {
+                            continue;
+                        }
+                        T* p = &Cb[row + static_cast<std::ptrdiff_t>(col) * ldc];
+                        *p = beta == T(0) ? alpha * accum[i][j] : alpha * accum[i][j] + beta * *p;
+                    }
+                }
+            });
+    });
+
+    return ctx.get_event();
+}
+
+// The tile has to cover n, and wants to be no wider than that: every column of
+// slack is arithmetic thrown away. ThreadTile then follows from keeping the
+// thread tile at the 4-wide band the vectorized fragment loads are built on.
+template <typename T>
+Event syrk_gram_tiles(Queue& ctx,
+                      const MatrixView<T, MatrixFormat::Dense>& A,
+                      const MatrixView<T, MatrixFormat::Dense>& C,
+                      T alpha,
+                      T beta,
+                      Uplo uplo,
+                      Transpose transA) {
+    const int n = static_cast<int>(C.rows());
+    const bool trans = transA != Transpose::NoTrans;
+
+    auto dispatch = [&](auto tile_tag) {
+        constexpr int NTile = decltype(tile_tag)::value;
+        constexpr int ThreadTile = 4;
+        constexpr int KC = 32;
+        return trans
+            ? launch_syrk_gram_tiles<T, NTile, ThreadTile, KC, true>(ctx, A, C, alpha, beta, uplo)
+            : launch_syrk_gram_tiles<T, NTile, ThreadTile, KC, false>(ctx, A, C, alpha, beta, uplo);
+    };
+
+    if (n <= 32) {
+        return dispatch(std::integral_constant<int, 32>{});
+    }
+    if (n <= 64) {
+        return dispatch(std::integral_constant<int, 64>{});
+    }
+    return dispatch(std::integral_constant<int, 128>{});
+}
+
+} // namespace batchlas::backend::detail

--- a/src/backends/syrk_gram_tiles.hh
+++ b/src/backends/syrk_gram_tiles.hh
@@ -64,42 +64,6 @@ namespace batchlas::backend::detail {
 // kernel can serve.
 inline constexpr int kGramMaxTile = 128;
 
-// Conjugation is a no-op on a real scalar, which is what lets one kernel serve
-// both syrk and herk rather than two near-copies.
-template <typename T>
-inline T conj_if(const T& value) {
-    if constexpr (sycl::detail::is_complex<T>::value) {
-        return std::conj(value);
-    } else {
-        return value;
-    }
-}
-
-// accum += a * b, written out rather than delegated to std::complex.
-//
-// `std::complex<float>::operator*` lowers to the __mulsc3 libcall, which
-// implements C99 Annex G -- a branch on Inf and NaN around every single
-// multiply. In the innermost loop of a GEMM that is ruinous and it is invisible
-// in the source: the first complex build of this kernel ran at 1.2 TFLOP/s
-// against float's 13.8, and at n = 128 took 38 ms where a cuBLAS GEMM took 1.5.
-// Four real multiplies and two adds is the whole operation; there is no
-// exceptional case here worth a branch, because a NaN in the input is already
-// a NaN in the answer.
-template <typename T>
-inline void accumulate(T& accum, const T& a, const T& b) {
-    if constexpr (sycl::detail::is_complex<T>::value) {
-        using Real = typename T::value_type;
-        const Real ar = a.real();
-        const Real ai = a.imag();
-        const Real br = b.real();
-        const Real bi = b.imag();
-        accum = T(accum.real() + ar * br - ai * bi,
-                  accum.imag() + ar * bi + ai * br);
-    } else {
-        accum += a * b;
-    }
-}
-
 // Drops the imaginary part BLAS guarantees is zero on a HERK diagonal. It is
 // zero only up to rounding, and leaving the residue there would make a matrix
 // that is not quite Hermitian, which the eigensolvers downstream do notice.
@@ -267,10 +231,8 @@ Event launch_syrk_gram_tiles(Queue& ctx,
                                 // nothing writes it.
                                 const int qa = swizzle(tr * Bands + b, p);
                                 const int qb = swizzle(tc * Bands + b, p);
-                                T va[4];
-                                T vb[4];
-                                tile_load4(row + qa * 4, va);
-                                tile_load4(row + qb * 4, vb);
+                                const TileVec4<T> va = tile_load4(row + qa * 4);
+                                const TileVec4<T> vb = tile_load4(row + qb * 4);
 #pragma unroll
                                 for (int e = 0; e < 4; ++e) {
                                     // HERK conjugates whichever operand carries
@@ -280,11 +242,11 @@ Event launch_syrk_gram_tiles(Queue& ctx,
                                     // Hermitian matrix, so this cannot be
                                     // caught by inspecting the result's shape.
                                     if constexpr (Conjugate) {
-                                        af[b * 4 + e] = TransOperand ? conj_if(va[e]) : va[e];
-                                        bf[b * 4 + e] = TransOperand ? vb[e] : conj_if(vb[e]);
+                                        af[b * 4 + e] = TransOperand ? conj_if(va.v[e]) : va.v[e];
+                                        bf[b * 4 + e] = TransOperand ? vb.v[e] : conj_if(vb.v[e]);
                                     } else {
-                                        af[b * 4 + e] = va[e];
-                                        bf[b * 4 + e] = vb[e];
+                                        af[b * 4 + e] = va.v[e];
+                                        bf[b * 4 + e] = vb.v[e];
                                     }
                                 }
                             }
@@ -292,7 +254,7 @@ Event launch_syrk_gram_tiles(Queue& ctx,
                             for (int i = 0; i < ThreadTile; ++i) {
 #pragma unroll
                                 for (int j = 0; j < ThreadTile; ++j) {
-                                    accumulate(accum[i][j], af[i], bf[j]);
+                                    accum[i][j] = accumulate(accum[i][j], af[i], bf[j]);
                                 }
                             }
                         }

--- a/src/backends/syrk_gram_tiles.hh
+++ b/src/backends/syrk_gram_tiles.hh
@@ -64,10 +64,58 @@ namespace batchlas::backend::detail {
 // kernel can serve.
 inline constexpr int kGramMaxTile = 128;
 
-template <typename T, int NTile, int ThreadTile, int KC, bool TransOperand>
+// Conjugation is a no-op on a real scalar, which is what lets one kernel serve
+// both syrk and herk rather than two near-copies.
+template <typename T>
+inline T conj_if(const T& value) {
+    if constexpr (sycl::detail::is_complex<T>::value) {
+        return std::conj(value);
+    } else {
+        return value;
+    }
+}
+
+// accum += a * b, written out rather than delegated to std::complex.
+//
+// `std::complex<float>::operator*` lowers to the __mulsc3 libcall, which
+// implements C99 Annex G -- a branch on Inf and NaN around every single
+// multiply. In the innermost loop of a GEMM that is ruinous and it is invisible
+// in the source: the first complex build of this kernel ran at 1.2 TFLOP/s
+// against float's 13.8, and at n = 128 took 38 ms where a cuBLAS GEMM took 1.5.
+// Four real multiplies and two adds is the whole operation; there is no
+// exceptional case here worth a branch, because a NaN in the input is already
+// a NaN in the answer.
+template <typename T>
+inline void accumulate(T& accum, const T& a, const T& b) {
+    if constexpr (sycl::detail::is_complex<T>::value) {
+        using Real = typename T::value_type;
+        const Real ar = a.real();
+        const Real ai = a.imag();
+        const Real br = b.real();
+        const Real bi = b.imag();
+        accum = T(accum.real() + ar * br - ai * bi,
+                  accum.imag() + ar * bi + ai * br);
+    } else {
+        accum += a * b;
+    }
+}
+
+// Drops the imaginary part BLAS guarantees is zero on a HERK diagonal. It is
+// zero only up to rounding, and leaving the residue there would make a matrix
+// that is not quite Hermitian, which the eigensolvers downstream do notice.
+template <typename T>
+inline T real_part_of(const T& value) {
+    if constexpr (sycl::detail::is_complex<T>::value) {
+        return T(value.real(), typename T::value_type(0));
+    } else {
+        return value;
+    }
+}
+
+template <typename T, int NTile, int ThreadTile, int KC, bool TransOperand, bool Conjugate>
 class SyrkGramTilesKernel;
 
-template <typename T, int NTile, int ThreadTile, int KC, bool TransOperand>
+template <typename T, int NTile, int ThreadTile, int KC, bool TransOperand, bool Conjugate>
 Event launch_syrk_gram_tiles(Queue& ctx,
                              const MatrixView<T, MatrixFormat::Dense>& A,
                              const MatrixView<T, MatrixFormat::Dense>& C,
@@ -114,7 +162,7 @@ Event launch_syrk_gram_tiles(Queue& ctx,
         const int stride_c = C.stride();
         const bool lower = uplo == Uplo::Lower;
 
-        h.parallel_for<SyrkGramTilesKernel<T, NTile, ThreadTile, KC, TransOperand>>(
+        h.parallel_for<SyrkGramTilesKernel<T, NTile, ThreadTile, KC, TransOperand, Conjugate>>(
             sycl::nd_range<2>(global, local), [=](sycl::nd_item<2> item) {
                 const int bid = static_cast<int>(item.get_group(0));
                 if (bid >= batch) {
@@ -219,19 +267,32 @@ Event launch_syrk_gram_tiles(Queue& ctx,
                                 // nothing writes it.
                                 const int qa = swizzle(tr * Bands + b, p);
                                 const int qb = swizzle(tc * Bands + b, p);
-                                const TileVec4<T> va = tile_vec4(row + qa * 4);
-                                const TileVec4<T> vb = tile_vec4(row + qb * 4);
+                                T va[4];
+                                T vb[4];
+                                tile_load4(row + qa * 4, va);
+                                tile_load4(row + qb * 4, vb);
 #pragma unroll
                                 for (int e = 0; e < 4; ++e) {
-                                    af[b * 4 + e] = va.v[e];
-                                    bf[b * 4 + e] = vb.v[e];
+                                    // HERK conjugates whichever operand carries
+                                    // the ^H. With transA = ConjTrans that is
+                                    // the row index, with NoTrans the column;
+                                    // conjugating the wrong one still yields a
+                                    // Hermitian matrix, so this cannot be
+                                    // caught by inspecting the result's shape.
+                                    if constexpr (Conjugate) {
+                                        af[b * 4 + e] = TransOperand ? conj_if(va[e]) : va[e];
+                                        bf[b * 4 + e] = TransOperand ? vb[e] : conj_if(vb[e]);
+                                    } else {
+                                        af[b * 4 + e] = va[e];
+                                        bf[b * 4 + e] = vb[e];
+                                    }
                                 }
                             }
 #pragma unroll
                             for (int i = 0; i < ThreadTile; ++i) {
 #pragma unroll
                                 for (int j = 0; j < ThreadTile; ++j) {
-                                    accum[i][j] += af[i] * bf[j];
+                                    accumulate(accum[i][j], af[i], bf[j]);
                                 }
                             }
                         }
@@ -264,7 +325,17 @@ Event launch_syrk_gram_tiles(Queue& ctx,
                             continue;
                         }
                         T* p = &Cb[row + static_cast<std::ptrdiff_t>(col) * ldc];
-                        *p = beta == T(0) ? alpha * accum[i][j] : alpha * accum[i][j] + beta * *p;
+                        T value = beta == T(0) ? alpha * accum[i][j]
+                                               : alpha * accum[i][j] + beta * *p;
+                        // HERK's diagonal is real by construction and BLAS says
+                        // so; rounding leaves a residue that would make C only
+                        // almost Hermitian.
+                        if constexpr (Conjugate) {
+                            if (row == col) {
+                                value = real_part_of(value);
+                            }
+                        }
+                        *p = value;
                     }
                 }
             });
@@ -273,10 +344,41 @@ Event launch_syrk_gram_tiles(Queue& ctx,
     return ctx.get_event();
 }
 
+// Everything the kernel needs from the problem, independent of scalar type and
+// of the queue. Only the tile-to-n range is served: above kGramMaxTile there is
+// no single tile to put C in, and for anything but float that is the end of the
+// road, since syrk_triangular_tiles' staging and fragment loads are written
+// around a 128-bit packet that only float has.
+template <typename T>
+bool syrk_gram_supported(const MatrixView<T, MatrixFormat::Dense>& A,
+                         const MatrixView<T, MatrixFormat::Dense>& C,
+                         Transpose transA,
+                         bool conjugated) {
+    if (C.rows() != C.cols() || C.rows() <= 0 || C.rows() > kGramMaxTile) {
+        return false;
+    }
+    if (A.batch_size() != C.batch_size()) {
+        return false;
+    }
+    if (A.is_heterogeneous() || C.is_heterogeneous()) {
+        return false;
+    }
+    // SYRK spells A*A^T and must not be handed a ConjTrans; HERK spells A*A^H
+    // and must not be handed a plain Trans, which would be complex-symmetric.
+    if (conjugated ? (transA != Transpose::NoTrans && transA != Transpose::ConjTrans)
+                   : (transA == Transpose::ConjTrans)) {
+        return false;
+    }
+    const int n = C.rows();
+    const int k = transA == Transpose::NoTrans ? A.cols() : A.rows();
+    const int expected_n = transA == Transpose::NoTrans ? A.rows() : A.cols();
+    return expected_n == n && k > 0;
+}
+
 // The tile has to cover n, and wants to be no wider than that: every column of
 // slack is arithmetic thrown away. ThreadTile then follows from keeping the
 // thread tile at the 4-wide band the vectorized fragment loads are built on.
-template <typename T>
+template <typename T, bool Conjugate = false>
 Event syrk_gram_tiles(Queue& ctx,
                       const MatrixView<T, MatrixFormat::Dense>& A,
                       const MatrixView<T, MatrixFormat::Dense>& C,
@@ -289,11 +391,21 @@ Event syrk_gram_tiles(Queue& ctx,
 
     auto dispatch = [&](auto tile_tag) {
         constexpr int NTile = decltype(tile_tag)::value;
-        constexpr int ThreadTile = 4;
+        // A 4-wide thread tile puts 528 tiles -- 544 threads -- on the 128-wide
+        // case, which is what float wants and measured fastest there. A complex
+        // scalar cannot afford the block: two components per accumulator took it
+        // to 205 registers per work-item, and 544 x 205 is past the 65536 a
+        // work-group gets, which the runtime rejects outright rather than
+        // spilling. Doubling the thread tile quarters the thread count to 160
+        // and the same accumulators fit.
+        constexpr int ThreadTile =
+            (NTile == 128 && sycl::detail::is_complex<T>::value) ? 8 : 4;
         constexpr int KC = 32;
         return trans
-            ? launch_syrk_gram_tiles<T, NTile, ThreadTile, KC, true>(ctx, A, C, alpha, beta, uplo)
-            : launch_syrk_gram_tiles<T, NTile, ThreadTile, KC, false>(ctx, A, C, alpha, beta, uplo);
+            ? launch_syrk_gram_tiles<T, NTile, ThreadTile, KC, true, Conjugate>(
+                  ctx, A, C, alpha, beta, uplo)
+            : launch_syrk_gram_tiles<T, NTile, ThreadTile, KC, false, Conjugate>(
+                  ctx, A, C, alpha, beta, uplo);
     };
 
     if (n <= 32) {

--- a/src/backends/triangular_tiles.hh
+++ b/src/backends/triangular_tiles.hh
@@ -29,6 +29,31 @@ inline TileVec4<T>& tile_vec4(T* p) {
     return *reinterpret_cast<TileVec4<T>*>(p);
 }
 
+// Four contiguous elements into registers.
+//
+// For float the 4-wide packet is exactly a 128-bit LDS and the reinterpret is
+// how we get one. For anything wider it is not: four doubles are 32 bytes and
+// four complex<double> are 64, which no load form covers, and -- worse -- the
+// reinterpret asserts an alignment `sycl::local_accessor` never promised, since
+// it aligns to T and not to 4*sizeof(T). So wider scalars stay scalar. This is
+// the only thing standing between these kernels and a misaligned access in
+// double, and it is silent when wrong.
+template <typename T>
+inline void tile_load4(const T* p, T (&out)[4]) {
+    if constexpr (sizeof(T) == sizeof(float)) {
+        const TileVec4<T>& v = tile_vec4(p);
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            out[i] = v.v[i];
+        }
+    } else {
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            out[i] = p[i];
+        }
+    }
+}
+
 inline constexpr int kTriangularTile = 128;
 inline constexpr int kTriangularTileK = 8;
 

--- a/src/backends/triangular_tiles.hh
+++ b/src/backends/triangular_tiles.hh
@@ -29,6 +29,61 @@ inline TileVec4<T>& tile_vec4(T* p) {
     return *reinterpret_cast<TileVec4<T>*>(p);
 }
 
+// Conjugation is a no-op on a real scalar, which is what lets one kernel serve
+// both the plain and the ^H spellings rather than two near-copies.
+template <typename T>
+inline T conj_if(const T& value) {
+    if constexpr (sycl::detail::is_complex<T>::value) {
+        return std::conj(value);
+    } else {
+        return value;
+    }
+}
+
+// accum + a * b, written out rather than delegated to std::complex.
+//
+// `std::complex<float>::operator*` lowers to the __mulsc3 libcall, which
+// implements C99 Annex G -- a branch on Inf and NaN around every single
+// multiply. In the innermost loop of a GEMM that is ruinous and it is invisible
+// in the source: the first complex build of the Gram kernel ran at 1.2 TFLOP/s
+// against float's 13.8, and at n = 128 took 38 ms where a cuBLAS GEMM took 1.5.
+// Four real multiplies and two adds is the whole operation, and it folds to the
+// four FMAs a complex MAC should be; there is no exceptional case here worth a
+// branch, because a NaN in the input is already a NaN in the answer.
+//
+// Returns the new accumulator rather than updating one through a reference.
+// That is not a style choice: taking the address of an element of the
+// register-resident accumulator array is enough for the compiler to stop
+// believing it can stay in registers, and the array goes to local memory. It
+// cost 43% on float at m = 512 (0.659 -> 0.944 ms) when this was first written
+// with a `T&` out-parameter, with no other change.
+template <typename T>
+inline T accumulate(const T& accum, const T& a, const T& b) {
+    if constexpr (sycl::detail::is_complex<T>::value) {
+        using Real = typename T::value_type;
+        const Real ar = a.real();
+        const Real ai = a.imag();
+        const Real br = b.real();
+        const Real bi = b.imag();
+        return T(accum.real() + ar * br - ai * bi,
+                 accum.imag() + ar * bi + ai * br);
+    } else {
+        return accum + a * b;
+    }
+}
+
+template <typename T>
+inline void tile_store4(T* p, const TileVec4<T>& in) {
+    if constexpr (sizeof(T) == sizeof(float)) {
+        tile_vec4(p) = in;
+    } else {
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            p[i] = in.v[i];
+        }
+    }
+}
+
 // Four contiguous elements into registers.
 //
 // For float the 4-wide packet is exactly a 128-bit LDS and the reinterpret is
@@ -38,19 +93,20 @@ inline TileVec4<T>& tile_vec4(T* p) {
 // it aligns to T and not to 4*sizeof(T). So wider scalars stay scalar. This is
 // the only thing standing between these kernels and a misaligned access in
 // double, and it is silent when wrong.
+//
+// Returned by value for the same reason `accumulate` is: an out-parameter array
+// reference is an address the fragment registers do not survive.
 template <typename T>
-inline void tile_load4(const T* p, T (&out)[4]) {
+inline TileVec4<T> tile_load4(const T* p) {
     if constexpr (sizeof(T) == sizeof(float)) {
-        const TileVec4<T>& v = tile_vec4(p);
-#pragma unroll
-        for (int i = 0; i < 4; ++i) {
-            out[i] = v.v[i];
-        }
+        return tile_vec4(p);
     } else {
+        TileVec4<T> out;
 #pragma unroll
         for (int i = 0; i < 4; ++i) {
-            out[i] = p[i];
+            out.v[i] = p[i];
         }
+        return out;
     }
 }
 

--- a/src/backends/trmm_custom_dispatch.cc
+++ b/src/backends/trmm_custom_dispatch.cc
@@ -3,10 +3,14 @@
 #include "gemm_cublasdx_dispatch.hh"
 #include "gemm_variant.hh"
 #include "trmm_cublasdx_fused.hh"
+#include "trmm_triangular_tiles.hh"
 #include "cublasdx_dispatch_common.hh"
 
 #include "../util/kernel-trace.hh"
 
+#include <cctype>
+#include <cstdlib>
+#include <string>
 #include <algorithm>
 #include <stdexcept>
 
@@ -28,6 +32,67 @@ TrmmVariantRequest trmm_variant_request() {
                                                   TrmmVariantRequest::CuBLASDx,
                                                   TrmmVariantRequest::Auto);
 }
+
+// BATCHLAS_TRMM_VARIANT=triangular pins the tile kernel, =vendor the expansion
+// plus GEMM it replaces, so the two stay independently measurable.
+bool trmm_triangular_requested() {
+    const char* raw = std::getenv("BATCHLAS_TRMM_VARIANT");
+    if (raw == nullptr) {
+        return false;
+    }
+    std::string value(raw);
+    for (char& ch : value) {
+        ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+    }
+    return value == "triangular" || value == "tiles";
+}
+
+// Every left-side float problem with a homogeneous batch. The kernel indexes
+// both operands as base + batch * stride, which a batch of unrelated pointers
+// or differing shapes is out of reach of; everything else it handles, because
+// uplo, trans and diag are loop bounds and a staging mask rather than separate
+// kernels.
+bool trmm_triangular_supported(const MatrixView<float, MatrixFormat::Dense>& A,
+                               const MatrixView<float, MatrixFormat::Dense>& B,
+                               const MatrixView<float, MatrixFormat::Dense>& C,
+                               Side side) {
+    if (side != Side::Left) {
+        return false;
+    }
+    if (A.rows() != A.cols() || A.rows() != C.rows()) {
+        return false;
+    }
+    if (A.batch_size() != B.batch_size() || B.batch_size() != C.batch_size()) {
+        return false;
+    }
+    if (B.rows() != C.rows() || B.cols() != C.cols()) {
+        return false;
+    }
+    if (A.is_heterogeneous() || B.is_heterogeneous() || C.is_heterogeneous()) {
+        return false;
+    }
+    return C.rows() > 0 && C.cols() > 0;
+}
+
+// There is no threshold here, and the first cut of this router had one because
+// it asked the wrong question. Whether trmm beats the *gemm* spelling of the
+// same product depends strongly on m -- see the header of
+// trmm_triangular_tiles.hh -- but that is a question for the caller. What this
+// router chooses between is the tile kernel and the expansion-plus-GEMM, and
+// against that the tile kernel wins nearly everywhere, including exactly the
+// m = 128..256 band a gemm-calibrated threshold had excluded.
+//
+// Measured in float on RTX 4090 / sm_89, tile against vendor, at batch sizes
+// that saturate (ms):
+//
+//   m=128 nC=512  batch 1024   0.698 vs 0.784
+//   m=128 nC=1024 batch 512    0.686 vs 0.687
+//   m=256 nC=256  batch 512    0.536 vs 0.692
+//   m=256 nC=1024 batch 256    0.915 vs 0.855   <- the one loss, 7%
+//
+// Gating on m therefore cost up to 1.29x on the shapes it was meant to protect.
+// The single 7% cell is not worth a special case that would have to be
+// re-tuned every time either route changes.
 
 bool trmm_problem_supported(const MatrixView<float, MatrixFormat::Dense>& A,
                             const MatrixView<float, MatrixFormat::Dense>& B,
@@ -77,6 +142,15 @@ bool trmm_use_cuda_custom(const Queue& ctx,
                           Uplo uplo,
                           Transpose transA,
                           Diag) {
+    // `=vendor` has to keep meaning the vendor even though the tile kernel is
+    // now the default: it is the only "before" a measurement can be taken
+    // against, and a pin that silently returns the new route would report the
+    // new route as the old one.
+    if (detail::is_gpu_queue(ctx) && trmm_triangular_supported(A, B, C, side) &&
+        (trmm_triangular_requested() ||
+         trmm_variant_request() != TrmmVariantRequest::Vendor)) {
+        return true;
+    }
     const auto request = trmm_variant_request();
     const bool problem_supported = trmm_problem_supported(A, B, C, side, uplo, transA);
     return detail::should_use_cublasdx(ctx,
@@ -102,6 +176,13 @@ Event trmm_cuda_custom(Queue& ctx,
             throw_forced_trmm_unavailable("the active queue is not a GPU queue");
         }
         return trmm_vendor_cuda_raw(ctx, A, B, C, alpha, side, uplo, transA, diag);
+    }
+    // The tile kernel is the only route that respects the triangle rather than
+    // expanding it, so it is what the automatic choice takes wherever it fits.
+    if (trmm_triangular_supported(A, B, C, side) &&
+        (trmm_triangular_requested() ||
+         (!forced && trmm_variant_request() != TrmmVariantRequest::Vendor))) {
+        return detail::trmm_triangular_tiles(ctx, A, B, C, alpha, uplo, transA, diag);
     }
     if (!trmm_problem_supported(A, B, C, side, uplo, transA)) {
         if (forced) {

--- a/src/backends/trmm_custom_dispatch.cc
+++ b/src/backends/trmm_custom_dispatch.cc
@@ -130,6 +130,10 @@ bool trmm_prefer_cuda_custom_heuristic(const MatrixView<float, MatrixFormat::Den
 
 } // namespace
 
+bool trmm_route_prefers_vendor() {
+    return trmm_variant_request() == TrmmVariantRequest::Vendor && !trmm_triangular_requested();
+}
+
 bool trmm_cuda_custom_forced() {
     return trmm_variant_request() == TrmmVariantRequest::CuBLASDx;
 }

--- a/src/backends/trmm_custom_dispatch.hh
+++ b/src/backends/trmm_custom_dispatch.hh
@@ -9,6 +9,12 @@ namespace batchlas::backend {
 
 bool trmm_cuda_custom_forced();
 
+// True when BATCHLAS_TRMM_VARIANT pins the vendor. The float router reads the
+// variable through its own enum; double and complex reach only the tile kernel,
+// so they need just this one bit of it -- but they do need it, or `=vendor`
+// would silently measure the new route and report it as the old one.
+bool trmm_route_prefers_vendor();
+
 bool trmm_use_cuda_custom(const Queue& ctx,
                           const MatrixView<float, MatrixFormat::Dense>& A,
                           const MatrixView<float, MatrixFormat::Dense>& B,

--- a/src/backends/trmm_triangular_tiles.hh
+++ b/src/backends/trmm_triangular_tiles.hh
@@ -1,0 +1,341 @@
+#pragma once
+
+// A batched TRMM that actually skips the zero half of A.
+//
+// Until now nothing in this tree did. `src/extensions/trmm.cc` recurses only
+// until the block is 256 wide and then calls the very GEMM it is meant to
+// replace, so for any ib in {16,32,64,128,256} -- which is every block size
+// ormqr and ormbr use -- the triangular structure was never exploited at all.
+// On CUDA the operation does not even reach that recursion: `trmm_vendor_impl`
+// expands the triangle into a k x k x batch scratch buffer and hands the result
+// to a full GEMM, paying an extra write and an extra read of the expansion for
+// the privilege of doing twice the arithmetic. PR #61 measured the consequence
+// and correctly refused to use trmm anywhere.
+//
+// The structure worth exploiting is in the k loop, not in a mask. For
+// C = alpha * op(A) * B with op(A) upper triangular, output row i only ever
+// touches op(A)_{i,p} for p >= i, so an output tile starting at row m0 can
+// start its reduction at p = m0 and skip everything before it -- a loop bound
+// rather than a predicate, so the arithmetic is not done and then discarded.
+// Only the one k-tile straddling the diagonal needs masking, and that mask
+// lives in the A staging where the tile is small and read once.
+//
+// How much that saves depends entirely on how many row tiles m covers, and it
+// is worth being precise because it is not the textbook 2x: with R row tiles
+// the reduction shrinks to (R+1)/2R of the square, so 1.0x at R = 1, 1.33x at
+// R = 2, and only 1.78x by R = 8. `trmm_prefer_triangular_tiles` carries the
+// measured consequence -- this kernel is ahead of the vendor at m <= 64 (on
+// fusion, not arithmetic) and at m >= 512, and behind it in between.
+//
+// Which end of the reduction is skipped comes from uplo and trans together:
+// transposing an upper triangle gives a lower one, so the kernel keys off
+// `lower_eff = (uplo == Lower) != transposed` and nothing else.
+//
+// The tile is sized to m rather than fixed at 128, for the same reason the Gram
+// SYRK kernel next door sizes its tile to n: ormqr's W2 = T^H W1 has m = ib in
+// the tens, and a 128-row tile would spend four times the arithmetic on it.
+//
+// Shared layout, staging and the packet swizzle are those of
+// syrk_gram_tiles.hh -- an aligned stride so the fragment loads issue as
+// LDS.128, and a packet rotation by reduction-row group so the staging writes
+// that have to transpose do not all land in the same bank.
+
+#include "triangular_tiles.hh"
+
+#include "../queue.hh"
+#include "../util/kernel-trace.hh"
+
+#include <blas/enums.hh>
+#include <blas/matrix.hh>
+
+#include <sycl/sycl.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace batchlas::backend::detail {
+
+inline constexpr int kTrmmTileN = 128;
+inline constexpr int kTrmmTileK = 16;
+
+// Threads per side of the tile, and hence the per-thread tile. A 128-wide side
+// gets 16 lanes of 8; anything narrower keeps the 4-wide band the vectorized
+// fragment load is built on and drops lanes instead.
+inline constexpr int trmm_lanes(int tile) { return tile >= 64 ? 16 : 8; }
+
+template <typename T, int TileM>
+class TrmmTriangularTilesKernel;
+
+template <typename T, int TileM>
+Event launch_trmm_triangular_tiles(Queue& ctx,
+                                   const MatrixView<T, MatrixFormat::Dense>& A,
+                                   const MatrixView<T, MatrixFormat::Dense>& B,
+                                   const MatrixView<T, MatrixFormat::Dense>& C,
+                                   T alpha,
+                                   Uplo uplo,
+                                   Transpose transA,
+                                   Diag diag) {
+    BATCHLAS_KERNEL_TRACE_SCOPE("trmm_cuda_custom.triangular_tiles");
+
+    constexpr int TileN = kTrmmTileN;
+    constexpr int TileK = kTrmmTileK;
+    constexpr int LocalRows = trmm_lanes(TileM);
+    constexpr int LocalCols = trmm_lanes(TileN);
+    constexpr int ThreadRows = TileM / LocalRows;
+    constexpr int ThreadCols = TileN / LocalCols;
+    constexpr int Threads = LocalRows * LocalCols;
+    constexpr int SA = TileM;                    // aligned strides
+    constexpr int SB = TileN;
+    constexpr int PacksA = TileM / 4;
+    constexpr int PacksB = TileN / 4;
+    constexpr int BandsR = ThreadRows / 4;
+    constexpr int BandsC = ThreadCols / 4;
+    constexpr int BandSpanR = TileM / BandsR;
+    constexpr int BandSpanC = TileN / BandsC;
+    constexpr int PacketsA = TileK * PacksA;
+    constexpr int PacketsB = TileK * PacksB;
+
+    static_assert(ThreadRows % 4 == 0 && ThreadCols % 4 == 0, "fragments are 4-wide bands");
+    static_assert(TileM % TileK == 0, "the diagonal tile has to fall on a k boundary");
+    static_assert((PacksA & (PacksA - 1)) == 0 && (PacksB & (PacksB - 1)) == 0,
+                  "the swizzle needs a power-of-two packet count");
+
+    const int m = static_cast<int>(C.rows());
+    const int n = static_cast<int>(C.cols());
+    const int batch = A.batch_size();
+    const int tiles_m = (m + TileM - 1) / TileM;
+    const int tiles_n = (n + TileN - 1) / TileN;
+
+    const bool transposed = transA != Transpose::NoTrans;
+    // Transposing an upper triangle gives a lower one, so this single flag is
+    // everything the kernel needs from uplo and trans.
+    const bool lower_eff = (uplo == Uplo::Lower) != transposed;
+    const bool unit = diag == Diag::Unit;
+
+    const sycl::range<3> local(1, 1, static_cast<size_t>(Threads));
+    const sycl::range<3> global(static_cast<size_t>(batch),
+                                static_cast<size_t>(tiles_m * tiles_n),
+                                static_cast<size_t>(Threads));
+
+    ctx->submit([&](sycl::handler& h) {
+        sycl::local_accessor<T, 1> tile_a(sycl::range<1>(TileK * SA), h);
+        sycl::local_accessor<T, 1> tile_b(sycl::range<1>(TileK * SB), h);
+
+        const T* a_ptr = A.data_ptr();
+        const T* b_ptr = B.data_ptr();
+        T* c_ptr = C.data_ptr();
+        const int lda = A.ld();
+        const int ldb = B.ld();
+        const int ldc = C.ld();
+        const int stride_a = A.stride();
+        const int stride_b = B.stride();
+        const int stride_c = C.stride();
+
+        h.parallel_for<TrmmTriangularTilesKernel<T, TileM>>(
+            sycl::nd_range<3>(global, local), [=](sycl::nd_item<3> item) {
+                const int bid = static_cast<int>(item.get_group(0));
+                if (bid >= batch) {
+                    return;
+                }
+                const int gid = static_cast<int>(item.get_group(1));
+                const int tile_row = gid / tiles_n;
+                const int tile_col = gid % tiles_n;
+                const int m0 = tile_row * TileM;
+                const int n0 = tile_col * TileN;
+
+                const int tid = static_cast<int>(item.get_local_id(2));
+                const int tr = tid % LocalRows;
+                const int tc = tid / LocalRows;
+
+                const T* Ab = a_ptr + static_cast<std::ptrdiff_t>(bid) * stride_a;
+                const T* Bb = b_ptr + static_cast<std::ptrdiff_t>(bid) * stride_b;
+                T* Cb = c_ptr + static_cast<std::ptrdiff_t>(bid) * stride_c;
+                T* sa = tile_a.template get_multi_ptr<sycl::access::decorated::no>().get();
+                T* sb = tile_b.template get_multi_ptr<sycl::access::decorated::no>().get();
+
+                auto swizzle_a = [](int packet, int pp) {
+                    return packet ^ ((pp >> 2) & (PacksA - 1));
+                };
+                auto swizzle_b = [](int packet, int pp) {
+                    return packet ^ ((pp >> 2) & (PacksB - 1));
+                };
+
+                T accum[ThreadRows][ThreadCols];
+#pragma unroll
+                for (int i = 0; i < ThreadRows; ++i) {
+#pragma unroll
+                    for (int j = 0; j < ThreadCols; ++j) {
+                        accum[i][j] = T(0);
+                    }
+                }
+
+                // The whole point: an output tile rooted at row m0 reads only
+                // the part of the reduction its triangle can reach.
+                const int p_begin = lower_eff ? 0 : m0;
+                const int p_end = lower_eff ? sycl::min(m, m0 + TileM) : m;
+
+                for (int p0 = p_begin; p0 < p_end; p0 += TileK) {
+                    // op(A): rows [m0, m0+TileM) against reduction [p0, p0+TileK),
+                    // with the triangle, the unit diagonal and the edges of the
+                    // matrix all resolved here, so the inner loop sees a dense
+                    // tile and the zero half is never multiplied.
+                    // op(A) is read down i when it is not transposed and down p
+                    // when it is, and the staging assignment has to follow -- a
+                    // warp walking i over a transposed A strides by lda and each
+                    // lane pulls its own 32-byte sector, which measured as the
+                    // dominant cost before the split.
+                    if (transposed) {
+                        for (int flat = tid; flat < PacketsA; flat += Threads) {
+                            const int i = m0 + flat / (TileK / 4);
+                            const int pp0 = (flat % (TileK / 4)) * 4;
+                            const int ii = i - m0;
+                            const int phys = (swizzle_a(ii >> 2, pp0) << 2) | (ii & 3);
+#pragma unroll
+                            for (int e = 0; e < 4; ++e) {
+                                const int p = p0 + pp0 + e;
+                                T value = T(0);
+                                if (i < m && p < m) {
+                                    if (i == p) {
+                                        value = unit
+                                            ? T(1)
+                                            : Ab[i + static_cast<std::ptrdiff_t>(i) * lda];
+                                    } else if (lower_eff ? (p < i) : (p > i)) {
+                                        value = Ab[p + static_cast<std::ptrdiff_t>(i) * lda];
+                                    }
+                                }
+                                sa[(pp0 + e) * SA + phys] = value;
+                            }
+                        }
+                    } else {
+                    for (int flat = tid; flat < PacketsA; flat += Threads) {
+                        const int pp = flat / PacksA;
+                        const int ii0 = (flat % PacksA) * 4;
+                        const int p = p0 + pp;
+                        const int phys = swizzle_a(ii0 >> 2, pp) << 2;
+                        // The four rows a thread stages are adjacent in shared,
+                        // so they go back as one 128-bit store. Writing them
+                        // singly would put every lane of the warp on one of only
+                        // eight banks -- the row stride is a multiple of 32, so
+                        // it drops out, and a single-element store cannot spread
+                        // wider than the packet index does.
+                        TileVec4<T> packet;
+#pragma unroll
+                        for (int e = 0; e < 4; ++e) {
+                            const int i = m0 + ii0 + e;
+                            T value = T(0);
+                            if (i < m && p < m) {
+                                if (i == p) {
+                                    value = unit
+                                        ? T(1)
+                                        : Ab[i + static_cast<std::ptrdiff_t>(i) * lda];
+                                } else if (lower_eff ? (p < i) : (p > i)) {
+                                    value = Ab[i + static_cast<std::ptrdiff_t>(p) * lda];
+                                }
+                            }
+                            packet.v[e] = value;
+                        }
+                        tile_vec4(&sa[pp * SA + phys]) = packet;
+                    }
+                    }
+
+                    // B: reduction rows [p0, p0+TileK) against columns
+                    // [n0, n0+TileN). B is contiguous down its row index, so a
+                    // thread takes four adjacent reduction rows of one column.
+                    for (int flat = tid; flat < PacketsB; flat += Threads) {
+                        const int col = flat / (TileK / 4);
+                        const int pp0 = (flat % (TileK / 4)) * 4;
+                        const int j = n0 + col;
+                        const int phys = (swizzle_b(col >> 2, pp0) << 2) | (col & 3);
+#pragma unroll
+                        for (int e = 0; e < 4; ++e) {
+                            const int p = p0 + pp0 + e;
+                            sb[(pp0 + e) * SB + phys] =
+                                (j < n && p < m)
+                                ? Bb[p + static_cast<std::ptrdiff_t>(j) * ldb]
+                                : T(0);
+                        }
+                    }
+                    item.barrier(sycl::access::fence_space::local_space);
+
+#pragma unroll 4
+                    for (int p = 0; p < TileK; ++p) {
+                        const T* rowa = &sa[p * SA];
+                        const T* rowb = &sb[p * SB];
+                        T af[ThreadRows];
+                        T bf[ThreadCols];
+#pragma unroll
+                        for (int b = 0; b < BandsR; ++b) {
+                            const TileVec4<T> v =
+                                tile_vec4(rowa + (swizzle_a(b * (BandSpanR / 4) + tr, p) << 2));
+#pragma unroll
+                            for (int e = 0; e < 4; ++e) {
+                                af[b * 4 + e] = v.v[e];
+                            }
+                        }
+#pragma unroll
+                        for (int b = 0; b < BandsC; ++b) {
+                            const TileVec4<T> v =
+                                tile_vec4(rowb + (swizzle_b(b * (BandSpanC / 4) + tc, p) << 2));
+#pragma unroll
+                            for (int e = 0; e < 4; ++e) {
+                                bf[b * 4 + e] = v.v[e];
+                            }
+                        }
+#pragma unroll
+                        for (int i = 0; i < ThreadRows; ++i) {
+#pragma unroll
+                            for (int j = 0; j < ThreadCols; ++j) {
+                                accum[i][j] += af[i] * bf[j];
+                            }
+                        }
+                    }
+                    item.barrier(sycl::access::fence_space::local_space);
+                }
+
+                // TRMM overwrites C; there is no beta, so nothing here reads it.
+#pragma unroll
+                for (int j = 0; j < ThreadCols; ++j) {
+                    const int col = n0 + (j / 4) * BandSpanC + tc * 4 + (j % 4);
+                    if (col >= n) {
+                        continue;
+                    }
+#pragma unroll
+                    for (int i = 0; i < ThreadRows; ++i) {
+                        const int row = m0 + (i / 4) * BandSpanR + tr * 4 + (i % 4);
+                        if (row >= m) {
+                            continue;
+                        }
+                        Cb[row + static_cast<std::ptrdiff_t>(col) * ldc] = alpha * accum[i][j];
+                    }
+                }
+            });
+    });
+
+    return ctx.get_event();
+}
+
+// The row tile is sized to m when m is small -- ormqr hands this ib in the tens
+// and a 128-row tile would quadruple its arithmetic -- and capped at 128, above
+// which the grid tiles m and the k-range restriction does the saving.
+template <typename T>
+Event trmm_triangular_tiles(Queue& ctx,
+                            const MatrixView<T, MatrixFormat::Dense>& A,
+                            const MatrixView<T, MatrixFormat::Dense>& B,
+                            const MatrixView<T, MatrixFormat::Dense>& C,
+                            T alpha,
+                            Uplo uplo,
+                            Transpose transA,
+                            Diag diag) {
+    const int m = static_cast<int>(C.rows());
+    if (m <= 32) {
+        return launch_trmm_triangular_tiles<T, 32>(ctx, A, B, C, alpha, uplo, transA, diag);
+    }
+    if (m <= 64) {
+        return launch_trmm_triangular_tiles<T, 64>(ctx, A, B, C, alpha, uplo, transA, diag);
+    }
+    return launch_trmm_triangular_tiles<T, 128>(ctx, A, B, C, alpha, uplo, transA, diag);
+}
+
+} // namespace batchlas::backend::detail

--- a/src/backends/trmm_triangular_tiles.hh
+++ b/src/backends/trmm_triangular_tiles.hh
@@ -23,9 +23,9 @@
 // How much that saves depends entirely on how many row tiles m covers, and it
 // is worth being precise because it is not the textbook 2x: with R row tiles
 // the reduction shrinks to (R+1)/2R of the square, so 1.0x at R = 1, 1.33x at
-// R = 2, and only 1.78x by R = 8. `trmm_prefer_triangular_tiles` carries the
-// measured consequence -- this kernel is ahead of the vendor at m <= 64 (on
-// fusion, not arithmetic) and at m >= 512, and behind it in between.
+// R = 2, and only 1.78x by R = 8. Getting R above 1 is the single thing that
+// decides whether this beats a GEMM -- see `trmm_row_tile`, which is where the
+// scalar type enters.
 //
 // Which end of the reduction is skipped comes from uplo and trans together:
 // transposing an upper triangle gives a lower one, so the kernel keys off
@@ -82,7 +82,22 @@ Event launch_trmm_triangular_tiles(Queue& ctx,
     constexpr int TileN = kTrmmTileN;
     constexpr int TileK = kTrmmTileK;
     constexpr int LocalRows = trmm_lanes(TileM);
-    constexpr int LocalCols = trmm_lanes(TileN);
+    // A complex scalar halves how many elements the shared path delivers per
+    // clock while leaving the FMA rate per element alone, so the fragment-to-
+    // FFMA ratio that is comfortable in float becomes the binding constraint:
+    // a 4x8 thread tile reads 12 complex and issues 32 complex MACs, which
+    // needs 2.67 MAC per load against a capability of 2. Widening the thread
+    // tile to 4x16 takes it to 3.2 and puts the kernel back on the FMA pipe.
+    // Halving the lane count is what pays for it, and the row tiling -- where
+    // the triangle saving lives -- is left untouched.
+    //
+    // Only at the 64-row tile, though. At the 32-row tile the block is already
+    // down to 64 threads and halving the lanes again costs more in outstanding
+    // loads than the ratio buys -- that end is bandwidth bound, not FMA bound,
+    // and measured 0.374 -> 0.424 ms at m = 32.
+    constexpr int LocalCols = (sycl::detail::is_complex<T>::value && TileM >= 64)
+                                  ? trmm_lanes(TileN) / 2
+                                  : trmm_lanes(TileN);
     constexpr int ThreadRows = TileM / LocalRows;
     constexpr int ThreadCols = TileN / LocalCols;
     constexpr int Threads = LocalRows * LocalCols;
@@ -113,6 +128,7 @@ Event launch_trmm_triangular_tiles(Queue& ctx,
     // everything the kernel needs from uplo and trans.
     const bool lower_eff = (uplo == Uplo::Lower) != transposed;
     const bool unit = diag == Diag::Unit;
+    const bool conjugated = transA == Transpose::ConjTrans;
 
     const sycl::range<3> local(1, 1, static_cast<size_t>(Threads));
     const sycl::range<3> global(static_cast<size_t>(batch),
@@ -197,12 +213,19 @@ Event launch_trmm_triangular_tiles(Queue& ctx,
                                 const int p = p0 + pp0 + e;
                                 T value = T(0);
                                 if (i < m && p < m) {
+                                    // ConjTrans means op(A) = A^H, so the
+                                    // element is conjugated on the way in. The
+                                    // unit diagonal is a literal 1 and has
+                                    // nothing to conjugate.
                                     if (i == p) {
                                         value = unit
                                             ? T(1)
-                                            : Ab[i + static_cast<std::ptrdiff_t>(i) * lda];
+                                            : conjugated
+                                                ? conj_if(Ab[i + static_cast<std::ptrdiff_t>(i) * lda])
+                                                : Ab[i + static_cast<std::ptrdiff_t>(i) * lda];
                                     } else if (lower_eff ? (p < i) : (p > i)) {
-                                        value = Ab[p + static_cast<std::ptrdiff_t>(i) * lda];
+                                        const T raw = Ab[p + static_cast<std::ptrdiff_t>(i) * lda];
+                                        value = conjugated ? conj_if(raw) : raw;
                                     }
                                 }
                                 sa[(pp0 + e) * SA + phys] = value;
@@ -236,7 +259,7 @@ Event launch_trmm_triangular_tiles(Queue& ctx,
                             }
                             packet.v[e] = value;
                         }
-                        tile_vec4(&sa[pp * SA + phys]) = packet;
+                        tile_store4(&sa[pp * SA + phys], packet);
                     }
                     }
 
@@ -268,7 +291,7 @@ Event launch_trmm_triangular_tiles(Queue& ctx,
 #pragma unroll
                         for (int b = 0; b < BandsR; ++b) {
                             const TileVec4<T> v =
-                                tile_vec4(rowa + (swizzle_a(b * (BandSpanR / 4) + tr, p) << 2));
+                                tile_load4(rowa + (swizzle_a(b * (BandSpanR / 4) + tr, p) << 2));
 #pragma unroll
                             for (int e = 0; e < 4; ++e) {
                                 af[b * 4 + e] = v.v[e];
@@ -277,7 +300,7 @@ Event launch_trmm_triangular_tiles(Queue& ctx,
 #pragma unroll
                         for (int b = 0; b < BandsC; ++b) {
                             const TileVec4<T> v =
-                                tile_vec4(rowb + (swizzle_b(b * (BandSpanC / 4) + tc, p) << 2));
+                                tile_load4(rowb + (swizzle_b(b * (BandSpanC / 4) + tc, p) << 2));
 #pragma unroll
                             for (int e = 0; e < 4; ++e) {
                                 bf[b * 4 + e] = v.v[e];
@@ -287,7 +310,7 @@ Event launch_trmm_triangular_tiles(Queue& ctx,
                         for (int i = 0; i < ThreadRows; ++i) {
 #pragma unroll
                             for (int j = 0; j < ThreadCols; ++j) {
-                                accum[i][j] += af[i] * bf[j];
+                                accum[i][j] = accumulate(accum[i][j], af[i], bf[j]);
                             }
                         }
                     }
@@ -316,9 +339,76 @@ Event launch_trmm_triangular_tiles(Queue& ctx,
     return ctx.get_event();
 }
 
-// The row tile is sized to m when m is small -- ormqr hands this ib in the tens
-// and a 128-row tile would quadruple its arithmetic -- and capped at 128, above
-// which the grid tiles m and the k-range restriction does the saving.
+// Everything the kernel needs from the problem, independent of scalar type and
+// of the queue. Left side only: the right-side product C = alpha * B * op(A)
+// puts the triangle on the column index, which is a different k-loop bound and
+// a different staging assignment, not a transpose of this one.
+template <typename T>
+bool trmm_tiles_supported(const MatrixView<T, MatrixFormat::Dense>& A,
+                          const MatrixView<T, MatrixFormat::Dense>& B,
+                          const MatrixView<T, MatrixFormat::Dense>& C,
+                          Side side) {
+    if (side != Side::Left) {
+        return false;
+    }
+    if (A.rows() != A.cols() || A.rows() != C.rows()) {
+        return false;
+    }
+    if (A.batch_size() != B.batch_size() || B.batch_size() != C.batch_size()) {
+        return false;
+    }
+    if (B.rows() != C.rows() || B.cols() != C.cols()) {
+        return false;
+    }
+    if (A.is_heterogeneous() || B.is_heterogeneous() || C.is_heterogeneous()) {
+        return false;
+    }
+    return C.rows() > 0 && C.cols() > 0;
+}
+
+// How wide a row tile to cut m into, which is the kernel's one real trade-off.
+//
+// R = m/TileM row tiles shrink the reduction to (R+1)/2R of the square, so a
+// smaller tile does strictly less arithmetic: 1.0x at R = 1, 0.75x at R = 2,
+// 0.5625x at R = 8. It also re-reads B, because each row tile stages its own
+// copy of the reduction range it needs -- (R+1)/2 times over in the worst case,
+// though in practice much of that is L2 hits.
+//
+// Which of the two dominates is decided by the scalar type, not by the shape:
+//
+//   float   is bandwidth bound at these sizes -- intensity is m/4 flop per byte
+//           against a ridge near 40 -- so paying B twice to save a quarter of
+//           the arithmetic is a bad trade, and the widest tile that fits wins.
+//   double  runs at 1/64 rate on this part, which puts the ridge near 1.4 flop
+//           per byte and the problem far on the compute side of it. There the
+//           arithmetic is the whole cost and B's re-read is close to free, so
+//           the narrowest tile wins. Complex is the same argument: a complex
+//           multiply is four real ones.
+//
+// This is why one threshold cannot serve both, and why the first version of
+// this kernel -- tuned on float alone, one tile for m <= 128 -- could not beat
+// a GEMM at m = 128 in any type: R = 1 saves nothing at all.
+template <typename T>
+inline int trmm_row_tile(int m) {
+    constexpr bool wide = sizeof(typename base_type<T>::type) > 4 || sycl::detail::is_complex<T>::value;
+    if (m <= 32) {
+        return 32;
+    }
+    if constexpr (wide) {
+        // Never 128. Beyond the argument above, a 128x128 tile is an 8x8 thread
+        // tile, which in complex<double> is 256 registers of accumulator alone
+        // -- 256 threads x 256 is the entire 65536 a work-group gets, and the
+        // runtime rejects the launch rather than spilling.
+        return m <= 64 ? 32 : 64;
+    } else {
+        // Measured, float, against the GEMM (ms): at m = 128 nC = 512 batch
+        // 1024, TileM 32/64/128 gives 0.663 / 0.658 / 0.699 against a GEMM's
+        // 0.674 -- so 128 loses and 64 wins. 32 is worse than 64 everywhere,
+        // which is the B re-read showing up. Only at m = 1024 does 128 come
+        // back ahead (1.146 vs 1.180).
+        return m <= 512 ? 64 : 128;
+    }
+}
 template <typename T>
 Event trmm_triangular_tiles(Queue& ctx,
                             const MatrixView<T, MatrixFormat::Dense>& A,
@@ -329,10 +419,18 @@ Event trmm_triangular_tiles(Queue& ctx,
                             Transpose transA,
                             Diag diag) {
     const int m = static_cast<int>(C.rows());
-    if (m <= 32) {
+    // BATCHLAS_TRMM_TILE_M pins the row tile so the trade-off below can be
+    // swept from one binary.
+    const int forced = [] {
+        const char* raw = std::getenv("BATCHLAS_TRMM_TILE_M");
+        return raw ? std::atoi(raw) : 0;
+    }();
+
+    const int tile_m = forced ? forced : trmm_row_tile<T>(m);
+    if (tile_m <= 32) {
         return launch_trmm_triangular_tiles<T, 32>(ctx, A, B, C, alpha, uplo, transA, diag);
     }
-    if (m <= 64) {
+    if (tile_m <= 64) {
         return launch_trmm_triangular_tiles<T, 64>(ctx, A, B, C, alpha, uplo, transA, diag);
     }
     return launch_trmm_triangular_tiles<T, 128>(ctx, A, B, C, alpha, uplo, transA, diag);

--- a/src/extensions/ormqr_blocked.cc
+++ b/src/extensions/ormqr_blocked.cc
@@ -20,6 +20,33 @@ namespace batchlas {
 
 namespace {
 
+// The WY block factor W2 = op(T) W1 has T upper triangular -- larft builds it
+// that way and zeroes the half below, which is why the GEMM spelling below is
+// correct in the first place. A trmm expresses it without multiplying through
+// those zeros.
+//
+// BATCHLAS_ORMQR_WY=gemm pins the old spelling so the substitution stays
+// measurable from one binary.
+inline bool use_trmm_for_wy() {
+    static const bool result = []() {
+        const char* v = std::getenv("BATCHLAS_ORMQR_WY");
+        return !(v && std::string(v) == "gemm");
+    }();
+    return result;
+}
+
+// Where the tile kernel is ahead of the GEMM it replaces. Float and CUDA
+// because that is the only combination with a batched triangular kernel --
+// everything else would take trmm_vendor_impl, which expands the triangle into
+// a scratch buffer and then runs the very GEMM being replaced, strictly worse.
+// ib <= 64 because above it the tile kernel measured 0.83x-0.97x against the
+// GEMM (see experiments/TRMM_SYRK_BATCHED_KERNELS.md); every block size syev
+// uses is inside that anyway.
+template <Backend B, typename T>
+inline bool wy_trmm_applicable(int ib) {
+    return B == Backend::CUDA && std::is_same_v<T, float> && ib <= 64 && use_trmm_for_wy();
+}
+
 // Returns true when BATCHLAS_ORMQR_IMPL=device, false otherwise (legacy is the default).
 // Evaluated once and cached for the lifetime of the process.
 inline bool use_device_ormqr() {
@@ -439,7 +466,19 @@ Event ormqr_blocked_impl(Queue& ctx,
             gemm<B>(q, Vblk, Csub, W1, {.transA = Transpose::ConjTrans});
 
             const Transpose t_eff = transpose_apply ? Transpose::ConjTrans : Transpose::NoTrans;
-            gemm<B>(q, Tblk, W1, W2, {.transA = t_eff});
+            // W2 = op(T) W1. trmm overwrites C on the routes that have a
+            // batched kernel, matching this GEMM's beta = 0, so the two are
+            // interchangeable here.
+            if constexpr (B == Backend::CUDA && std::is_same_v<T, float>) {
+                if (wy_trmm_applicable<B, T>(ib)) {
+                    trmm<B, T>(q, Tblk, W1, W2, T(1),
+                               Side::Left, Uplo::Upper, t_eff, Diag::NonUnit);
+                } else {
+                    gemm<B>(q, Tblk, W1, W2, {.transA = t_eff});
+                }
+            } else {
+                gemm<B>(q, Tblk, W1, W2, {.transA = t_eff});
+            }
 
             gemm<B>(q, Vblk, W2, Csub, {.alpha = T(-1), .beta = T(1)});
         } else {

--- a/src/extensions/ortho.cc
+++ b/src/extensions/ortho.cc
@@ -7,6 +7,8 @@
 #include <sycl/sycl.hpp>
 #include <complex>
 #include <numeric>
+#include <cstdlib>
+#include <string>
 #include <algorithm>
 #include <blas/linalg.hh>
 #include <batchlas/backend_config.h>
@@ -118,6 +120,65 @@ namespace batchlas {
         auto potrf_workspace = wsl.potrf_ws;
         auto ATA_stride = k * k;
 
+        // C = A^H A is a Gram matrix, which is exactly what syrk spells, and it
+        // does half the arithmetic a GEMM does. PR #61 measured this
+        // substitution and rejected it -- correctly at the time, because syrk
+        // reached no batched kernel at these shapes and fell to a host loop over
+        // cublasXsyrk: 96x slower in float, and 115 ms against a 0.9 ms GEMM in
+        // double. `syrk_gram_tiles` is that missing kernel.
+        //
+        // Two conditions, both measured rather than assumed (RTX 4090 / sm_89,
+        // batches that saturate):
+        //
+        //   k          the single-tile Gram kernel lives at k <= 128, but the
+        //              useful limit differs by precision and the end-to-end
+        //              numbers say so (m = 1024, batch 512, Chol2):
+        //
+        //                k    float           double
+        //                32   1.62x           1.02x
+        //                64   1.12x           1.20x
+        //                128  0.96x  <- loss  1.34x
+        //
+        //              Float at k = 128 is a wash because the SGEMM it replaces
+        //              is already against both the compute and the bandwidth
+        //              roof, so there is nothing for the halved arithmetic to
+        //              buy. FP64 runs at 1/64 rate on this part, so double is
+        //              squarely compute bound and the halving lands in full --
+        //              and it grows with k, where float's shrinks. Hence 64 for
+        //              float and 128 for double, not one number for both.
+        //              Above those, double and complex are still on the host
+        //              loop, which at k = 256 loses to the GEMM by 2x.
+        //   real only  a complex multiply is four real ones, so herk is compute
+        //              bound where syrk is bandwidth bound, and the existing
+        //              GEMM-plus-Hermitian-fold beats the tile kernel at every
+        //              Gram shape. Complex keeps the GEMM.
+        //
+        // Only the lower triangle is produced. Everything downstream of these
+        // two call sites reads exactly that -- potrf and trsm both default to
+        // Uplo::Lower, and shift_chol_alg's shift kernel touches only the
+        // diagonal. svqb_alg is the exception and keeps its GEMM: it scales the
+        // whole k x k before handing it to syev, so a half-written C would leave
+        // it multiplying uninitialised workspace.
+        // BATCHLAS_ORTHO_GRAM=gemm pins the old spelling, so the substitution
+        // stays measurable from one binary rather than needing a build of the
+        // parent commit to compare against.
+        constexpr bool gram_is_real = !sycl::detail::is_complex<T>::value;
+        const bool gram_pinned_to_gemm = [] {
+            const char* raw = std::getenv("BATCHLAS_ORTHO_GRAM");
+            return raw != nullptr && std::string(raw) == "gemm";
+        }();
+        constexpr int gram_max_k = std::is_same_v<T, float> ? 64 : 128;
+        const bool gram_via_syrk =
+            (B == Backend::CUDA) && gram_is_real && k <= gram_max_k && !gram_pinned_to_gemm;
+        auto gram_into_C = [&](const auto& in_mat) {
+            if constexpr (B == Backend::CUDA && gram_is_real) {
+                if (gram_via_syrk) {
+                    return syrk<B, T>(ctx, in_mat, C, T(1), T(0), Uplo::Lower, inv_trans);
+                }
+            }
+            return gemm<B>(ctx, in_mat, in_mat, C, {.transA = inv_trans, .transB = transA});
+        };
+
 
         auto real_part = [](T value) { if constexpr (sycl::detail::is_complex<T>::value) return value.real(); else return value; };
         auto square = [](T value) { if constexpr (sycl::detail::is_complex<T>::value) return (value * std::conj(value)).real(); else return value * value; };
@@ -126,7 +187,7 @@ namespace batchlas {
             constexpr T alpha = 1.0;
             constexpr T beta = 0.0;
             //Compute StS = S^T * S or StS = S * S^T (depending on transA)
-            gemm<B>(ctx, A, A, C, {.transA = inv_trans, .transB = transA});
+            gram_into_C(A);
             //Compute the Cholesky Factorization of StS
             potrf<B>(ctx, C, PotrfOptions{}, potrf_workspace);
             //Solve X * Chol(StS) = S
@@ -195,7 +256,7 @@ namespace batchlas {
         };
 
         auto shift_chol_alg = [&](){
-            gemm<B>(ctx, A, A, C, {.transA = inv_trans, .transB = transA});
+            gram_into_C(A);
 
             auto ATA_ptr = C.data_ptr();
             ctx -> submit([&](sycl::handler& h){

--- a/tests/herk_tests.cc
+++ b/tests/herk_tests.cc
@@ -324,6 +324,101 @@ TYPED_TEST(HerkTest, OptionStructMatchesPositional) {
     }
 }
 
+// The two tests above check the *shape* of the answer -- that the untouched
+// triangle stays untouched, and that the two uplo runs agree. Neither can catch
+// conjugating the wrong operand, which is the one thing a shared syrk/herk
+// kernel is most likely to get wrong: conjugating the row index instead of the
+// column returns conj(C) rather than C, which is still Hermitian and still
+// consistent across both triangles. Only a value comparison sees it.
+//
+// n is swept because the narrow kernel picks a different tile width -- and, for
+// complex, a different thread tile -- at 32, 64 and 128, and k is deliberately
+// not a multiple of the k chunk.
+TYPED_TEST(HerkTest, MatchesGemmReference) {
+    using T = typename TestFixture::ScalarType;
+    using real_t = typename base_type<T>::type;
+    constexpr Backend Ba = TestFixture::BackendType;
+
+    const int k = 200;
+    const int batch = 3;
+    const real_t alpha = real_t(0.9);
+    const real_t beta = real_t(-0.35);
+    const real_t tol = test_utils::tolerance<T>() * real_t(12 * k);
+
+    auto sweep = [&](const char* route) {
+    for (int n : {24, 32, 48, 64, 96, 128}) {
+        for (auto transA : {Transpose::NoTrans, Transpose::ConjTrans}) {
+            for (auto uplo : {Uplo::Lower, Uplo::Upper}) {
+                const int a_rows = transA == Transpose::NoTrans ? n : k;
+                const int a_cols = transA == Transpose::NoTrans ? k : n;
+
+                Matrix<T, MatrixFormat::Dense> A =
+                    Matrix<T, MatrixFormat::Dense>::Random(a_rows, a_cols, false, batch);
+                Matrix<T, MatrixFormat::Dense> C0 =
+                    Matrix<T, MatrixFormat::Dense>::Random(n, n, false, batch);
+                Matrix<T, MatrixFormat::Dense> C(n, n, batch);
+                Matrix<T, MatrixFormat::Dense> C_ref(n, n, batch);
+
+                // BLAS does not reference the imaginary part of a Hermitian C's
+                // diagonal, so herk drops it and a plain GEMM scales it by beta.
+                // Starting from a real diagonal is what makes the two
+                // comparable; without it the test fails on element (0,0) for a
+                // reason that has nothing to do with the kernel.
+                for (int b = 0; b < batch; ++b) {
+                    for (int d = 0; d < n; ++d) {
+                        C0(d, d, b) = T(C0(d, d, b).real(), real_t(0));
+                    }
+                }
+                this->ctx->wait();
+
+                MatrixView<T, MatrixFormat::Dense>::copy(*(this->ctx), C.view(), C0.view()).wait();
+                MatrixView<T, MatrixFormat::Dense>::copy(*(this->ctx), C_ref.view(), C0.view()).wait();
+
+                herk<Ba, T>(*(this->ctx), A.view(), C.view(), alpha, beta, uplo, transA).wait();
+
+                gemm(*(this->ctx), A.view(), A.view(), C_ref.view(),
+                     {.alpha = T(alpha), .beta = T(beta), .transA = transA,
+                      .transB = transA == Transpose::NoTrans ? Transpose::ConjTrans
+                                                             : Transpose::NoTrans}).wait();
+
+                // Mirror both, so the half herk was not asked for is compared
+                // against the reference too rather than against its own input.
+                C.view().symmetrize(*(this->ctx), uplo).wait();
+                C_ref.view().symmetrize(*(this->ctx), uplo).wait();
+
+                for (int b = 0; b < batch; ++b) {
+                    for (int j = 0; j < n; ++j) {
+                        for (int i = 0; i < n; ++i) {
+                            const T got = C(i, j, b);
+                            const T want = C_ref(i, j, b);
+                            ASSERT_NEAR(got.real(), want.real(), tol)
+                                << "real route=" << route << " n=" << n
+                                << " trans=" << static_cast<int>(transA)
+                                << " uplo=" << static_cast<int>(uplo)
+                                << " b=" << b << " row=" << i << " col=" << j;
+                            ASSERT_NEAR(got.imag(), want.imag(), tol)
+                                << "imag route=" << route << " n=" << n
+                                << " trans=" << static_cast<int>(transA)
+                                << " uplo=" << static_cast<int>(uplo)
+                                << " b=" << b << " row=" << i << " col=" << j;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    };
+
+    sweep("default");
+    if constexpr (Ba == Backend::CUDA) {
+        // The Gram kernel is not on herk's automatic path -- it loses to the
+        // GEMM-plus-fold in complex -- so without pinning it the conjugation
+        // this test exists to check would never run.
+        ScopedEnvVar pin("BATCHLAS_SYRK_VARIANT", "gram");
+        sweep("gram");
+    }
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/syrk_tests.cc
+++ b/tests/syrk_tests.cc
@@ -102,6 +102,74 @@ TYPED_TEST(SyrkTest, MatchesGemmReference) {
     }
 }
 
+// MatchesGemmReference above pins one shape, n = 96, which reaches exactly one
+// of the narrow kernel's three tile widths. The other two -- and the wider
+// range ortho actually asks for, where k is the block size and n is tens of
+// vectors -- went unexercised, so the band-split bug that broke n = 96 could
+// equally have hidden at n = 32 or 64 with nothing to catch it. Each n here
+// selects a different instantiation: 32 and 24 the 32-wide tile, 64 and 48 the
+// 64-wide one, 128 and 96 the 128-wide one, with the odd sizes checking the
+// masking of a tile the matrix does not fill.
+TYPED_TEST(SyrkTest, NarrowShapesMatchGemmReference) {
+    using T = typename TestFixture::ScalarType;
+    using real_t = typename base_type<T>::type;
+
+    const int k = 200;   // deliberately not a multiple of the k chunk
+    const int batch = 3;
+    const T alpha = T(0.9);
+    const T beta = T(-0.35);
+    const real_t tol = test_utils::tolerance<T>() * real_t(12 * k);
+
+    for (int n : {24, 32, 48, 64, 96, 128}) {
+        for (auto transA : {Transpose::NoTrans, Transpose::Trans}) {
+            for (auto uplo : {Uplo::Lower, Uplo::Upper}) {
+                const int a_rows = transA == Transpose::NoTrans ? n : k;
+                const int a_cols = transA == Transpose::NoTrans ? k : n;
+
+                Matrix<T, MatrixFormat::Dense> A =
+                    Matrix<T, MatrixFormat::Dense>::Random(a_rows, a_cols, false, batch);
+                Matrix<T, MatrixFormat::Dense> C0 =
+                    Matrix<T, MatrixFormat::Dense>::Random(n, n, false, batch);
+                Matrix<T, MatrixFormat::Dense> C(n, n, batch);
+                Matrix<T, MatrixFormat::Dense> C_ref(n, n, batch);
+
+                MatrixView<T, MatrixFormat::Dense>::copy(*(this->ctx), C.view(), C0.view()).wait();
+                MatrixView<T, MatrixFormat::Dense>::copy(*(this->ctx), C_ref.view(), C0.view()).wait();
+
+                syrk(*(this->ctx), A.view(), C.view(),
+                     {.alpha = alpha, .beta = beta, .uplo = uplo, .trans = transA}).wait();
+
+                gemm(*(this->ctx), A.view(), A.view(), C_ref.view(),
+                     {.alpha = alpha, .beta = beta, .transA = transA,
+                      .transB = transA == Transpose::NoTrans ? Transpose::Trans
+                                                            : Transpose::NoTrans}).wait();
+
+                // Comparing the untouched half would only compare C0 with
+                // itself, so both sides are mirrored from the half syrk was
+                // asked for -- that way every element of the answer is checked
+                // against the reference, including the ones a wrongly indexed
+                // thread tile would have left at their input value.
+                C.view().symmetrize(*(this->ctx), uplo).wait();
+                C_ref.view().symmetrize(*(this->ctx), uplo).wait();
+
+                for (int b = 0; b < batch; ++b) {
+                    for (int j = 0; j < n; ++j) {
+                        for (int i = 0; i < n; ++i) {
+                            ASSERT_NEAR(C(i, j, b), C_ref(i, j, b), tol)
+                                << "n=" << n
+                                << ", trans=" << static_cast<int>(transA)
+                                << ", uplo=" << static_cast<int>(uplo)
+                                << ", batch=" << b
+                                << ", row=" << i
+                                << ", col=" << j;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## What this is

PR #61 surveyed `src/extensions` for places a level-3 op could replace a GEMM and
declined to use `trmm` or `syrk` anywhere. It was right on the evidence it had:
neither op reached a batched kernel at the shapes its callers produce. This is
the other half of that result — writing the two kernels that were missing, then
re-measuring the conclusion.

Hardware: RTX 4090 / sm_89, CUDA 13.2, RelWithDebInfo, idle box. Every shape is
paired with a batch large enough to saturate; batch = 1 is not a design target.
Full tables and the negative results are in
`experiments/TRMM_SYRK_BATCHED_KERNELS.md`.

## Two new kernels

**`syrk_gram_tiles.hh`** — the tall-skinny Gram shape (`C = A^H A`, small square
C). The existing 128×128 triangular kernel needs three tiles a side, so `n ≤ 128`
fell to a host loop over `cublasXsyrk`. The new kernel sizes the tile to `n`, so
one tile covers C and A crosses the bus once, and takes the triangle at
*thread-tile* granularity — masking only the epilogue would leave the block doing
exactly a GEMM's arithmetic.

**`trmm_triangular_tiles.hh`** — nothing in the tree exploited triangularity in
`trmm`. `src/extensions/trmm.cc` recurses only to 256 wide and then calls the
GEMM it is meant to replace; on CUDA it does not even reach that, because
`trmm_vendor_impl` expands the triangle into a `k × k × batch` scratch and hands
it to a full GEMM. The new kernel puts the structure in the k-loop bound, so the
skipped arithmetic is never issued.

## Results

**SYRK vs the GEMM spelling** (float; against the vendor route it replaces,
73×–431×):

| m | n | batch | gemm | syrk before | syrk now | |
|---|---|---|---|---|---|---|
| 256 | 32 | 2048 | 0.334 | 33.588 | **0.078** | 4.29x |
| 1024 | 64 | 1024 | 0.668 | 60.397 | **0.333** | 2.01x |
| 2048 | 128 | 256 | 0.404 | 29.370 | **0.382** | 1.06x |

At n = 32 it reads 71 MB in 78 µs — 933 GB/s, the memory roofline.

**TRMM vs the GEMM spelling**, all four dtypes (**bold** = win):

| m | float | double | complex&lt;float&gt; | complex&lt;double&gt; |
|---|---|---|---|---|
| 32 | **1.13x** | **1.29x** | 0.88x | **1.05x** |
| 64 | **1.07x** | **1.45x** | 0.88x | **1.41x** |
| 128 | **1.03x** | **1.48x** | 0.69x | **1.42x** |
| 256 | 0.91x | **1.77x** | 0.93x | **1.71x** |
| 512 | **1.16x** | **1.91x** | **1.10x** | **1.84x** |
| 1024 | **1.26x** | **2.02x** | **1.23x** | **1.95x** |

**Wired into callers.** `ortho`'s two Cholesky Gram sites now call `syrk`
(1.62x at k=32 float, 1.34x at k=128 double), and `ormqr_blocked`'s WY block
factor is now a `trmm`.

## What does not work, stated plainly

- **`complex<float>` TRMM loses below m = 512**, and **float loses at m = 256**.
  Same cause: cuBLAS is at or near the FP32 FMA peak on those shapes while this
  kernel reaches 50–60% of it, and the triangle's 1.33x–1.6x cannot cover the
  gap. For `complex<float>` it is a register-file ceiling — twice the accumulator
  width, so the thread tile that would fix the fragment-to-FMA ratio does not fit
  at usable occupancy (forcing it measured 15.06 ms against 2.18, pure spill).
- **`herk` deliberately keeps its existing route.** The tile kernel loses to the
  GEMM-plus-Hermitian-fold at every Gram shape measured (2.08 vs 1.57 ms at
  n=128). A complex multiply is four real ones, so herk is compute bound where
  real syrk is bandwidth bound. Reachable as `BATCHLAS_SYRK_VARIANT=gram` so the
  conjugation stays measurable and under test.
- **syev gains almost nothing, and the trace says why.** syev never calls
  `ortho`, and above n ≈ 256 it takes the two-stage path, which uses no
  triangular level-3 op at all. Wiring `trmm` into `ormqr_blocked` returns 1.036x
  at n=64 falling to 1.003x at n=512 — real, consistent across eight cells, and
  capped because the substituted op is 1.0% of traced syev time. At n=512,
  `backtransform_q2` (46%), `sb2st_hh` (26%) and `stedc_eigvecs` (11%) are 82% of
  it and none is a level-3 op. **Level-3 substitution is not the lever for syev.**
- `trmm`'s kernel is `Side::Left` only; `ormbr` is not wired.

## Three bugs found on the way, two of them mine

1. **Band split vs. triangular compaction.** Splitting a thread's 8 rows into two
   bands 64 apart — what the square 128×128 kernels do for bank spreading — is
   incompatible with deciding a whole thread tile is inside the triangle from its
   tile indices. Thread (0,1) then owns element (64,4): lower triangle, upper
   tile, so nothing wrote it. Silent, and only at n > 64.
2. **An out-parameter reference spills the accumulator array.** Writing
   `void accumulate(T& acc, ...)` takes the address of a register-resident array
   element and the whole array goes to local memory — **43% on float at m = 512**
   (0.659 → 0.944 ms), no other change.
3. **`std::complex::operator*` is the `__mulsc3` libcall** (C99 Annex G: a branch
   on Inf/NaN per multiply). **18x** in the inner loop — 38 ms at n=128 where
   cuBLAS took 1.5.

## Testing

Green on CUDA: `trmm_tests` 9, `syrk_tests` 7, `herk_tests` 8, `her2k_tests` 6,
`syr2k_tests` 7, `symm_tests` 5, `hemm_tests` 6, `ormqr_tests` 8, `ortho_tests` 8,
`syev_tests` 4, `syev_blocked_tests` 24. Each new route was confirmed by kernel
trace to actually execute rather than pass by fallback.

Two test gaps closed, both of which could not previously have failed:

- `syrk_tests` pinned one shape (n=96), reaching one of three tile widths.
  `NarrowShapesMatchGemmReference` now sweeps n ∈ {24,32,48,64,96,128}.
- `herk_tests` checked only the *shape* of the answer, which cannot catch
  conjugating the wrong operand — that returns `conj(C)`, still Hermitian and
  still agreeing across both triangles. `MatchesGemmReference` was confirmed to
  fail when the conjugation is flipped.

Route pins for A/B from one binary: `BATCHLAS_SYRK_VARIANT`,
`BATCHLAS_TRMM_VARIANT`, `BATCHLAS_TRMM_TILE_M`, `BATCHLAS_ORTHO_GRAM`,
`BATCHLAS_ORMQR_WY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xz5kySEhUssjqFrpKXRUs5
