### PR TITLE
perf(ormqr,trmm): lift the WY trmm gate off CUDA-and-float, and add the 16-row tile

### DIFF
--- a/experiments/TRMM_SYRK_BATCHED_KERNELS.md
+++ b/experiments/TRMM_SYRK_BATCHED_KERNELS.md
@@ -378,10 +378,53 @@ coverage at all -- which is what a lift extending to netlib would have needed.
 `build/batchlas-env.sh` sets; without it, that configuration fails on `Side::Right`
 too, which never touches trmm.)
 
+## The 16-row tile, and what R = 2 is actually worth to complex
+
+The obvious follow-up from the table above was that complex loses at `ib <= 32`
+because the 32-row tile was the kernel's floor, so those cells ran at `R = 1`
+and skipped no arithmetic at all -- and `ib = 16` was worse still, computing 32
+rows and masking half of them off at the epilogue after the FMAs had issued. So
+a 16-row tile was built to give `ib = 32` `R = 2` and `ib = 16` an exact fit.
+
+It needed one change beyond the instantiation: `ThreadRows` must stay a multiple
+of 4 for the 4-wide fragment bands, and `16 / 8 lanes = 2` is not, so the 16-row
+tile drops to 4 row lanes (a 64-thread block) rather than narrowing the band.
+
+Measured tile16 against tile32, same shapes as above, both forced through
+`BATCHLAS_TRMM_TILE_M` in one binary:
+
+| type | tile16 vs tile32 | tile16 vs GEMM | was, on tile32 |
+|---|---|---|---|
+| `double` | 1.007x - 1.022x | **1.013x - 1.036x** | 1.004x - 1.016x |
+| `complex<double>` | 0.995x - 1.040x | 0.996x - 1.018x | 0.958x - 1.010x |
+| `complex<float>` | 0.993x - 1.026x | 0.946x - 0.983x | 0.944x - 0.995x |
+| `float` | 0.966x - 0.997x | 1.004x - 1.028x | 1.006x - 1.046x |
+
+**The R argument is confirmed and it is not enough for complex.** Every type
+moves the way the argument says it should -- narrower helps where the kernel is
+compute bound (double, complex), and hurts float, which is bandwidth bound and
+pays for it in B's re-read, the same reason 32 loses to 64 for float further up.
+`complex<double>`'s `ib = 16` hole does close, 0.958x to 0.996x, which is the
+single clearest confirmation that the hole was the masked-off half tile. But it
+closes to *parity*, not to a win, and `complex<float>` stays 2-5% behind.
+
+That is because the complex deficit was never mainly the R saving. A complex
+multiply is four real ones, so the kernel starts that much further from cuBLAS's
+per-flop rate, and one 16x16 triangle's worth of skipped arithmetic cannot pay
+the difference back. `wy_trmm_applicable` is therefore unchanged: complex still
+takes the GEMM.
+
+The tile is kept anyway, because the type it does pay for is **double** -- the
+route ormqr had just enabled. It takes double from 1.004x-1.016x to
+1.013x-1.036x against the GEMM, better in all six cells. `trmm_row_tile` now
+routes `double` to 16 through m = 64 and complex to 16 through m = 32; complex's
+64-row cell measured a wash (0.993x in `complex<float>`) and keeps the wider
+tile, since at TileM 16 the launch is down to 64 threads. float is untouched.
+
 ## What is not done
 
-- Complex would need the tile kernel to be worth its launch at `R = 1`, or a
-  16-row tile so `ib = 32` gets `R = 2`. Either would make the gate type-free.
+- Complex would need the tile kernel closer to cuBLAS's per-flop rate, not a
+  better R -- see the table above, where R was fixed and complex still lost.
 - Wiring the tile kernel into `rocblas.cc`'s trmm would make ROCm a real
   candidate; `wy_trmm_applicable` is where to re-measure it.
 - `trmm`'s tile kernel is `Side::Left` only. `ormqr`/`ormbr` use both sides;

--- a/experiments/TRMM_SYRK_BATCHED_KERNELS.md
+++ b/experiments/TRMM_SYRK_BATCHED_KERNELS.md
@@ -331,8 +331,59 @@ At n = 512 with eigenvectors the time is `backtransform_q2` 46.4%, `sb2st_hh`
 25.5%, `stedc_eigvecs` 10.6%. Those three are 82% and none is a level-3
 triangular op.
 
+## Lifting the CUDA-and-float gate on that trmm
+
+The gate above was justified by CUDA float being the only route with a batched
+triangular kernel. That stopped being true once the tile kernel was made
+type-generic and the CUDA router started sending double and complex to it, so
+the gate was removed outright and the result measured rather than assumed.
+
+`ormqr_blocked_benchmark`, `Side::Left`, `ConjTrans`, ABBA-ordered against
+`BATCHLAS_ORMQR_WY=gemm` on a dedicated 4090 via `gpu_guard.sh`, batch 256 (128
+for `complex<double>`), nb in {16,32,64}. Ratios are gemm/trmm, so above 1.00 is
+trmm ahead. Each figure is the mean of two runs per setting; the sweep was run
+twice at different measurement windows and both passes agree:
+
+| type | range over all cells | verdict |
+|---|---|---|
+| `float` | 1.006x - 1.046x | wins everywhere (already shipped) |
+| `double` | 1.004x - 1.016x | **wins everywhere -- newly enabled** |
+| `complex<float>` | 0.944x - 0.995x | loses everywhere |
+| `complex<double>` | 0.958x - 1.010x | loses at ib = 16, level above |
+| `netlib float` | 0.336x - 1.199x | 0.34x at n = 128, ib = 16 |
+| `netlib double` | 0.379x - 1.064x | 0.38x at n = 128, ib = 16 |
+
+**So only the double half of the gate was stale, and the split is per-type, not
+per-precision.** The reason is the same `R` arithmetic that sizes the row tile.
+Here `m` is `ib`, in the tens: at `ib <= 32` the kernel runs one 32-row tile,
+`R = 1`, and `(R+1)/2R = 1` means it skips no arithmetic at all. It then wins or
+loses purely on being one kernel instead of a cuBLAS call, and since a complex
+multiply is four real ones, that trade goes negative in complex where it is
+positive in float and double. It closes towards parity at `ib = 64`, where
+`R = 2` finally saves something (0.99x). A trace confirms complex really does
+take `trmm_cuda_custom.triangular_tiles` rather than the expansion fallback, so
+this is the kernel's shape response and not a mis-route.
+
+netlib is out for an unrelated reason: its trmm and its gemm are *both*
+per-batch cblas loops, so batching is not the difference. OpenBLAS's `?trmm` is
+simply weak on a 16x16 triangle against 128 right-hand sides, and the route also
+has to copy B into C first because `cblas_?trmm` works in place. ROCm is out
+because `rocblas_?trmm` is a per-batch vendor loop standing against a
+strided-batched GEMM.
+
+`ormqr_blocked_tests` also gained the two netlib configurations. The type list
+was a CUDA-*or*-host `#if`, so with a GPU backend built the host route had no
+coverage at all -- which is what a lift extending to netlib would have needed.
+(Note that netlib double needs `OPENBLAS_CORETYPE=SKYLAKEX` on this machine, as
+`build/batchlas-env.sh` sets; without it, that configuration fails on `Side::Right`
+too, which never touches trmm.)
+
 ## What is not done
 
+- Complex would need the tile kernel to be worth its launch at `R = 1`, or a
+  16-row tile so `ib = 32` gets `R = 2`. Either would make the gate type-free.
+- Wiring the tile kernel into `rocblas.cc`'s trmm would make ROCm a real
+  candidate; `wy_trmm_applicable` is where to re-measure it.
 - `trmm`'s tile kernel is `Side::Left` only. `ormqr`/`ormbr` use both sides;
   the right-side branch still takes the expansion. syev only uses Left, so this
   costs syev nothing.

--- a/src/backends/trmm_triangular_tiles.hh
+++ b/src/backends/trmm_triangular_tiles.hh
@@ -62,8 +62,13 @@ inline constexpr int kTrmmTileK = 16;
 
 // Threads per side of the tile, and hence the per-thread tile. A 128-wide side
 // gets 16 lanes of 8; anything narrower keeps the 4-wide band the vectorized
-// fragment load is built on and drops lanes instead.
-inline constexpr int trmm_lanes(int tile) { return tile >= 64 ? 16 : 8; }
+// fragment load is built on and drops lanes instead. That is what fixes the
+// 16-row tile at 4 lanes: ThreadRows must stay a multiple of 4, and 16/8 = 2 is
+// not one, so the lanes go rather than the band.
+inline constexpr int trmm_lanes(int tile) {
+    if (tile >= 64) return 16;
+    return tile >= 32 ? 8 : 4;
+}
 
 template <typename T, int TileM>
 class TrmmTriangularTilesKernel;
@@ -388,19 +393,41 @@ bool trmm_tiles_supported(const MatrixView<T, MatrixFormat::Dense>& A,
 // This is why one threshold cannot serve both, and why the first version of
 // this kernel -- tuned on float alone, one tile for m <= 128 -- could not beat
 // a GEMM at m = 128 in any type: R = 1 saves nothing at all.
+//
+// The 32-row tile used to be the floor, which left ormqr's WY update -- m = ib,
+// in the tens -- with R = 1 and no saving at all, and at m = 16 with half the
+// tile masked off at the epilogue after the arithmetic had already been issued.
+// A 16-row tile fixes both, and measured through ormqr_blocked_benchmark
+// (n 256/512, batch 128-256, ib 16/32/64) it goes exactly where the argument
+// above says it should -- tile16 against tile32:
+//
+//   double           1.007x - 1.022x   wins at every ib, including 64
+//   complex<double>  0.995x - 1.040x   wins to ib 32, a wash at 64
+//   complex<float>   0.993x - 1.026x   wins to ib 32, a wash at 64
+//   float            0.966x - 0.997x   loses everywhere, as predicted
+//
+// float losing is the B re-read, which is the same reason 32 loses to 64 for it
+// further up. The thresholds below are that table.
 template <typename T>
 inline int trmm_row_tile(int m) {
-    constexpr bool wide = sizeof(typename base_type<T>::type) > 4 || sycl::detail::is_complex<T>::value;
-    if (m <= 32) {
-        return 32;
-    }
+    constexpr bool complex_t = sycl::detail::is_complex<T>::value;
+    constexpr bool wide = sizeof(typename base_type<T>::type) > 4 || complex_t;
     if constexpr (wide) {
+        // Complex stops at 32 because its 64-row cell measured a wash either
+        // way (0.993x in complex<float>), and the wider tile keeps more of the
+        // block: at TileM 16 the launch is down to 64 threads.
+        if (m <= (complex_t ? 32 : 64)) {
+            return 16;
+        }
         // Never 128. Beyond the argument above, a 128x128 tile is an 8x8 thread
         // tile, which in complex<double> is 256 registers of accumulator alone
         // -- 256 threads x 256 is the entire 65536 a work-group gets, and the
         // runtime rejects the launch rather than spilling.
         return m <= 64 ? 32 : 64;
     } else {
+        if (m <= 32) {
+            return 32;
+        }
         // Measured, float, against the GEMM (ms): at m = 128 nC = 512 batch
         // 1024, TileM 32/64/128 gives 0.663 / 0.658 / 0.699 against a GEMM's
         // 0.674 -- so 128 loses and 64 wins. 32 is worse than 64 everywhere,
@@ -427,6 +454,9 @@ Event trmm_triangular_tiles(Queue& ctx,
     }();
 
     const int tile_m = forced ? forced : trmm_row_tile<T>(m);
+    if (tile_m <= 16) {
+        return launch_trmm_triangular_tiles<T, 16>(ctx, A, B, C, alpha, uplo, transA, diag);
+    }
     if (tile_m <= 32) {
         return launch_trmm_triangular_tiles<T, 32>(ctx, A, B, C, alpha, uplo, transA, diag);
     }

--- a/src/extensions/ormqr_blocked.cc
+++ b/src/extensions/ormqr_blocked.cc
@@ -25,12 +25,20 @@ namespace {
 // correct in the first place. A trmm expresses it without multiplying through
 // those zeros.
 //
-// BATCHLAS_ORMQR_WY=gemm pins the old spelling so the substitution stays
-// measurable from one binary.
-inline bool use_trmm_for_wy() {
-    static const bool result = []() {
+// BATCHLAS_ORMQR_WY pins the spelling so both stay measurable from one binary:
+// `gemm` is the old one, and `trmm` forces the substitution past the routing
+// below -- which is how a route the routing currently rejects gets measured at
+// all, rather than by editing the predicate and rebuilding.
+enum class WyPin { Measured, Gemm, Trmm };
+
+inline WyPin wy_pin() {
+    static const WyPin result = []() {
         const char* v = std::getenv("BATCHLAS_ORMQR_WY");
-        return !(v && std::string(v) == "gemm");
+        if (!v) return WyPin::Measured;
+        const std::string s(v);
+        if (s == "gemm") return WyPin::Gemm;
+        if (s == "trmm") return WyPin::Trmm;
+        return WyPin::Measured;
     }();
     return result;
 }
@@ -54,15 +62,30 @@ inline bool use_trmm_for_wy() {
 //   netlib double    0.379x - 1.064x   0.38x at n 128, ib 16
 //
 // So the dtype half was stale only for double, and the answer is per-type
-// rather than per-precision. m here is ib, in the tens, which is the one regime
-// where the tile kernel cannot use its structure: at ib <= 32 it runs a single
-// 32-row tile, R = 1, and (R+1)/2R = 1 means it skips no arithmetic whatsoever
-// and wins or loses purely on being one kernel instead of a cuBLAS call. In
-// float and double that trade is positive; a complex multiply is four real ones
-// and the same trade goes negative. It closes towards parity by ib = 64, where
-// R = 2 finally saves something (0.99x). Confirmed by trace that complex takes
+// rather than per-precision. m here is ib, in the tens, which was the one regime
+// the tile kernel could not use its structure in: the 32-row tile was its floor,
+// so ib <= 32 ran at R = 1, (R+1)/2R = 1 skipped no arithmetic whatsoever, and
+// ib = 16 additionally threw away half of what it computed at the epilogue.
+//
+// A 16-row tile was then added to see whether giving complex an R that pays
+// would close the gap (trmm_row_tile in trmm_triangular_tiles.hh, which is where
+// the tile-16-vs-tile-32 numbers live). It moves every type in the direction the
+// R argument predicts, but it does not change this gate. Against the GEMM, on
+// tile 16:
+//
+//   double           1.013x - 1.036x   was 1.004x - 1.016x on tile 32
+//   complex<double>  0.996x - 1.018x   was 0.958x - 1.010x; median exactly 1.000
+//   complex<float>   0.946x - 0.983x   was 0.944x - 0.995x; still behind
+//
+// complex<double>'s ib = 16 hole does close (0.958x -> 0.996x), but closing to
+// parity is not a reason to switch a call site, and complex<float> stays 2-5%
+// behind because the deficit there is not the R saving: a complex multiply is
+// four real ones, so the kernel is that much further from cuBLAS's per-flop rate
+// to begin with, and one 16x16 triangle's worth of saved arithmetic cannot pay
+// it back. Confirmed by trace that complex takes
 // trmm_cuda_custom.triangular_tiles and not the expansion fallback, so this is
-// the kernel's own shape response, not a mis-route.
+// the kernel's own shape response, not a mis-route. The type stays excluded; the
+// tile is kept because double wants it.
 //
 // netlib is excluded for a different reason. Its trmm and its gemm are both
 // per-batch cblas loops, so the batching is not the difference: OpenBLAS's
@@ -77,12 +100,15 @@ inline bool use_trmm_for_wy() {
 // and every block size syev uses is inside that anyway.
 template <Backend B, typename T>
 inline bool wy_trmm_applicable(int ib) {
+    const WyPin pin = wy_pin();
+    if (pin != WyPin::Measured) {
+        return pin == WyPin::Trmm;
+    }
     // The routes whose trmm reaches the batched triangular tile kernel. Not a
     // statement about CUDA the vendor -- it is where the kernel is wired.
     constexpr bool route_has_tile_kernel = (B == Backend::CUDA);
     constexpr bool type_beats_gemm_at_this_m = !internal::is_complex<T>::value;
-    return route_has_tile_kernel && type_beats_gemm_at_this_m && ib <= 64 &&
-           use_trmm_for_wy();
+    return route_has_tile_kernel && type_beats_gemm_at_this_m && ib <= 64;
 }
 
 // Returns true when BATCHLAS_ORMQR_IMPL=device, false otherwise (legacy is the default).

--- a/src/extensions/ormqr_blocked.cc
+++ b/src/extensions/ormqr_blocked.cc
@@ -35,16 +35,54 @@ inline bool use_trmm_for_wy() {
     return result;
 }
 
-// Where the tile kernel is ahead of the GEMM it replaces. Float and CUDA
-// because that is the only combination with a batched triangular kernel --
-// everything else would take trmm_vendor_impl, which expands the triangle into
-// a scratch buffer and then runs the very GEMM being replaced, strictly worse.
-// ib <= 64 because above it the tile kernel measured 0.83x-0.97x against the
-// GEMM (see experiments/TRMM_SYRK_BATCHED_KERNELS.md); every block size syev
-// uses is inside that anyway.
+// Where the tile kernel is ahead of the GEMM it replaces.
+//
+// This gate was written as `CUDA && float` on the argument that CUDA float was
+// the only combination reaching a batched triangular kernel at all. That
+// argument has expired -- the tile kernel is plain SYCL and type-generic, and
+// the CUDA router now sends double and complex to it too -- so the gate was
+// lifted outright and then measured, ormqr_blocked_benchmark, Side::Left,
+// ABBA-ordered against BATCHLAS_ORMQR_WY=gemm on a dedicated 4090, n in
+// {256,512,1024}, batch 128-256, nb in {16,32,64}. Ratios are gemm/trmm, so
+// above 1.00 is trmm ahead:
+//
+//   float            1.006x - 1.046x   every cell
+//   double           1.004x - 1.016x   every cell
+//   complex<float>   0.944x - 0.995x   every cell, ~3-5% behind
+//   complex<double>  0.958x - 1.010x   behind at ib 16, level above it
+//   netlib float     0.336x - 1.199x   0.34x at n 128, ib 16
+//   netlib double    0.379x - 1.064x   0.38x at n 128, ib 16
+//
+// So the dtype half was stale only for double, and the answer is per-type
+// rather than per-precision. m here is ib, in the tens, which is the one regime
+// where the tile kernel cannot use its structure: at ib <= 32 it runs a single
+// 32-row tile, R = 1, and (R+1)/2R = 1 means it skips no arithmetic whatsoever
+// and wins or loses purely on being one kernel instead of a cuBLAS call. In
+// float and double that trade is positive; a complex multiply is four real ones
+// and the same trade goes negative. It closes towards parity by ib = 64, where
+// R = 2 finally saves something (0.99x). Confirmed by trace that complex takes
+// trmm_cuda_custom.triangular_tiles and not the expansion fallback, so this is
+// the kernel's own shape response, not a mis-route.
+//
+// netlib is excluded for a different reason. Its trmm and its gemm are both
+// per-batch cblas loops, so the batching is not the difference: OpenBLAS's
+// ?trmm is simply weak on a 16x16 triangle against 128 right-hand sides, and
+// the route also copies B into C first because cblas_?trmm works in place.
+// ROCm is excluded because rocblas_?trmm is a per-batch vendor loop against a
+// strided-batched GEMM -- wire the tile kernel into rocblas.cc's trmm and this
+// predicate is where to re-measure.
+//
+// ib <= 64 predates all of the above and stays: past it the tile kernel
+// measured 0.83x-0.97x in float (see experiments/TRMM_SYRK_BATCHED_KERNELS.md),
+// and every block size syev uses is inside that anyway.
 template <Backend B, typename T>
 inline bool wy_trmm_applicable(int ib) {
-    return B == Backend::CUDA && std::is_same_v<T, float> && ib <= 64 && use_trmm_for_wy();
+    // The routes whose trmm reaches the batched triangular tile kernel. Not a
+    // statement about CUDA the vendor -- it is where the kernel is wired.
+    constexpr bool route_has_tile_kernel = (B == Backend::CUDA);
+    constexpr bool type_beats_gemm_at_this_m = !internal::is_complex<T>::value;
+    return route_has_tile_kernel && type_beats_gemm_at_this_m && ib <= 64 &&
+           use_trmm_for_wy();
 }
 
 // Returns true when BATCHLAS_ORMQR_IMPL=device, false otherwise (legacy is the default).
@@ -466,16 +504,17 @@ Event ormqr_blocked_impl(Queue& ctx,
             gemm<B>(q, Vblk, Csub, W1, {.transA = Transpose::ConjTrans});
 
             const Transpose t_eff = transpose_apply ? Transpose::ConjTrans : Transpose::NoTrans;
-            // W2 = op(T) W1. trmm overwrites C on the routes that have a
-            // batched kernel, matching this GEMM's beta = 0, so the two are
-            // interchangeable here.
-            if constexpr (B == Backend::CUDA && std::is_same_v<T, float>) {
-                if (wy_trmm_applicable<B, T>(ib)) {
-                    trmm<B, T>(q, Tblk, W1, W2, T(1),
-                               Side::Left, Uplo::Upper, t_eff, Diag::NonUnit);
-                } else {
-                    gemm<B>(q, Tblk, W1, W2, {.transA = t_eff});
-                }
+            // W2 = op(T) W1. Every trmm ormqr is instantiated for writes C
+            // rather than accumulating into it -- the tile kernel and the
+            // expand-plus-GEMM fallback both pass beta = 0, rocBLAS uses the
+            // out-of-place 14-argument form, and the netlib route copies B into
+            // C and calls the in-place cblas_?trmm on it -- which matches this
+            // GEMM's beta = 0, so the two are interchangeable here. (The
+            // accumulating trmm in extensions/trmm.cc is MKL-only and ormqr is
+            // not instantiated for MKL.)
+            if (wy_trmm_applicable<B, T>(ib)) {
+                trmm<B, T>(q, Tblk, W1, W2, T(1),
+                           Side::Left, Uplo::Upper, t_eff, Diag::NonUnit);
             } else {
                 gemm<B>(q, Tblk, W1, W2, {.transA = t_eff});
             }

--- a/tests/ormqr_blocked_tests.cc
+++ b/tests/ormqr_blocked_tests.cc
@@ -21,12 +21,21 @@ struct OrmqrBlockedConfig {
     static constexpr Backend BackendVal = B;
 };
 
-// CUDA-only: this repo setup expects CUDA to be the working backend here.
+// The GPU backend is the one this repo setup expects to be working, but the
+// host backend runs the same blocked algorithm over different BLAS routes --
+// the WY update's trmm among them -- so it is covered too wherever it is built
+// rather than only when no GPU backend is.
 #if BATCHLAS_HAS_CUDA_BACKEND
 using OrmqrBlockedTestTypes = ::testing::Types<OrmqrBlockedConfig<float, Backend::CUDA>,
                                               OrmqrBlockedConfig<double, Backend::CUDA>,
                                               OrmqrBlockedConfig<std::complex<float>, Backend::CUDA>,
-                                              OrmqrBlockedConfig<std::complex<double>, Backend::CUDA>>;
+                                              OrmqrBlockedConfig<std::complex<double>, Backend::CUDA>
+#if BATCHLAS_HAS_HOST_BACKEND
+                                              ,
+                                              OrmqrBlockedConfig<float, Backend::NETLIB>,
+                                              OrmqrBlockedConfig<double, Backend::NETLIB>
+#endif
+                                              >;
 #elif BATCHLAS_HAS_ROCM_BACKEND
 using OrmqrBlockedTestTypes = ::testing::Types<OrmqrBlockedConfig<float, Backend::ROCM>,
                                               OrmqrBlockedConfig<double, Backend::ROCM>,


### PR DESCRIPTION
Lifts the `CUDA && float` gate on ormqr_blocked's WY update, then follows the
one hypothesis that lift left open -- that complex loses only because the tile
kernel had no row tile narrow enough to give it an `R` that pays.

## The lift

The gate read `B == Backend::CUDA && is_same_v<T, float>`, justified by CUDA
float being the only route reaching a batched triangular kernel at all. That
argument had expired: the tile kernel is plain SYCL and type-generic, and the
CUDA router sends double and complex to it too. So the gate came off outright
and the result was measured rather than assumed -- ABBA-ordered against
`BATCHLAS_ORMQR_WY=gemm` on a dedicated 4090, `Side::Left`, n in
{256,512,1024}, batch 128-256, nb in {16,32,64}, two passes at different
measurement windows that agree. Ratios are gemm/trmm, so above 1.00 is trmm
ahead:

| route | ratio | |
|---|---|---|
| `float` | 1.006x - 1.046x | wins everywhere (already shipped) |
| `double` | 1.004x - 1.016x | **wins everywhere -- newly enabled** |
| `complex<float>` | 0.944x - 0.995x | loses everywhere |
| `complex<double>` | 0.958x - 1.010x | loses at ib 16, level above |
| netlib `float` / `double` | 0.34x / 0.38x at n 128, ib 16 | loses badly |

**Only the double half of the gate was stale, and the split is per-type, not
per-precision.** A blanket lift was implemented and measured first; it is not
what ships, because it would default complex to a 3-5% loss and netlib to 3x.

netlib loses for a reason unrelated to the kernel: its trmm and its gemm are
*both* per-batch cblas loops, so batching is not the difference -- OpenBLAS's
`?trmm` is simply weak on a 16x16 triangle against 128 right-hand sides, and the
route also copies B into C first because `cblas_?trmm` works in place. ROCm is
excluded because `rocblas_?trmm` is a per-batch vendor loop standing against a
strided-batched GEMM.

What ships is a runtime predicate rather than an `if constexpr` wall, naming the
two facts it depends on, so the next route to wire up a tile kernel has one
place to re-measure.

## The 16-row tile

The 32-row tile was the kernel's floor, so ormqr's WY update -- `m = ib`, in the
tens -- ran at `R = 1` and skipped no arithmetic at all, and `ib = 16` computed
32 rows and masked half of them off at the epilogue after the FMAs had issued.
A 16-row tile gives `ib = 32` `R = 2` and `ib = 16` an exact fit.

It needed one change beyond the instantiation: `ThreadRows` must stay a multiple
of 4 for the 4-wide fragment bands, and `16 / 8 lanes = 2` is not, so the 16-row
tile drops to 4 row lanes (a 64-thread block) rather than narrowing the band.

tile16 against tile32, both forced through `BATCHLAS_TRMM_TILE_M` in one binary:

| type | vs tile32 | vs GEMM | was, on tile32 |
|---|---|---|---|
| `double` | 1.007x - 1.022x | **1.013x - 1.036x** | 1.004x - 1.016x |
| `complex<double>` | 0.995x - 1.040x | 0.996x - 1.018x | 0.958x - 1.010x |
| `complex<float>` | 0.993x - 1.026x | 0.946x - 0.983x | 0.944x - 0.995x |
| `float` | 0.966x - 0.997x | -- | keeps tile32 |

**The R argument is confirmed and it is not enough for complex.** Every type
moves the way the argument predicts, including float losing -- that is B's
re-read, the same effect that makes 32 lose to 64 for float further up.
`complex<double>`'s `ib = 16` hole does close, 0.958x to 0.996x, which is the
clearest confirmation available that the hole was the masked-off half tile. But
it closes to parity, and `complex<float>` stays 2-5% behind, because the complex
deficit was never mainly the R saving: a complex multiply is four real ones, so
the kernel starts that much further from cuBLAS's per-flop rate and one 16x16
triangle of skipped arithmetic cannot pay the difference back.

So the gate is unchanged and complex still takes the GEMM. The tile is kept
because the type it pays for is **double**, the route the first commit had just
enabled: **1.014x - 1.028x against the GEMM end to end, up from 1.005x -
1.016x**, better in all six cells. `trmm_row_tile` routes double to 16 through
m = 64 and complex to 16 through m = 32; complex's 64-row cell is a wash and
keeps the wider tile, since TileM 16 is only a 64-thread block. float untouched.

## Also

- `BATCHLAS_ORMQR_WY` gains `trmm` alongside `gemm`, forcing the substitution
  past the routing -- which is how a route the routing rejects gets measured
  without editing the predicate and rebuilding.
- `ormqr_blocked_tests` gains the two netlib configurations. The type list was a
  CUDA-*or*-host `#if`, so with a GPU backend built the host route had no
  coverage at all -- which a lift extending to netlib would have needed.
- `experiments/TRMM_SYRK_BATCHED_KERNELS.md` carries both full tables.

## Testing

`trmm_tests`, `ormqr_tests`, `ormqr_blocked_tests` (30/30, all four CUDA dtypes
plus the two new netlib configs), `syev_blocked_tests`, `syev_two_stage_tests`
all pass. `trmm_tests` is also green under a forced 16 tile across 336 traced
tile-kernel launches. Verified by trace that complex reaches
`trmm_cuda_custom.triangular_tiles` and not the expansion fallback, so its loss
is the kernel's shape response and not a mis-route; and verified the shipped
default is inert for complex (1.000x).

One pre-existing failure clarified, not introduced here: netlib `double` fails
when the test binary is run directly, identically with the old `gemm` spelling,
including on `Side::Right` which never touches trmm. That is the known bad
OpenBLAS kernel on this machine; ctest sets `OPENBLAS_CORETYPE=SKYLAKEX` itself,
as `build/batchlas-env.sh` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFRtDtU8dqVLTnWvv3LRfD
