### PR TITLE
fix(tuning): make the harness runnable, split the aliased constants, and retune

### DIFF
--- a/cmake/tuning_params.h.in
+++ b/cmake/tuning_params.h.in
@@ -8,6 +8,16 @@
 
 namespace batchlas::tuning {
 
+// WARNING: this template is DEAD CODE and has drifted from the real header.
+//
+// It is configured into build/include/batchlas/tuning_params.hh, but the
+// compile line lists -I<repo>/include before -I<repo>/build/include, so
+// include/batchlas/tuning_params.hh always shadows it. Nothing compiles what
+// this file generates. It is already missing accessors the sources call
+// (sytrd_fuse_panel_update_for_n, the bucketed LATRD hint, gebrd_block_size_for_n),
+// so making it live again requires porting those first, not just fixing -I order.
+//
+// See evaluation/tuning/README.md, "Generating compile-time tuning constants".
 inline constexpr int32_t ORMQR_BLOCK_SIZE_TINY = @BATCHLAS_TUNE_DEFAULT_ORMQR_BLOCK_SIZE_TINY@;
 inline constexpr int32_t ORMQR_BLOCK_SIZE_SMALL = @BATCHLAS_TUNE_DEFAULT_ORMQR_BLOCK_SIZE_SMALL@;
 inline constexpr int32_t ORMQR_BLOCK_SIZE_MEDIUM = @BATCHLAS_TUNE_DEFAULT_ORMQR_BLOCK_SIZE_MEDIUM@;

--- a/evaluation/perf_eval.py
+++ b/evaluation/perf_eval.py
@@ -528,18 +528,18 @@ def main(argv: Optional[List[str]] = None) -> int:
         p.error("Must specify --record or --check")
 
     repo_root = _repo_root()
-    build_dir = Path(args.build_dir) if args.build_dir else _default_build_dir(repo_root)
+    build_dir = Path(args.build_dir) if args.build_dir else default_build_dir(repo_root)
     cases_path = Path(args.cases) if args.cases else (repo_root / "evaluation" / "perf_cases.json")
     baseline_path = (repo_root / args.baseline).resolve() if not Path(args.baseline).is_absolute() else Path(args.baseline)
 
     cases = _load_cases(cases_path)
 
-    stedc_exe = _default_benchmark_path(build_dir, "stedc_benchmark")
-    steqr_exe = _default_benchmark_path(build_dir, "steqr_benchmark")
-    sytrd_cta_exe = _default_benchmark_path(build_dir, "sytrd_cta_benchmark")
+    stedc_exe = default_benchmark_path(build_dir, "stedc_benchmark")
+    steqr_exe = default_benchmark_path(build_dir, "steqr_benchmark")
+    sytrd_cta_exe = default_benchmark_path(build_dir, "sytrd_cta_benchmark")
     # Historical naming: the executable is ormqr_cta_benchmark, but the kernel under test is ormqx_cta.
-    ormx_cta_exe = _default_benchmark_path(build_dir, "ormqr_cta_benchmark")
-    syev_cta_exe = _default_benchmark_path(build_dir, "syev_cta_benchmark")
+    ormx_cta_exe = default_benchmark_path(build_dir, "ormqr_cta_benchmark")
+    syev_cta_exe = default_benchmark_path(build_dir, "syev_cta_benchmark")
 
     measurements: List[Measurement] = []
     trace_events: Optional[List[Dict[str, Any]]] = [] if args.trace else None

--- a/evaluation/tuning/README.md
+++ b/evaluation/tuning/README.md
@@ -33,7 +33,7 @@ Notes:
   "What is still untuned" below.
 
 A bench belongs in `default.json` only if the generator names it. Today that is
-`stedc`, `sytrd_blocked`, `ormqr_blocked`, `syev`, `gesvd`, `latrd_lower_panel`.
+`stedc`, `sytrd_blocked`, `ormqr_blocked`, `syev`, `gesvd`, `sb2st`, `sy2sb`.
 Anything else is measured and then silently dropped — which is what `steqr` did
 for its whole life in `default.json`.
 
@@ -47,6 +47,9 @@ Each bench entry contains:
 - Optional `env`: `{param_name: ENV_VAR}`. Params listed here are passed to the
   benchmark as environment variables instead of positional arguments, and must
   *not* appear in `arg_spec`.
+- Optional `row`: substring selecting which benchmark row to read when the
+  executable registers more than one. **Required** in that case — the harness
+  now refuses to guess.
 
 `pre_tune` phases run before the main search. The selected values are then injected into every case as fixed parameters for the main sweep and are still recorded in the final profile's `best`, `top`, and `per_case_best` parameter sets.
 
@@ -65,6 +68,47 @@ retune "wins" with the best of a grid that never contained the incumbent and
 silently downgrades it. `stedc`'s `wg_multiplier` swept `[1,2,4]` while
 `STEDC_WG_MULTIPLIER_*` shipped 8, for exactly this failure.
 
+**One executable can register several benchmarks.** `sb2st_hh_benchmark` emits
+`BM_SB2ST_HH_CHASE` and `BM_SB2ST_HH_BACK`; `syev_two_stage_benchmark` emits
+`BM_SYEV_BLOCKED_BASELINE` and `BM_SYEV_TWO_STAGE`. Reading the first row
+measured a kernel the tuned parameters cannot affect and reported the resulting
+noise (1.4% spread) as a winner, where the intended kernel spans 3.6x. Set
+`row`; `tune.py` errors out rather than picking one for you, and `--validate`
+catches it in seconds.
+
+## Pruning the space: `sensitivity.py`
+
+Grid search costs the product of every grid, so an axis that changes nothing
+multiplies the cost of every other axis for free.
+
+```
+python3 evaluation/tuning/sensitivity.py build/tuning/profile.json
+```
+
+For each `(bench, parameter)` it sweeps that parameter with everything else held
+fixed and reports how far the metric moves. Prefer the **profile** over a log:
+env-only params never appear in the benchmark's CSV columns, so a log cannot
+see them at all.
+
+The 2026-08-07 pass removed the `latrd_lower_panel` bench outright — its only
+tuned parameter moved the metric by at most 0.38%, so it was sampling, not
+tuning — and trimmed values that never won. Net: **609 → 265 invocations while
+adding sb2st and sy2sb coverage.**
+
+## The consumer can overrule the bench
+
+Not just for aliased constants — it happens to ordinary ones too. The `stedc`
+bench picked `wg_multiplier` 2–4 and `threads_per_root` 4–8. Adopting that cost
+**syev 2.7% at n=256**. Measured through syev with everything else pinned, 8/8
+wins nearly everywhere (7.6% at n=64; noise at n≥512), so both ship as 8.
+
+The stedc benchmark measures the merge in isolation; syev pays for the whole
+tridiagonal solve. Those are different objectives and they disagree. A
+parameter whose owning bench is not its dominant consumer must be confirmed at
+the consumer before adoption — the sensitivity number from the isolated bench
+(0.56% median for `wg_multiplier`) understated its real cost by an order of
+magnitude.
+
 ## Output format (high level)
 
 The output JSON contains:
@@ -82,7 +126,7 @@ one. Verify with:
 ```
 g++ -std=c++17 -fsyntax-only -I include -I build/include -x c++ - <<'EOF'
 #include <batchlas/tuning_params.hh>
-static_assert(batchlas::tuning::ORMQR_BLOCK_SIZE_MEDIUM == 16);
+static_assert(batchlas::tuning::ORMQR_BLOCK_SIZE_MEDIUM == 24);
 EOF
 ```
 
@@ -320,14 +364,16 @@ Measured shares on CUDA/float, RTX 4090, from `BATCHLAS_KERNEL_TRACE=1` and
 
 | kernel | share | tuned by |
 |---|---|---|
-| `syev_two_stage.sb2st_hh` | **52.9%** of syev at n=1024 | nothing |
-| `gesvd.gebrd` | **79-95%** of gesvd | `gesvd` bench (new) |
-| `ormqr_blocked.larft` + `pack_v_panel` | ~20% of syev at n=1024 | `ormqr_blocked`, but shadowed on syev's hot path by the sy2sb gate |
-| two-stage band width `kd` | sets the whole stage-1/chase balance | nothing (hand table) |
+| `syev_two_stage.sb2st_hh` | **52.9%** of syev at n=1024 | `sb2st` bench — but its heuristic already wins, so the constants stay 0 |
+| `gesvd.gebrd` | **79-95%** of gesvd | `gesvd` bench |
+| `ormqr_blocked.larft` + `pack_v_panel` | ~20% of syev at n=1024 | `ormqr_blocked`, plus `sy2sb` for the width that shadows it |
+| two-stage band width `kd` | sets the whole stage-1/chase balance | nothing (hand table) — still in `unwired.json` |
+| chase blocking factor | hardcoded 32 | nothing — still in `unwired.json` |
+| steqr CTA knobs | leaf of every stedc merge | nothing — still in `unwired.json` |
 
-`sb2st_hh` is the single largest kernel in the library's eigensolver path and no
-bench in `default.json` touches it. Its knobs are env-only with no constants
-behind them, which is why it sits in `unwired.json`.
+`sb2st_hh` is the single largest kernel in the eigensolver path. It is now
+tuned, and the answer was that the shipped heuristic is already right — worth
+knowing, and only knowable by measuring.
 
 Promoting anything out of `unwired.json` takes three steps, in order:
 

--- a/evaluation/tuning/README.md
+++ b/evaluation/tuning/README.md
@@ -41,23 +41,78 @@ The output JSON contains:
 
 ## Generating compile-time tuning constants
 
-BatchLAS now provides a generated header at build time:
+**The header the library actually compiles is `include/batchlas/tuning_params.hh`,
+not the one under `build/include/`.** Both files exist and declare the same
+symbols, and the compile line lists `-I<repo>/include` *before*
+`-I<repo>/build/include`, so the checked-in header always shadows the generated
+one. Verify with:
 
-- `build/include/batchlas/tuning_params.hh`
+```
+g++ -std=c++17 -fsyntax-only -I include -I build/include -x c++ - <<'EOF'
+#include <batchlas/tuning_params.hh>
+static_assert(batchlas::tuning::ORMQR_BLOCK_SIZE_MEDIUM == 16);
+EOF
+```
 
-By default, this header is generated with safe fallback values at CMake configure time.
+Consequences, both confirmed on this tree:
 
-To generate benchmark-derived constants from a profile:
+- `cmake --build build --target batchlas_tuning_header` writes
+  `build/include/batchlas/tuning_params.hh` and therefore **changes nothing**.
+  It is a no-op for the library.
+- CMake's `configure_file` rewrites that same path from hardcoded defaults on
+  every reconfigure, so even its contents are transient.
 
-- One-shot from an existing profile:
+To actually move the constants, regenerate and port the values into the
+checked-in header:
 
-  `python3 evaluation/tuning/generate_tuning_header.py --profile build/tuning/profile.json --out build/include/batchlas/tuning_params.hh`
+```
+python3 evaluation/tuning/generate_tuning_header.py \
+    --profile build/tuning/profile.json \
+    --out /tmp/tuning_params.hh
+diff include/batchlas/tuning_params.hh /tmp/tuning_params.hh
+```
 
-- Through CMake target (when `BATCHLAS_ENABLE_TUNING=ON`):
+Copy across only the `inline constexpr` values you intend to change. Do not
+overwrite the file wholesale: its comments are hand-maintained (see the
+`StedcMergeVariant` note), the generator's template does not carry them, and
+several shipped constants are outside the default space's grid — regenerating
+blindly would silently downgrade e.g. `STEDC_WG_MULTIPLIER_*` from 8 to 4
+because the space only sweeps `[1,2,4]`.
 
-  `cmake --build build --target batchlas_tuning_header`
+### Faster: A/B a candidate with no rebuild
 
-This target depends on `batchlas_tune`, so it will run the tuning harness first and then regenerate the header.
+Every accessor consults an environment variable first, so a candidate can be
+measured against the compiled default in the existing build:
+
+```
+BATCHLAS_TUNE_ORMQR_BLOCK_SIZE=48 ./build/benchmarks/gesvd_blocked_benchmark \
+    --backend=CUDA --type=float 512 256
+```
+
+The variables are `BATCHLAS_TUNE_{ORMQR_BLOCK_SIZE, SYTRD_BLOCK_SIZE,
+LATRD_WG_HINT, STEDC_RECURSION_THRESHOLD, STEDC_MERGE_VARIANT,
+STEDC_THREADS_PER_ROOT, STEDC_WG_MULTIPLIER}`. Each overrides *all* size
+buckets at once, so test one `n` at a time. Do not change one mid-process: the
+same accessor feeds `*_buffer_size()` queries and the matching solve.
+
+## Validate a winner at the consumer before adopting it
+
+A per-kernel winner is not automatically an end-to-end win, and can be a loss.
+Measured 2026-08-06 on CUDA/float after fixing the grid-intersection bug:
+
+| block size | ormqr kernel, n=1024 | syev n=1024 | gesvd_blocked n=512 |
+|---|---|---|---|
+| 16 (shipped) | 536 µs | 899 µs | 940 µs |
+| 48/56 (tuned) | 238 µs (**2.16x faster**) | 905 µs (no change) | 1045 µs (**11% slower**) |
+
+So the 2.16x kernel win was not adopted. `ORMQR_BLOCK_SIZE_*` is read by
+`syev_blocked`, `syev_two_stage`, `syevx_direct_subset` *and* by
+`gesvd_blocked.cc`, where it also sets `gebrd_block_size` — a different kernel
+with a different optimum. `ormqr_blocked_benchmark` cannot see that coupling
+because it takes the block size as an explicit argument.
+
+Always A/B the consumer benchmarks with the env override before editing a
+constant.
 
 ## Current model (size-aware only)
 
@@ -105,23 +160,46 @@ At runtime, recursion thresholds are clamped to local subproblem size (`threshol
 
 ## Practical workflow
 
-1) Configure with benchmarks+tuning enabled:
+Do not use the `batchlas_tuning_header` CMake target -- see above, it writes a
+header nothing compiles. Drive the scripts directly.
 
-`cmake -B build -DBATCHLAS_BUILD_BENCHMARKS=ON -DBATCHLAS_ENABLE_TUNING=ON`
+1) Build the five benchmarks the default space needs (they are ordinary
+   benchmark targets; `BATCHLAS_ENABLE_TUNING` is not required):
 
-2) Run tuning + regenerate header:
+```
+cmake -B build -DBATCHLAS_BUILD_BENCHMARKS=ON
+cmake --build build -j --target stedc_benchmark steqr_benchmark \
+      sytrd_blocked_benchmark ormqr_blocked_benchmark syev_benchmark
+```
 
-`cmake --build build --target batchlas_tuning_header -j`
+2) Run the sweep. **~12 minutes** for the full default space on CUDA/float
+   (RTX 4090, measured 2026-08-06: 535 benchmark invocations):
 
-3) Inspect outputs:
+```
+python3 evaluation/tuning/tune.py \
+    --space evaluation/tuning/spaces/default.json \
+    --backend CUDA --type float \
+    --out build/tuning/profile.json --skip-missing
+```
 
-- Profile JSON: `build/tuning/profile.json`
-- Generated header: `build/include/batchlas/tuning_params.hh`
+   Prefer `--skip-missing` alone. Adding `--skip-failed` (which the CMake target
+   passes) converts a broken bench into a silent omission and still writes a
+   profile that looks successful.
 
-4) Verify the selected parameters:
+   To go faster, cut the space file rather than the iteration counts: drop the
+   large-`n` cases, which dominate. `sytrd_blocked` at n=1024 is ~7.4 s per
+   invocation against ~0.6 s for the small cases.
 
-- Check `results[].per_case_best` for per-`n` winners.
-- Check header constants and `*_for_n` selectors match your expected ranges.
+3) Inspect the profile at `build/tuning/profile.json`:
+
+- `results[].per_case_best` -- per-`n` winners, what the bucketed header reads.
+- `results[].best` -- the single parameter set best *averaged* across cases.
+  Only combos legal for every case appear here, so for a bench whose per-case
+  grids barely overlap this is a much smaller search than `per_case_best`.
+
+4) A/B any candidate with the env override (no rebuild), at the *consumer*
+   benchmark, then port the constant by hand into
+   `include/batchlas/tuning_params.hh` and rebuild.
 
 ## Notes
 

--- a/evaluation/tuning/README.md
+++ b/evaluation/tuning/README.md
@@ -95,24 +95,85 @@ STEDC_THREADS_PER_ROOT, STEDC_WG_MULTIPLIER}`. Each overrides *all* size
 buckets at once, so test one `n` at a time. Do not change one mid-process: the
 same accessor feeds `*_buffer_size()` queries and the matching solve.
 
-## Validate a winner at the consumer before adopting it
+## Why a kernel winner can be an end-to-end loss
 
-A per-kernel winner is not automatically an end-to-end win, and can be a loss.
-Measured 2026-08-06 on CUDA/float after fixing the grid-intersection bug:
+Measured 2026-08-06 on CUDA/float, after fixing the grid-intersection bug:
 
 | block size | ormqr kernel, n=1024 | syev n=1024 | gesvd_blocked n=512 |
 |---|---|---|---|
 | 16 (shipped) | 536 µs | 899 µs | 940 µs |
-| 48/56 (tuned) | 238 µs (**2.16x faster**) | 905 µs (no change) | 1045 µs (**11% slower**) |
+| 48/56 (tuned) | 238 µs (**2.16x faster**) | 905 µs (inert) | 1045 µs (**11% slower**) |
 
-So the 2.16x kernel win was not adopted. `ORMQR_BLOCK_SIZE_*` is read by
-`syev_blocked`, `syev_two_stage`, `syevx_direct_subset` *and* by
-`gesvd_blocked.cc`, where it also sets `gebrd_block_size` — a different kernel
-with a different optimum. `ormqr_blocked_benchmark` cannot see that coupling
-because it takes the block size as an explicit argument.
+The 2.16x kernel win was real and was still not adopted. Three separate
+mechanisms produce that, and none is visible from `ormqr_blocked_benchmark`.
 
-Always A/B the consumer benchmarks with the env override before editing a
-constant.
+### 1. Aliasing — one constant drives unrelated kernels
+
+`gesvd_blocked.cc` reads `ormqr_block_size_for_n` three times: twice for genuine
+ormbr backtransforms, and once at line 753 as `gebrd_block_size` — the
+bidiagonal reduction, a completely different kernel. With
+`BATCHLAS_GESVD_PROFILE=1` at n=512, batch=256, vectors on:
+
+| stage | nb=16 | nb=48 |
+|---|---|---|
+| `gesvd.gebrd` | 229.7 ms | 259.2 ms (**+12.8%**) |
+| `gesvd.apply_left_backtransform` | 18.35 ms | 14.87 ms (−19%) |
+| `gesvd.apply_right_backtransform` | 18.25 ms | 15.12 ms (−17%) |
+
+The two uses have **opposite gradients**, and gebrd is 6.3x the bigger term, so
+its loss (+29.5 ms) swamps the backtransform win (−6.6 ms). Worse, the two
+curves have very different shapes: sweeping the knob against the `gesvd.gebrd`
+stage alone gives 8:234.9  12:232.1  **16:230.7**  24:235.5  32:240.9  48:256.6 —
+gebrd's own optimum is 16, and its curve is flat (±2%), while ormqr's is steep
+(2.16x). Aliasing therefore pins the steep knob at the flat knob's optimum.
+
+(With vectors *off*, which is the default in `gesvd_blocked_benchmark`, the
+backtransforms do not run at all — 95% of that call is gebrd. So the original
+"11% slower" measurement was 100% gebrd, with ormqr never invoked.)
+
+### 2. Shadowing — the hot path never reads the constant
+
+syev looked insensitive, which is not the same as the parameter not mattering.
+`sytrd_sy2sb.cc`'s `sy2sb_ormqr_block_size_hint` returns `kd` outright when
+`n >= 1024 && batch >= 32`, passing ormqr an explicit hint that bypasses the
+tuning table. Flipping the tuning constant leaves the kernel trace
+*bit-identical* (124 `ormqr_blocked.larft` calls at both 16 and 56).
+
+Disable that local gate and the constant comes alive:
+
+| | nb=16 | nb=56 |
+|---|---|---|
+| `BATCHLAS_SY2SB_ORMQR_NB=off` | 1094.9 µs | 905.4 µs (**1.21x**) |
+| default (gate on) | 898.6 µs | 905.0 µs (inert) |
+
+So the win is genuine — a hand-written local override had simply already
+claimed it. **"No change" from a global knob is not evidence the parameter is
+unimportant; it can mean the knob is dead code on that path.**
+
+### 3. The bucket is keyed on the wrong dimension
+
+`ormqr_block_size_for_n` keys on `A.rows()`, but the WY block width is bounded
+by `k`, the reflector count. In sy2sb those differ by orders of magnitude
+(rows in the thousands, `k = kd = 32`). The long comment at `sytrd_sy2sb.cc:26`
+documents this, and mechanism 2 exists precisely to work around it.
+
+### What to do about it
+
+- **A/B at the consumer with the env override before editing any constant.**
+  Cheap, no rebuild. This is the one non-negotiable step.
+- **If flipping a knob changes nothing, check whether it is even read** —
+  `BATCHLAS_KERNEL_TRACE=1` and compare call counts. A bit-identical trace means
+  shadowing, not insignificance.
+- **Do not tune a shared constant through a benchmark that takes it as an
+  explicit argument.** `ormqr_blocked_benchmark` is structurally blind to all
+  three mechanisms above.
+- **Split aliased constants.** Giving gebrd its own `GEBRD_BLOCK_SIZE_*` would
+  let gebrd keep 16 while ormqr consumers take 48 — worth ~2.3% on
+  gesvd-with-vectors by the stage timings above, and it unblocks the 2.16x
+  everywhere else. This is the highest-value follow-up, and it is a code change,
+  not a tuning change.
+- **Note what is not tuned at all.** `gesvd.gebrd` is ~79% of gesvd-with-vectors
+  and ~95% without, and no bench in the default space tunes it.
 
 ## Current model (size-aware only)
 

--- a/evaluation/tuning/README.md
+++ b/evaluation/tuning/README.md
@@ -23,6 +23,20 @@ Notes:
 - Some benchmarks are only built/active for certain backends (e.g. `sytrd_blocked_benchmark` is CUDA-only today). Use `--skip-missing` to ignore unavailable executables.
 - You can change problem sizes and search ranges by editing the JSON space file.
 
+## The two space files
+
+- **`spaces/default.json`** — benches that feed a constant in
+  `include/batchlas/tuning_params.hh`. This is what you run to retune.
+- **`spaces/unwired.json`** — parameters that measurably matter but that no
+  constant can carry, so `generate_tuning_header.py` ignores them entirely.
+  Running it produces a profile for a human to read. See
+  "What is still untuned" below.
+
+A bench belongs in `default.json` only if the generator names it. Today that is
+`stedc`, `sytrd_blocked`, `ormqr_blocked`, `syev`, `gesvd`, `latrd_lower_panel`.
+Anything else is measured and then silently dropped — which is what `steqr` did
+for its whole life in `default.json`.
+
 ## Tuning space format
 
 Each bench entry contains:
@@ -30,8 +44,26 @@ Each bench entry contains:
 - `arg_spec`: positional benchmark arguments.
 - `cases`: problem sizes, each with `fixed` args and a case-local `tune` grid.
 - Optional `pre_tune`: one or more bench-level phases of the form `{ "params": { ... }, "cases": [ ... ] }`.
+- Optional `env`: `{param_name: ENV_VAR}`. Params listed here are passed to the
+  benchmark as environment variables instead of positional arguments, and must
+  *not* appear in `arg_spec`.
 
 `pre_tune` phases run before the main search. The selected values are then injected into every case as fixed parameters for the main sweep and are still recorded in the final profile's `best`, `top`, and `per_case_best` parameter sets.
+
+`env` exists because several knobs have no positional argument anywhere —
+gebrd's panel width, the LATRD wg hint, the sb2st back-transform tiling, the
+sy2sb ormqr hint. The overrides are merged onto the parent environment, never
+substituted for it, and they form part of the measurement cache key.
+
+Per-case grids are searched as a **union**, so each case sweeps exactly the grid
+it declares. Only combos legal for every case are scored into the cross-case
+`best`/`top`; per-case winners — which is what the bucketed header reads — are
+recorded regardless.
+
+**A grid must contain the value currently shipped in the header.** Otherwise a
+retune "wins" with the best of a grid that never contained the incumbent and
+silently downgrades it. `stedc`'s `wg_multiplier` swept `[1,2,4]` while
+`STEDC_WG_MULTIPLIER_*` shipped 8, for exactly this failure.
 
 ## Output format (high level)
 
@@ -262,7 +294,52 @@ python3 evaluation/tuning/tune.py \
    benchmark, then port the constant by hand into
    `include/batchlas/tuning_params.hh` and rebuild.
 
+## Dependencies between the benches
+
+Tuning order matters, because several benches inherit another's result:
+
+- **`syev` overrides `sytrd_blocked`.** Whenever a `syev` entry exists the
+  generator derives `SYTRD_BLOCK_SIZE_*` from syev's coupled `nb`, not from the
+  standalone bench. `sytrd_blocked` only fills sizes syev does not cover, so
+  syev's `nb` grid must be at least as wide as `sytrd_blocked`'s or the
+  standalone winner is unreachable.
+- **`syev` couples three knobs on purpose.** `nb`, the LATRD lower-panel `wg`
+  hint and the fused panel update trade against each other inside the panel
+  loop, so they are searched as one tuple against end-to-end eigensolver time.
+- **`stedc`'s constants are global.** They are tuned standalone and then
+  inherited by syev's and gesvd's tridiagonal solve. Tune stedc first.
+- **`ormqr` and `gebrd` must stay separate.** They shared a constant until
+  2026-08-06; see the split note in `tuning_params.hh`.
+- **`latrd_lower_panel` is a fallback only**, for sizes syev's coupled `wg`
+  does not reach.
+
+## What is still untuned
+
+Measured shares on CUDA/float, RTX 4090, from `BATCHLAS_KERNEL_TRACE=1` and
+`BATCHLAS_GESVD_PROFILE=1`:
+
+| kernel | share | tuned by |
+|---|---|---|
+| `syev_two_stage.sb2st_hh` | **52.9%** of syev at n=1024 | nothing |
+| `gesvd.gebrd` | **79-95%** of gesvd | `gesvd` bench (new) |
+| `ormqr_blocked.larft` + `pack_v_panel` | ~20% of syev at n=1024 | `ormqr_blocked`, but shadowed on syev's hot path by the sy2sb gate |
+| two-stage band width `kd` | sets the whole stage-1/chase balance | nothing (hand table) |
+
+`sb2st_hh` is the single largest kernel in the library's eigensolver path and no
+bench in `default.json` touches it. Its knobs are env-only with no constants
+behind them, which is why it sits in `unwired.json`.
+
+Promoting anything out of `unwired.json` takes three steps, in order:
+
+1. add `<NAME>_{TINY..XLARGE}` constants and a `*_for_n` accessor to
+   `include/batchlas/tuning_params.hh` (with a `BATCHLAS_TUNE_*` env override,
+   so it can be A/B'd without a rebuild);
+2. teach `generate_tuning_header.py` to derive them from the bench;
+3. make the production call site read the accessor instead of its hardcoded
+   default — this is the step that is easy to forget and that makes the whole
+   exercise a no-op if skipped.
+
 ## Notes
 
-- `syev` now supports coupled tuning of SYTRD internals (`nb`, LATRD lower-panel `wg`, and fused panel update) so the selected tuple is optimized for end-to-end eigensolver time.
+- `syev` supports coupled tuning of SYTRD internals (`nb`, LATRD lower-panel `wg`, and fused panel update) so the selected tuple is optimized for end-to-end eigensolver time.
 - If your profile does not cover some size ranges, configured fallback bucket values are used for those missing ranges.

--- a/evaluation/tuning/generate_tuning_header.py
+++ b/evaluation/tuning/generate_tuning_header.py
@@ -133,6 +133,7 @@ def _emit_header(out_path: Path,
                  ormqr_medium: int,
                  ormqr_large: int,
                  ormqr_xlarge: int,
+                 gebrd: Dict[str, int],
                  sytrd_tiny: int,
                  sytrd_small: int,
                  sytrd_medium: int,
@@ -190,6 +191,15 @@ inline constexpr int32_t ORMQR_BLOCK_SIZE_MEDIUM = {ormqr_medium};
 inline constexpr int32_t ORMQR_BLOCK_SIZE_LARGE = {ormqr_large};
 inline constexpr int32_t ORMQR_BLOCK_SIZE_XLARGE = {ormqr_xlarge};
 
+// gebrd's panel width. Deliberately NOT the ormqr constant: gesvd used to size
+// its bidiagonal reduction from ORMQR_BLOCK_SIZE_*, and the two have opposite
+// gradients, so one knob pinned the steep parameter at the flat one's optimum.
+inline constexpr int32_t GEBRD_BLOCK_SIZE_TINY = {gebrd["tiny"]};
+inline constexpr int32_t GEBRD_BLOCK_SIZE_SMALL = {gebrd["small"]};
+inline constexpr int32_t GEBRD_BLOCK_SIZE_MEDIUM = {gebrd["medium"]};
+inline constexpr int32_t GEBRD_BLOCK_SIZE_LARGE = {gebrd["large"]};
+inline constexpr int32_t GEBRD_BLOCK_SIZE_XLARGE = {gebrd["xlarge"]};
+
 inline constexpr int32_t SYTRD_BLOCK_SIZE_TINY = {sytrd_tiny};
 inline constexpr int32_t SYTRD_BLOCK_SIZE_SMALL = {sytrd_small};
 inline constexpr int32_t SYTRD_BLOCK_SIZE_MEDIUM = {sytrd_medium};
@@ -242,6 +252,14 @@ inline constexpr int32_t ormqr_block_size_default_for_n(int32_t n) {{
     if (n <= 256) return ORMQR_BLOCK_SIZE_MEDIUM;
     if (n <= 512) return ORMQR_BLOCK_SIZE_LARGE;
     return ORMQR_BLOCK_SIZE_XLARGE;
+}}
+
+inline constexpr int32_t gebrd_block_size_default_for_n(int32_t n) {{
+    if (n <= 64) return GEBRD_BLOCK_SIZE_TINY;
+    if (n <= 128) return GEBRD_BLOCK_SIZE_SMALL;
+    if (n <= 256) return GEBRD_BLOCK_SIZE_MEDIUM;
+    if (n <= 512) return GEBRD_BLOCK_SIZE_LARGE;
+    return GEBRD_BLOCK_SIZE_XLARGE;
 }}
 
 inline constexpr int32_t sytrd_block_size_default_for_n(int32_t n) {{
@@ -302,6 +320,11 @@ inline int32_t ormqr_block_size_for_n(int32_t n) {{
                                        ormqr_block_size_default_for_n(n));
 }}
 
+inline int32_t gebrd_block_size_for_n(int32_t n) {{
+    return detail::tuning_env_override("BATCHLAS_TUNE_GEBRD_BLOCK_SIZE",
+                                       gebrd_block_size_default_for_n(n));
+}}
+
 inline int32_t sytrd_block_size_for_n(int32_t n) {{
     return detail::tuning_env_override("BATCHLAS_TUNE_SYTRD_BLOCK_SIZE",
                                        sytrd_block_size_default_for_n(n));
@@ -360,6 +383,11 @@ def main() -> int:
     parser.add_argument("--fallback-ormqr-block-size-medium", type=int, default=-1)
     parser.add_argument("--fallback-ormqr-block-size-large", type=int, default=-1)
     parser.add_argument("--fallback-ormqr-block-size-xlarge", type=int, default=-1)
+    parser.add_argument("--fallback-gebrd-block-size-tiny", type=int, default=-1)
+    parser.add_argument("--fallback-gebrd-block-size-small", type=int, default=-1)
+    parser.add_argument("--fallback-gebrd-block-size-medium", type=int, default=-1)
+    parser.add_argument("--fallback-gebrd-block-size-large", type=int, default=-1)
+    parser.add_argument("--fallback-gebrd-block-size-xlarge", type=int, default=-1)
     parser.add_argument("--fallback-sytrd-block-size-tiny", type=int, default=-1)
     parser.add_argument("--fallback-sytrd-block-size-small", type=int, default=-1)
     parser.add_argument("--fallback-sytrd-block-size-medium", type=int, default=-1)
@@ -430,6 +458,22 @@ def main() -> int:
                                               sytrd_buckets["xlarge"],
                                               direction="min")
 
+    # gebrd is tuned through gesvd, whose gebrd stage is 79-95% of the call.
+    # Falls back to 16 -- the value gesvd shipped while gebrd and ormqr shared a
+    # constant -- so a profile without a gesvd bench leaves behaviour unchanged.
+    gesvd_entry = _find_bench_entry(profile, "gesvd")
+    gesvd_params = _find_best_params(profile, "gesvd")
+    gebrd_default = int(gesvd_params.get("gebrd_nb", 16))
+
+    def _gebrd_fallback(bucket: str) -> int:
+        v = getattr(args, f"fallback_gebrd_block_size_{bucket}")
+        return v if v > 0 else gebrd_default
+
+    gebrd_buckets = _derive_param_buckets(
+        gesvd_entry, "gebrd_nb",
+        *[_gebrd_fallback(b) for b in ["tiny", "small", "medium", "large", "xlarge"]],
+        direction="min")
+
     latrd_wg_fallback = int(latrd_params.get("wg", args.fallback_latrd_lower_panel_wg_hint))
     latrd_wg_buckets = _derive_param_buckets(syev_entry,
                                              "wg",
@@ -486,6 +530,7 @@ def main() -> int:
                  ormqr_buckets["medium"],
                  ormqr_buckets["large"],
                  ormqr_buckets["xlarge"],
+                 gebrd_buckets,
                  sytrd_buckets["tiny"],
                  sytrd_buckets["small"],
                  sytrd_buckets["medium"],

--- a/evaluation/tuning/generate_tuning_header.py
+++ b/evaluation/tuning/generate_tuning_header.py
@@ -134,6 +134,9 @@ def _emit_header(out_path: Path,
                  ormqr_large: int,
                  ormqr_xlarge: int,
                  gebrd: Dict[str, int],
+                 sb2st_tile: Dict[str, int],
+                 sb2st_subs: Dict[str, int],
+                 sy2sb_nb: Dict[str, int],
                  sytrd_tiny: int,
                  sytrd_small: int,
                  sytrd_medium: int,
@@ -200,6 +203,28 @@ inline constexpr int32_t GEBRD_BLOCK_SIZE_MEDIUM = {gebrd["medium"]};
 inline constexpr int32_t GEBRD_BLOCK_SIZE_LARGE = {gebrd["large"]};
 inline constexpr int32_t GEBRD_BLOCK_SIZE_XLARGE = {gebrd["xlarge"]};
 
+// sb2st back-transform geometry for the wave path. 0 = keep the shape-adaptive
+// heuristic in sytrd_sb2st_hh.cc. Only tile in {1,2,4,8} x subs in {4,8,16} are
+// instantiated; anything else falls through to a slower kernel.
+inline constexpr int32_t SB2ST_BACK_TILE_TINY = {sb2st_tile["tiny"]};
+inline constexpr int32_t SB2ST_BACK_TILE_SMALL = {sb2st_tile["small"]};
+inline constexpr int32_t SB2ST_BACK_TILE_MEDIUM = {sb2st_tile["medium"]};
+inline constexpr int32_t SB2ST_BACK_TILE_LARGE = {sb2st_tile["large"]};
+inline constexpr int32_t SB2ST_BACK_TILE_XLARGE = {sb2st_tile["xlarge"]};
+
+inline constexpr int32_t SB2ST_BACK_SUBS_TINY = {sb2st_subs["tiny"]};
+inline constexpr int32_t SB2ST_BACK_SUBS_SMALL = {sb2st_subs["small"]};
+inline constexpr int32_t SB2ST_BACK_SUBS_MEDIUM = {sb2st_subs["medium"]};
+inline constexpr int32_t SB2ST_BACK_SUBS_LARGE = {sb2st_subs["large"]};
+inline constexpr int32_t SB2ST_BACK_SUBS_XLARGE = {sb2st_subs["xlarge"]};
+
+// WY block width for the sy2sb panel back-transform. 0 = keep the shape gate.
+inline constexpr int32_t SY2SB_ORMQR_NB_TINY = {sy2sb_nb["tiny"]};
+inline constexpr int32_t SY2SB_ORMQR_NB_SMALL = {sy2sb_nb["small"]};
+inline constexpr int32_t SY2SB_ORMQR_NB_MEDIUM = {sy2sb_nb["medium"]};
+inline constexpr int32_t SY2SB_ORMQR_NB_LARGE = {sy2sb_nb["large"]};
+inline constexpr int32_t SY2SB_ORMQR_NB_XLARGE = {sy2sb_nb["xlarge"]};
+
 inline constexpr int32_t SYTRD_BLOCK_SIZE_TINY = {sytrd_tiny};
 inline constexpr int32_t SYTRD_BLOCK_SIZE_SMALL = {sytrd_small};
 inline constexpr int32_t SYTRD_BLOCK_SIZE_MEDIUM = {sytrd_medium};
@@ -260,6 +285,30 @@ inline constexpr int32_t gebrd_block_size_default_for_n(int32_t n) {{
     if (n <= 256) return GEBRD_BLOCK_SIZE_MEDIUM;
     if (n <= 512) return GEBRD_BLOCK_SIZE_LARGE;
     return GEBRD_BLOCK_SIZE_XLARGE;
+}}
+
+inline constexpr int32_t sb2st_back_tile_default_for_n(int32_t n) {{
+    if (n <= 64) return SB2ST_BACK_TILE_TINY;
+    if (n <= 128) return SB2ST_BACK_TILE_SMALL;
+    if (n <= 256) return SB2ST_BACK_TILE_MEDIUM;
+    if (n <= 512) return SB2ST_BACK_TILE_LARGE;
+    return SB2ST_BACK_TILE_XLARGE;
+}}
+
+inline constexpr int32_t sb2st_back_subs_default_for_n(int32_t n) {{
+    if (n <= 64) return SB2ST_BACK_SUBS_TINY;
+    if (n <= 128) return SB2ST_BACK_SUBS_SMALL;
+    if (n <= 256) return SB2ST_BACK_SUBS_MEDIUM;
+    if (n <= 512) return SB2ST_BACK_SUBS_LARGE;
+    return SB2ST_BACK_SUBS_XLARGE;
+}}
+
+inline constexpr int32_t sy2sb_ormqr_nb_default_for_n(int32_t n) {{
+    if (n <= 64) return SY2SB_ORMQR_NB_TINY;
+    if (n <= 128) return SY2SB_ORMQR_NB_SMALL;
+    if (n <= 256) return SY2SB_ORMQR_NB_MEDIUM;
+    if (n <= 512) return SY2SB_ORMQR_NB_LARGE;
+    return SY2SB_ORMQR_NB_XLARGE;
 }}
 
 inline constexpr int32_t sytrd_block_size_default_for_n(int32_t n) {{
@@ -323,6 +372,21 @@ inline int32_t ormqr_block_size_for_n(int32_t n) {{
 inline int32_t gebrd_block_size_for_n(int32_t n) {{
     return detail::tuning_env_override("BATCHLAS_TUNE_GEBRD_BLOCK_SIZE",
                                        gebrd_block_size_default_for_n(n));
+}}
+
+inline int32_t sb2st_back_tile_for_n(int32_t n) {{
+    return detail::tuning_env_override("BATCHLAS_TUNE_SB2ST_BACK_TILE",
+                                       sb2st_back_tile_default_for_n(n));
+}}
+
+inline int32_t sb2st_back_subs_for_n(int32_t n) {{
+    return detail::tuning_env_override("BATCHLAS_TUNE_SB2ST_BACK_SUBS",
+                                       sb2st_back_subs_default_for_n(n));
+}}
+
+inline int32_t sy2sb_ormqr_nb_for_n(int32_t n) {{
+    return detail::tuning_env_override("BATCHLAS_TUNE_SY2SB_ORMQR_NB",
+                                       sy2sb_ormqr_nb_default_for_n(n));
 }}
 
 inline int32_t sytrd_block_size_for_n(int32_t n) {{
@@ -474,6 +538,19 @@ def main() -> int:
         *[_gebrd_fallback(b) for b in ["tiny", "small", "medium", "large", "xlarge"]],
         direction="min")
 
+    # sb2st and sy2sb: 0 means "no opinion, keep the call site's heuristic",
+    # which is what ships. A profile without these benches therefore leaves
+    # behaviour unchanged rather than inventing a geometry.
+    sb2st_entry = _find_bench_entry(profile, "sb2st")
+    sy2sb_entry = _find_bench_entry(profile, "sy2sb")
+
+    sb2st_tile_buckets = _derive_param_buckets(
+        sb2st_entry, "back_tile", 0, 0, 0, 0, 0, direction="min")
+    sb2st_subs_buckets = _derive_param_buckets(
+        sb2st_entry, "back_subs", 0, 0, 0, 0, 0, direction="min")
+    sy2sb_nb_buckets = _derive_param_buckets(
+        sy2sb_entry, "sy2sb_nb", 0, 0, 0, 0, 0, direction="min")
+
     latrd_wg_fallback = int(latrd_params.get("wg", args.fallback_latrd_lower_panel_wg_hint))
     latrd_wg_buckets = _derive_param_buckets(syev_entry,
                                              "wg",
@@ -531,6 +608,9 @@ def main() -> int:
                  ormqr_buckets["large"],
                  ormqr_buckets["xlarge"],
                  gebrd_buckets,
+                 sb2st_tile_buckets,
+                 sb2st_subs_buckets,
+                 sy2sb_nb_buckets,
                  sytrd_buckets["tiny"],
                  sytrd_buckets["small"],
                  sytrd_buckets["medium"],

--- a/evaluation/tuning/generate_tuning_header.py
+++ b/evaluation/tuning/generate_tuning_header.py
@@ -174,10 +174,10 @@ namespace detail {{
 // inside one.
 inline int32_t tuning_env_override(const char* name, int32_t fallback) {{
     const char* v = std::getenv(name);
-    if (v == nullptr || *v == '\0') return fallback;
+    if (v == nullptr || *v == '\\0') return fallback;
     char* end = nullptr;
     const long parsed = std::strtol(v, &end, 10);
-    if (end == v || *end != '\0') return fallback;   // not a clean integer
+    if (end == v || *end != '\\0') return fallback;   // not a clean integer
     if (parsed <= 0 || parsed > 2147483647L) return fallback;  // non-positive / out of range
     return static_cast<int32_t>(parsed);
 }}

--- a/evaluation/tuning/sensitivity.py
+++ b/evaluation/tuning/sensitivity.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Find tuning parameters that do not earn their place in the search.
+
+Grid search costs the product of every grid, so a parameter that changes
+nothing multiplies the run time of every other parameter for free. This reads a
+sweep log and, for each (bench, case, parameter), reports how much the metric
+moves across that parameter's values when the others are held fixed.
+
+Usage:
+    python3 evaluation/tuning/sensitivity.py build/tuning/sweep_log.txt
+    python3 evaluation/tuning/sensitivity.py build/tuning/sweep_log.txt --noise 1.5
+
+Read it as: "holding everything else constant, sweeping this parameter changes
+the metric by X% in the median case". Below the noise floor the parameter is
+not being tuned, it is being sampled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+# The benchmarks colour their output; the arg columns follow the name column.
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+# The name column has no trailing space before the first argument -- rows read
+# "(BM_SYEV<float, batchlas::Backend::CUDA>)1024    256 ...". Splitting on
+# whitespace alone glues ")1024" to the template arguments and silently drops
+# arg0, which shifts every column by one and makes the iteration count look
+# like the last tuned parameter. Match the closing paren explicitly.
+ROW = re.compile(r"\(BM_([A-Z_0-9]+)<[^)]*\)\s*(.*)$")
+
+# arg_spec per benchmark executable, matching evaluation/tuning/spaces/*.json.
+# Only args that any space actually tunes need naming; the rest anchor position.
+ARG_NAMES: Dict[str, List[str]] = {
+    "STEDC": ["n", "batch", "recursion_threshold", "flat", "threads_per_root", "wg_multiplier"],
+    "STEQR": ["n", "batch", "n_sweeps", "wg_multiplier", "shift_kind"],
+    "SYTRD_BLOCKED": ["n", "batch", "nb", "uplo"],
+    "ORMQR_BLOCKED": ["n", "batch", "side", "trans", "block_size"],
+    "SYEV": ["n", "batch", "nb", "wg", "fuse"],
+    "GESVD_BLOCKED": ["n", "batch", "jobu", "jobvh"],
+    "LATRD_LOWER_PANEL": ["n", "batch", "ib", "j0", "fuse"],
+    "SYEV_TWO_STAGE": ["n", "batch", "kd"],
+    "SB2ST_HH": ["n", "batch", "kd"],
+}
+
+# Which positional args identify the *case* rather than a tuned parameter.
+CASE_KEYS = {"n", "batch", "uplo", "side", "trans", "jobu", "jobvh", "j0", "ib", "n_sweeps"}
+
+
+def parse(log_path: Path) -> List[Tuple[str, List[int], float]]:
+    rows: List[Tuple[str, List[int], float]] = []
+    for raw in log_path.read_text(errors="replace").splitlines():
+        line = ANSI.sub("", raw)
+        m = ROW.search(line)
+        if not m:
+            continue
+        bench = m.group(1)
+        # arg0 arg1 ... iterations avg_ms stddev_ms [GFLOPS] metric
+        fields = m.group(2).split()
+        nums: List[str] = [f for f in fields if re.fullmatch(r"-?\d+(\.\d+)?([eE][-+]?\d+)?", f)]
+        if len(nums) < 4:
+            continue
+        metric = float(nums[-1])
+        nargs = len(ARG_NAMES.get(bench, []))
+        if nargs == 0 or len(nums) < nargs:
+            continue
+        args = [int(float(x)) for x in nums[:nargs]]
+        rows.append((bench, args, metric))
+    return rows
+
+
+def parse_profile(profile_path: Path) -> List[Tuple[str, List[int], float]]:
+    """Rows from a profile's `measurements`, preferred over log scraping.
+
+    The profile knows each bench's arg_spec and env_spec, so env-only
+    parameters -- which never appear in the benchmark's CSV columns -- are
+    covered here and cannot be covered from a log.
+    """
+    import json
+
+    profile = json.loads(profile_path.read_text())
+    rows: List[Tuple[str, List[int], float]] = []
+    for entry in profile.get("results", []):
+        if not isinstance(entry, dict):
+            continue
+        bench = str(entry.get("bench"))
+        arg_spec = [str(a) for a in (entry.get("arg_spec") or [])]
+        env_spec = entry.get("env_spec") or {}
+        # Env params become extra trailing columns with synthetic names.
+        env_names = sorted(str(k) for k in env_spec)
+        env_vars = [str(env_spec[k]) for k in env_names]
+        names = arg_spec + env_names
+        ARG_NAMES[bench] = names
+        for meas in entry.get("measurements") or []:
+            args = [int(v) for v in meas.get("args", [])]
+            env = meas.get("env") or {}
+            if len(args) != len(arg_spec):
+                continue
+            try:
+                extra = [int(env[v]) for v in env_vars]
+            except (KeyError, TypeError, ValueError):
+                continue
+            rows.append((bench, args + extra, float(meas["value"])))
+    return rows
+
+
+def analyse(rows, noise_pct: float):
+    # (bench, param) -> list of per-slice spreads, where a slice fixes every
+    # other column. This is a one-at-a-time sensitivity, which is the right
+    # question for "can I delete this axis from the grid".
+    spreads: Dict[Tuple[str, str], List[float]] = defaultdict(list)
+    counts: Dict[Tuple[str, str], int] = defaultdict(int)
+
+    by_bench: Dict[str, List[Tuple[List[int], float]]] = defaultdict(list)
+    for bench, args, metric in rows:
+        by_bench[bench].append((args, metric))
+
+    for bench, entries in by_bench.items():
+        names = ARG_NAMES[bench]
+        for idx, name in enumerate(names):
+            if name in CASE_KEYS:
+                continue
+            slices: Dict[Tuple[int, ...], Dict[int, float]] = defaultdict(dict)
+            for args, metric in entries:
+                key = tuple(v for i, v in enumerate(args) if i != idx)
+                # Keep the best observation per value: repeats are re-runs.
+                prev = slices[key].get(args[idx])
+                if prev is None or metric < prev:
+                    slices[key][args[idx]] = metric
+            for key, vals in slices.items():
+                if len(vals) < 2:
+                    continue
+                lo, hi = min(vals.values()), max(vals.values())
+                if lo <= 0:
+                    continue
+                spreads[(bench, name)].append(100.0 * (hi - lo) / lo)
+                counts[(bench, name)] += len(vals)
+
+    print(f"{'bench':<20}{'parameter':<22}{'median':>9}{'p90':>9}{'max':>9}  {'obs':>6}  verdict")
+    print("-" * 92)
+    dead = []
+    for (bench, name), vals in sorted(spreads.items(), key=lambda kv: -statistics.median(kv[1])):
+        med = statistics.median(vals)
+        p90 = sorted(vals)[max(0, int(0.9 * len(vals)) - 1)]
+        mx = max(vals)
+        if mx < noise_pct:
+            verdict = "DEAD - never moves the metric"
+            dead.append((bench, name, mx))
+        elif med < noise_pct:
+            verdict = "mostly flat - shrink the grid"
+        else:
+            verdict = "keep"
+        print(f"{bench:<20}{name:<22}{med:>8.2f}%{p90:>8.2f}%{mx:>8.2f}%  {counts[(bench,name)]:>6}  {verdict}")
+
+    if dead:
+        print(f"\nDead axes (max spread < {noise_pct}% across every slice):")
+        for bench, name, mx in dead:
+            print(f"  {bench}.{name}: max {mx:.2f}%")
+    return dead
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("log", type=Path, nargs="+",
+                    help="profile JSON from tune.py (preferred), or sweep log(s)")
+    ap.add_argument("--noise", type=float, default=1.0,
+                    help="percent spread below which a parameter counts as inert (default 1.0)")
+    args = ap.parse_args()
+
+    rows: List[Tuple[str, List[int], float]] = []
+    for p in args.log:
+        rows.extend(parse_profile(p) if p.suffix == ".json" else parse(p))
+    if not rows:
+        print("no benchmark rows parsed", file=sys.stderr)
+        return 1
+    print(f"parsed {len(rows)} measurements from {len(args.log)} log(s)\n")
+    analyse(rows, args.noise)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evaluation/tuning/spaces/default.json
+++ b/evaluation/tuning/spaces/default.json
@@ -139,6 +139,7 @@
       "metric": "Time (ms)",
       "direction": "min",
       "arg_spec": ["n", "batch", "kd"],
+      "row": "BM_SB2ST_HH_BACK",
       "env": {
         "back_tile": "BATCHLAS_TUNE_SB2ST_BACK_TILE",
         "back_subs": "BATCHLAS_TUNE_SB2ST_BACK_SUBS"
@@ -149,6 +150,10 @@
         "ONLY tile in {1,2,4,8} and subs in {4,8,16} are instantiated -- any",
         "other pair silently falls through to a slower tiled kernel, so these",
         "grids must not be widened past those sets.",
+        "The executable emits TWO rows, BM_SB2ST_HH_CHASE and BM_SB2ST_HH_BACK.",
+        "These knobs move only the back-transform, so 'row' selects it; reading",
+        "the chase instead showed a 1.4% spread (noise) and picked a winner at",
+        "random, where the back-transform actually spans 3.6x.",
         "The knobs are read nowhere else, so the standalone bench is a faithful",
         "objective; still A/B at syev before adopting, per the rule above."
       ],

--- a/evaluation/tuning/spaces/default.json
+++ b/evaluation/tuning/spaces/default.json
@@ -2,8 +2,8 @@
   "_comment": [
     "Every bench here feeds a constant in include/batchlas/tuning_params.hh.",
     "The generator reads exactly these bench names: stedc, sytrd_blocked,",
-    "ormqr_blocked, syev, gesvd, latrd_lower_panel. A bench whose winner has",
-    "nowhere to go belongs in unwired.json, not here.",
+    "ormqr_blocked, syev, gesvd, sb2st, sy2sb. A bench whose winner has nowhere",
+    "to go belongs in unwired.json, not here.",
     "",
     "Dependencies, in the order they matter:",
     " - syev overrides the sytrd_blocked buckets. sytrd_blocked is only the",
@@ -18,10 +18,19 @@
     " - ormqr and gebrd had one shared constant until 2026-08-06. They are",
     "   separate now; see the split note in tuning_params.hh. Do not merge the",
     "   grids again.",
+    " - sy2sb's hint SHADOWS ormqr_block_size on syev's two-stage path, so it",
+    "   is tuned through syev rather than standalone, and after ormqr.",
     "",
     "Grids must contain the value currently shipped in tuning_params.hh, or a",
     "retune silently downgrades that constant to the best of a grid that never",
-    "contained it."
+    "contained it.",
+    "",
+    "Grids were trimmed on 2026-08-07 using evaluation/tuning/sensitivity.py.",
+    "Values that never won any case and never moved the metric were removed;",
+    "the per-parameter spreads that justified each cut are recorded below.",
+    "Re-run sensitivity.py after any retune -- a value that stops winning is a",
+    "candidate for removal, and a parameter whose spread falls into the noise",
+    "should move to unwired.json or be deleted outright."
   ],
   "spaces": [
     {
@@ -30,16 +39,27 @@
       "metric": "Time (µs) / matrix",
       "direction": "min",
       "arg_spec": ["n", "batch", "recursion_threshold", "flat", "threads_per_root", "wg_multiplier"],
-      "_comment": "wg_multiplier includes 8 because STEDC_WG_MULTIPLIER_* ships 8; the old grid stopped at 4 and would have downgraded it. flat is the merge variant: 1=Fused, 2=FusedCta.",
+      "_comment": [
+        "flat is the merge variant: 0=Baseline, 1=Fused, 2=FusedCta. Baseline",
+        "dropped -- it lost every one of 5 cases and drags the measured spread",
+        "(21% median) almost single-handedly. Fused is kept because Fused vs",
+        "FusedCta has flipped before; see the note in tuning_params.hh.",
+        "threads_per_root trimmed [4,8,16,32] -> [4,8]: 16 and 32 won nothing,",
+        "and the parameter's median spread is 0.85%.",
+        "wg_multiplier trimmed [1,2,4,8] -> [2,4,8]: 1 won nothing. 8 is kept",
+        "only because it is the shipped value -- it also won nothing, so expect",
+        "a retune to move STEDC_WG_MULTIPLIER_* down, and A/B before believing",
+        "it: the parameter's median spread is 0.87%."
+      ],
       "pre_tune": [
         { "params": { "recursion_threshold": [8, 16, 32, 64] }, "cases": [0] }
       ],
       "cases": [
-        { "fixed": { "n": 64,   "batch": 8192 }, "tune": { "flat": [0, 1, 2], "threads_per_root": [4, 8, 16, 32], "wg_multiplier": [1, 2, 4, 8] } },
-        { "fixed": { "n": 128,  "batch": 4096 }, "tune": { "flat": [0, 1, 2], "threads_per_root": [4, 8, 16, 32], "wg_multiplier": [1, 2, 4, 8] } },
-        { "fixed": { "n": 256,  "batch": 2048 }, "tune": { "flat": [0, 1, 2], "threads_per_root": [4, 8, 16, 32], "wg_multiplier": [1, 2, 4, 8] } },
-        { "fixed": { "n": 512,  "batch": 1024 }, "tune": { "flat": [0, 1, 2], "threads_per_root": [4, 8, 16, 32], "wg_multiplier": [1, 2, 4, 8] } },
-        { "fixed": { "n": 1024, "batch": 512  }, "tune": { "flat": [0, 1, 2], "threads_per_root": [4, 8, 16, 32], "wg_multiplier": [1, 2, 4, 8] } }
+        { "fixed": { "n": 64,   "batch": 8192 }, "tune": { "flat": [1, 2], "threads_per_root": [4, 8], "wg_multiplier": [2, 4, 8] } },
+        { "fixed": { "n": 128,  "batch": 4096 }, "tune": { "flat": [1, 2], "threads_per_root": [4, 8], "wg_multiplier": [2, 4, 8] } },
+        { "fixed": { "n": 256,  "batch": 2048 }, "tune": { "flat": [1, 2], "threads_per_root": [4, 8], "wg_multiplier": [2, 4, 8] } },
+        { "fixed": { "n": 512,  "batch": 1024 }, "tune": { "flat": [1, 2], "threads_per_root": [4, 8], "wg_multiplier": [2, 4, 8] } },
+        { "fixed": { "n": 1024, "batch": 512  }, "tune": { "flat": [1, 2], "threads_per_root": [4, 8], "wg_multiplier": [2, 4, 8] } }
       ]
     },
 
@@ -49,13 +69,13 @@
       "metric": "T(µs)/matrix",
       "direction": "min",
       "arg_spec": ["n", "batch", "nb", "uplo"],
-      "_comment": "Fallback only: syev's coupled nb overrides these buckets whenever a syev entry is present.",
+      "_comment": "Fallback only: syev's coupled nb overrides these buckets whenever a syev entry is present. nb spread is 22% median, so the axis stays wide.",
       "cases": [
         { "fixed": { "n": 64,   "batch": 8192, "uplo": 0 }, "tune": { "nb": [8, 12, 16, 24] } },
         { "fixed": { "n": 128,  "batch": 4096, "uplo": 0 }, "tune": { "nb": [8, 12, 16, 24, 32] } },
-        { "fixed": { "n": 256,  "batch": 2048, "uplo": 0 }, "tune": { "nb": [8, 12, 16, 24, 32, 48, 64] } },
-        { "fixed": { "n": 512,  "batch": 1024, "uplo": 0 }, "tune": { "nb": [8, 12, 16, 24, 32, 48, 64] } },
-        { "fixed": { "n": 1024, "batch": 512,  "uplo": 0 }, "tune": { "nb": [8, 12, 16, 24, 32, 48, 64] } }
+        { "fixed": { "n": 256,  "batch": 2048, "uplo": 0 }, "tune": { "nb": [8, 12, 16, 24, 32, 48] } },
+        { "fixed": { "n": 512,  "batch": 1024, "uplo": 0 }, "tune": { "nb": [8, 12, 16, 24, 32, 48] } },
+        { "fixed": { "n": 1024, "batch": 512,  "uplo": 0 }, "tune": { "nb": [8, 12, 16, 24, 32, 48] } }
       ]
     },
 
@@ -66,24 +86,26 @@
       "direction": "min",
       "arg_spec": ["n", "batch", "side", "trans", "block_size"],
       "_comment": [
-        "Both sides at every n: they disagree at n=64 (side 0 wants 16, side 1 wants 8) and the bucket has to serve both.",
+        "Strongest parameter in the whole space: 101% median spread, 276% max.",
+        "Both sides at every n -- they disagree at n=64 (side 0 wants 16, side 1",
+        "wants 8) and the bucket has to serve both.",
         "This bench takes block_size as an explicit argument, so it is blind to",
-        "the two ways the constant reaches production wrongly: the sy2sb shape",
-        "gate shadows it at n>=1024, and gesvd used to alias it onto gebrd.",
-        "Always re-check a new winner with BATCHLAS_TUNE_ORMQR_BLOCK_SIZE against",
-        "syev_blocked and gesvd_blocked before editing the header."
+        "the two ways the constant reaches production wrongly: sy2sb's hint",
+        "shadows it on syev's two-stage path, and gesvd used to alias it onto",
+        "gebrd. Always re-check a winner with BATCHLAS_TUNE_ORMQR_BLOCK_SIZE",
+        "against syev_blocked and gesvd_blocked before editing the header."
       ],
       "cases": [
-        { "fixed": { "n": 64,   "batch": 8192, "side": 0, "trans": 0 }, "tune": { "block_size": [4, 8, 12, 16, 24, 32] } },
-        { "fixed": { "n": 64,   "batch": 8192, "side": 1, "trans": 0 }, "tune": { "block_size": [4, 8, 12, 16, 24, 32] } },
-        { "fixed": { "n": 128,  "batch": 4096, "side": 0, "trans": 0 }, "tune": { "block_size": [8, 16, 24, 32, 40, 48, 64] } },
-        { "fixed": { "n": 128,  "batch": 4096, "side": 1, "trans": 0 }, "tune": { "block_size": [8, 16, 24, 32, 40, 48, 64] } },
-        { "fixed": { "n": 256,  "batch": 2048, "side": 0, "trans": 0 }, "tune": { "block_size": [16, 24, 32, 40, 48, 56, 64] } },
-        { "fixed": { "n": 256,  "batch": 2048, "side": 1, "trans": 0 }, "tune": { "block_size": [16, 24, 32, 40, 48, 56, 64] } },
-        { "fixed": { "n": 512,  "batch": 1024, "side": 0, "trans": 0 }, "tune": { "block_size": [16, 24, 32, 40, 48, 56, 64] } },
-        { "fixed": { "n": 512,  "batch": 1024, "side": 1, "trans": 0 }, "tune": { "block_size": [16, 24, 32, 40, 48, 56, 64] } },
-        { "fixed": { "n": 1024, "batch": 512,  "side": 0, "trans": 0 }, "tune": { "block_size": [16, 24, 32, 40, 48, 56, 64] } },
-        { "fixed": { "n": 1024, "batch": 512,  "side": 1, "trans": 0 }, "tune": { "block_size": [16, 24, 32, 40, 48, 56, 64] } }
+        { "fixed": { "n": 64,   "batch": 8192, "side": 0, "trans": 0 }, "tune": { "block_size": [4, 8, 12, 16, 24] } },
+        { "fixed": { "n": 64,   "batch": 8192, "side": 1, "trans": 0 }, "tune": { "block_size": [4, 8, 12, 16, 24] } },
+        { "fixed": { "n": 128,  "batch": 4096, "side": 0, "trans": 0 }, "tune": { "block_size": [8, 16, 24, 32] } },
+        { "fixed": { "n": 128,  "batch": 4096, "side": 1, "trans": 0 }, "tune": { "block_size": [8, 16, 24, 32] } },
+        { "fixed": { "n": 256,  "batch": 2048, "side": 0, "trans": 0 }, "tune": { "block_size": [16, 24, 32, 40] } },
+        { "fixed": { "n": 256,  "batch": 2048, "side": 1, "trans": 0 }, "tune": { "block_size": [16, 24, 32, 40] } },
+        { "fixed": { "n": 512,  "batch": 1024, "side": 0, "trans": 0 }, "tune": { "block_size": [24, 32, 40, 48, 56] } },
+        { "fixed": { "n": 512,  "batch": 1024, "side": 1, "trans": 0 }, "tune": { "block_size": [24, 32, 40, 48, 56] } },
+        { "fixed": { "n": 1024, "batch": 512,  "side": 0, "trans": 0 }, "tune": { "block_size": [32, 40, 48, 56, 64] } },
+        { "fixed": { "n": 1024, "batch": 512,  "side": 1, "trans": 0 }, "tune": { "block_size": [32, 40, 48, 56, 64] } }
       ]
     },
 
@@ -100,35 +122,40 @@
         "jobu/jobvh are 0 (no vectors) on purpose: that makes gesvd.gebrd ~95% of",
         "the call, so the measurement is about the parameter being tuned rather",
         "than about the ormqr backtransforms, which have their own constant.",
-        "Measured optimum at n=512 is 16 with a flat +-2% curve -- if a retune",
-        "moves this far, be suspicious before believing it."
+        "Worth 3.5-48% depending on n, so this axis earns its place. Trimmed to",
+        "[8..24]: 32 and 48 lost every case."
       ],
       "cases": [
-        { "fixed": { "n": 128,  "batch": 1024, "jobu": 0, "jobvh": 0 }, "tune": { "gebrd_nb": [8, 12, 16, 24, 32] } },
-        { "fixed": { "n": 256,  "batch": 512,  "jobu": 0, "jobvh": 0 }, "tune": { "gebrd_nb": [8, 12, 16, 24, 32] } },
-        { "fixed": { "n": 512,  "batch": 256,  "jobu": 0, "jobvh": 0 }, "tune": { "gebrd_nb": [8, 12, 16, 24, 32, 48] } },
-        { "fixed": { "n": 1024, "batch": 128,  "jobu": 0, "jobvh": 0 }, "tune": { "gebrd_nb": [8, 12, 16, 24, 32, 48] } }
+        { "fixed": { "n": 128,  "batch": 1024, "jobu": 0, "jobvh": 0 }, "tune": { "gebrd_nb": [8, 12, 16, 24] } },
+        { "fixed": { "n": 256,  "batch": 512,  "jobu": 0, "jobvh": 0 }, "tune": { "gebrd_nb": [8, 12, 16, 24] } },
+        { "fixed": { "n": 512,  "batch": 256,  "jobu": 0, "jobvh": 0 }, "tune": { "gebrd_nb": [8, 12, 16, 24] } },
+        { "fixed": { "n": 1024, "batch": 128,  "jobu": 0, "jobvh": 0 }, "tune": { "gebrd_nb": [8, 12, 16, 24] } }
       ]
     },
 
     {
-      "bench": "latrd_lower_panel",
-      "exe": "latrd_lower_panel_benchmark",
-      "metric": "T(µs)/matrix",
+      "bench": "sb2st",
+      "exe": "sb2st_hh_benchmark",
+      "metric": "Time (ms)",
       "direction": "min",
-      "arg_spec": ["n", "batch", "ib", "j0", "fuse"],
-      "env": { "wg": "BATCHLAS_TUNE_LATRD_WG_HINT" },
+      "arg_spec": ["n", "batch", "kd"],
+      "env": {
+        "back_tile": "BATCHLAS_TUNE_SB2ST_BACK_TILE",
+        "back_subs": "BATCHLAS_TUNE_SB2ST_BACK_SUBS"
+      },
       "_comment": [
-        "Supplies the LATRD wg-hint fallback the generator looks for. syev's",
-        "coupled 'wg' still wins wherever syev covers the size; this only fills",
-        "the gaps. wg=0 means 'let the kernel choose', which is what ships.",
-        "The benchmark exposes ib/j0/fuse positionally but not wg, so the hint",
-        "goes through the env override."
+        "The largest single kernel in the eigensolver path:",
+        "syev_two_stage.sb2st_hh is 52.9% of syev at n=1024 batch=256.",
+        "ONLY tile in {1,2,4,8} and subs in {4,8,16} are instantiated -- any",
+        "other pair silently falls through to a slower tiled kernel, so these",
+        "grids must not be widened past those sets.",
+        "The knobs are read nowhere else, so the standalone bench is a faithful",
+        "objective; still A/B at syev before adopting, per the rule above."
       ],
       "cases": [
-        { "fixed": { "n": 128, "batch": 1024, "ib": 32, "j0": 0, "fuse": 0 }, "tune": { "wg": [64, 128, 256] } },
-        { "fixed": { "n": 256, "batch": 1024, "ib": 32, "j0": 0, "fuse": 0 }, "tune": { "wg": [64, 128, 256] } },
-        { "fixed": { "n": 512, "batch": 1024, "ib": 32, "j0": 0, "fuse": 0 }, "tune": { "wg": [64, 128, 256] } }
+        { "fixed": { "n": 256,  "batch": 1024, "kd": 32 }, "tune": { "back_tile": [1, 2, 4, 8], "back_subs": [4, 8, 16] } },
+        { "fixed": { "n": 512,  "batch": 512,  "kd": 32 }, "tune": { "back_tile": [1, 2, 4, 8], "back_subs": [4, 8, 16] } },
+        { "fixed": { "n": 1024, "batch": 256,  "kd": 32 }, "tune": { "back_tile": [1, 2, 4, 8], "back_subs": [4, 8, 16] } }
       ]
     },
 
@@ -142,15 +169,47 @@
         "The authority for SYTRD_BLOCK_SIZE_*, LATRD_LOWER_PANEL_WG_HINT_* and",
         "SYTRD_FUSE_PANEL_UPDATE_*: it optimises the tuple against end-to-end",
         "eigensolver time rather than against the panel kernel alone.",
-        "Note n>=512 takes the two-stage route, where sb2st_hh is ~53% of the",
-        "time and is tuned by nothing here -- see unwired.json."
+        "wg trimmed [0,64,128,256] -> [0,128]: 64 and 256 won nothing and the",
+        "median spread is 1.67%. 0 means 'let the kernel choose', which ships.",
+        "fuse=1 lost all five cases by a wide margin (53% median spread, all of",
+        "it against fuse). It is kept at ONE case only, as a tripwire in case a",
+        "kernel change ever makes it pay, rather than multiplying every other",
+        "axis by two. Per-case grids are searched independently, so this costs",
+        "nothing elsewhere."
       ],
       "cases": [
-        { "fixed": { "n": 64,   "batch": 4096 }, "tune": { "nb": [8, 12, 16, 24],                 "wg": [0, 64, 128, 256], "fuse": [0, 1] } },
-        { "fixed": { "n": 128,  "batch": 2048 }, "tune": { "nb": [8, 12, 16, 24, 32],             "wg": [0, 64, 128, 256], "fuse": [0, 1] } },
-        { "fixed": { "n": 256,  "batch": 1024 }, "tune": { "nb": [8, 12, 16, 24, 32, 48, 64],     "wg": [0, 64, 128, 256], "fuse": [0, 1] } },
-        { "fixed": { "n": 512,  "batch": 512  }, "tune": { "nb": [8, 12, 16, 24, 32, 48, 64],     "wg": [0, 64, 128, 256], "fuse": [0, 1] } },
-        { "fixed": { "n": 1024, "batch": 256  }, "tune": { "nb": [8, 12, 16, 24, 32, 48, 64],     "wg": [0, 64, 128, 256], "fuse": [0, 1] } }
+        { "fixed": { "n": 64,   "batch": 4096 }, "tune": { "nb": [8, 12, 16, 24],             "wg": [0, 128], "fuse": [0] } },
+        { "fixed": { "n": 128,  "batch": 2048 }, "tune": { "nb": [8, 12, 16, 24, 32],         "wg": [0, 128], "fuse": [0] } },
+        { "fixed": { "n": 256,  "batch": 1024 }, "tune": { "nb": [8, 12, 16, 24, 32, 48],     "wg": [0, 128], "fuse": [0, 1] } },
+        { "fixed": { "n": 512,  "batch": 512  }, "tune": { "nb": [8, 12, 16, 24, 32, 48, 64], "wg": [0, 128], "fuse": [0] } },
+        { "fixed": { "n": 1024, "batch": 256  }, "tune": { "nb": [8, 12, 16, 24, 32, 48, 64], "wg": [0, 128], "fuse": [0] } }
+      ]
+    },
+
+    {
+      "bench": "sy2sb",
+      "exe": "syev_benchmark",
+      "metric": "Time (µs) / matrix",
+      "direction": "min",
+      "arg_spec": ["n", "batch", "nb", "wg", "fuse"],
+      "env": { "sy2sb_nb": "BATCHLAS_TUNE_SY2SB_ORMQR_NB" },
+      "_comment": [
+        "The WY block width for the sy2sb panel back-transform, which SHADOWS",
+        "ORMQR_BLOCK_SIZE_* on syev's two-stage path: with the shape gate active",
+        "the ormqr constant is dead code there, and the kernel trace is identical",
+        "at nb=16 and nb=56.",
+        "Tuned through syev because sy2sb has no standalone benchmark, and",
+        "end-to-end time is the thing the gate was written to protect.",
+        "sy2sb_nb=0 means 'keep the shape gate' (return kd when n>=1024 and",
+        "batch>=32), which is what ships -- it is in the grid so the incumbent",
+        "competes. Positive values are clamped to kd at the call site, so",
+        "anything above kd=32 collapses onto 32; the grid stops there.",
+        "n>=512 only: below that syev does not take the two-stage route and the",
+        "parameter is unreachable."
+      ],
+      "cases": [
+        { "fixed": { "n": 512,  "batch": 512, "nb": 8, "wg": 0, "fuse": 0 }, "tune": { "sy2sb_nb": [0, 8, 16, 24, 32] } },
+        { "fixed": { "n": 1024, "batch": 256, "nb": 8, "wg": 0, "fuse": 0 }, "tune": { "sy2sb_nb": [0, 8, 16, 24, 32] } }
       ]
     }
   ]

--- a/evaluation/tuning/spaces/default.json
+++ b/evaluation/tuning/spaces/default.json
@@ -114,7 +114,7 @@
     {
       "bench": "latrd_lower_panel",
       "exe": "latrd_lower_panel_benchmark",
-      "metric": "Time (µs) / matrix",
+      "metric": "T(µs)/matrix",
       "direction": "min",
       "arg_spec": ["n", "batch", "ib", "j0", "fuse"],
       "env": { "wg": "BATCHLAS_TUNE_LATRD_WG_HINT" },

--- a/evaluation/tuning/spaces/default.json
+++ b/evaluation/tuning/spaces/default.json
@@ -1,4 +1,28 @@
 {
+  "_comment": [
+    "Every bench here feeds a constant in include/batchlas/tuning_params.hh.",
+    "The generator reads exactly these bench names: stedc, sytrd_blocked,",
+    "ormqr_blocked, syev, gesvd, latrd_lower_panel. A bench whose winner has",
+    "nowhere to go belongs in unwired.json, not here.",
+    "",
+    "Dependencies, in the order they matter:",
+    " - syev overrides the sytrd_blocked buckets. sytrd_blocked is only the",
+    "   fallback for sizes syev does not cover, so syev's nb grid must be at",
+    "   least as wide as sytrd_blocked's.",
+    " - syev couples nb, the LATRD lower-panel wg hint and the fused panel",
+    "   update in one tuple, because they trade against each other inside the",
+    "   panel loop and the end-to-end eigensolver time is the objective.",
+    " - stedc's constants are global, so they are tuned standalone and then",
+    "   inherited by syev's and gesvd's tridiagonal solve. Tune stedc first if",
+    "   you tune by hand.",
+    " - ormqr and gebrd had one shared constant until 2026-08-06. They are",
+    "   separate now; see the split note in tuning_params.hh. Do not merge the",
+    "   grids again.",
+    "",
+    "Grids must contain the value currently shipped in tuning_params.hh, or a",
+    "retune silently downgrades that constant to the best of a grid that never",
+    "contained it."
+  ],
   "spaces": [
     {
       "bench": "stedc",
@@ -6,179 +30,127 @@
       "metric": "Time (µs) / matrix",
       "direction": "min",
       "arg_spec": ["n", "batch", "recursion_threshold", "flat", "threads_per_root", "wg_multiplier"],
+      "_comment": "wg_multiplier includes 8 because STEDC_WG_MULTIPLIER_* ships 8; the old grid stopped at 4 and would have downgraded it. flat is the merge variant: 1=Fused, 2=FusedCta.",
       "pre_tune": [
-        {
-          "params": {
-            "recursion_threshold": [8, 16, 32, 64]
-          },
-          "cases": [0]
-        }
+        { "params": { "recursion_threshold": [8, 16, 32, 64] }, "cases": [0] }
       ],
       "cases": [
-        {
-          "fixed": {"n": 64, "batch": 8192},
-          "tune": {
-            "flat": [0, 1, 2],
-            "threads_per_root": [4, 8, 16, 32],
-            "wg_multiplier": [1, 2, 4]
-          }
-        },
-        {
-          "fixed": {"n": 128, "batch": 4096},
-          "tune": {
-            "flat": [0, 1, 2],
-            "threads_per_root": [4, 8, 16, 32],
-            "wg_multiplier": [1, 2, 4]
-          }
-        },
-        {
-          "fixed": {"n": 256, "batch": 2048},
-          "tune": {
-            "flat": [0, 1, 2],
-            "threads_per_root": [4, 8, 16, 32],
-            "wg_multiplier": [1, 2, 4]
-          }
-        },
-        {
-          "fixed": {"n": 512, "batch": 1024},
-          "tune": {
-            "flat": [0, 1, 2],
-            "threads_per_root": [4, 8, 16, 32],
-            "wg_multiplier": [1, 2, 4]
-          }
-        },
-        {
-          "fixed": {"n": 1024, "batch": 512},
-          "tune": {
-            "flat": [0, 1, 2],
-            "threads_per_root": [4, 8, 16, 32],
-            "wg_multiplier": [1, 2, 4]
-          }
-        }
+        { "fixed": { "n": 64,   "batch": 8192 }, "tune": { "flat": [0, 1, 2], "threads_per_root": [4, 8, 16, 32], "wg_multiplier": [1, 2, 4, 8] } },
+        { "fixed": { "n": 128,  "batch": 4096 }, "tune": { "flat": [0, 1, 2], "threads_per_root": [4, 8, 16, 32], "wg_multiplier": [1, 2, 4, 8] } },
+        { "fixed": { "n": 256,  "batch": 2048 }, "tune": { "flat": [0, 1, 2], "threads_per_root": [4, 8, 16, 32], "wg_multiplier": [1, 2, 4, 8] } },
+        { "fixed": { "n": 512,  "batch": 1024 }, "tune": { "flat": [0, 1, 2], "threads_per_root": [4, 8, 16, 32], "wg_multiplier": [1, 2, 4, 8] } },
+        { "fixed": { "n": 1024, "batch": 512  }, "tune": { "flat": [0, 1, 2], "threads_per_root": [4, 8, 16, 32], "wg_multiplier": [1, 2, 4, 8] } }
       ]
     },
-    {
-      "bench": "steqr",
-      "exe": "steqr_benchmark",
-      "metric": "T(µs)/matrix",
-      "direction": "min",
-      "arg_spec": ["n", "batch", "n_sweeps", "wg_multiplier", "shift_kind"],
-      "cases": [
-        {
-          "fixed": {"n": 16, "batch": 4096, "n_sweeps": 10},
-          "tune": {"wg_multiplier": [1, 2, 4], "shift_kind": [0, 1, 2]}
-        },
-        {
-          "fixed": {"n": 32, "batch": 4096, "n_sweeps": 10},
-          "tune": {"wg_multiplier": [1, 2, 4], "shift_kind": [0, 1, 2]}
-        }
-      ]
-    },
+
     {
       "bench": "sytrd_blocked",
       "exe": "sytrd_blocked_benchmark",
       "metric": "T(µs)/matrix",
       "direction": "min",
       "arg_spec": ["n", "batch", "nb", "uplo"],
+      "_comment": "Fallback only: syev's coupled nb overrides these buckets whenever a syev entry is present.",
       "cases": [
-        {
-          "fixed": {"n": 64, "batch": 8192, "uplo": 0},
-          "tune": {"nb": [8, 12, 16]}
-        },
-        {
-          "fixed": {"n": 128, "batch": 4096, "uplo": 0},
-          "tune": {"nb": [8, 12, 16, 24, 32]}
-        },
-        {
-          "fixed": {"n": 256, "batch": 2048, "uplo": 0},
-          "tune": {"nb": [8, 12, 16, 24, 32, 48, 64]}
-        },
-        {
-          "fixed": {"n": 512, "batch": 1024, "uplo": 0},
-          "tune": {"nb": [8, 12, 16, 24, 32, 48, 64]}
-        },
-        {
-          "fixed": {"n": 1024, "batch": 512, "uplo": 0},
-          "tune": {"nb": [8, 12, 16, 24, 32, 48, 64]}
-        }
+        { "fixed": { "n": 64,   "batch": 8192, "uplo": 0 }, "tune": { "nb": [8, 12, 16, 24] } },
+        { "fixed": { "n": 128,  "batch": 4096, "uplo": 0 }, "tune": { "nb": [8, 12, 16, 24, 32] } },
+        { "fixed": { "n": 256,  "batch": 2048, "uplo": 0 }, "tune": { "nb": [8, 12, 16, 24, 32, 48, 64] } },
+        { "fixed": { "n": 512,  "batch": 1024, "uplo": 0 }, "tune": { "nb": [8, 12, 16, 24, 32, 48, 64] } },
+        { "fixed": { "n": 1024, "batch": 512,  "uplo": 0 }, "tune": { "nb": [8, 12, 16, 24, 32, 48, 64] } }
       ]
     },
+
     {
       "bench": "ormqr_blocked",
       "exe": "ormqr_blocked_benchmark",
       "metric": "Time (µs) / matrix",
       "direction": "min",
       "arg_spec": ["n", "batch", "side", "trans", "block_size"],
+      "_comment": [
+        "Both sides at every n: they disagree at n=64 (side 0 wants 16, side 1 wants 8) and the bucket has to serve both.",
+        "This bench takes block_size as an explicit argument, so it is blind to",
+        "the two ways the constant reaches production wrongly: the sy2sb shape",
+        "gate shadows it at n>=1024, and gesvd used to alias it onto gebrd.",
+        "Always re-check a new winner with BATCHLAS_TUNE_ORMQR_BLOCK_SIZE against",
+        "syev_blocked and gesvd_blocked before editing the header."
+      ],
       "cases": [
-        {
-          "fixed": {"n": 64, "batch": 8192, "side": 0, "trans": 0},
-          "tune": {"block_size": [4, 8, 12, 16]}
-        },
-        {
-          "fixed": {"n": 64, "batch": 8192, "side": 1, "trans": 0},
-          "tune": {"block_size": [4, 8, 12, 16]}
-        },
-        {
-          "fixed": {"n": 128, "batch": 4096, "side": 0, "trans": 0},
-          "tune": {"block_size": [16, 24, 32, 40, 48, 56, 64]}
-        },
-        {
-          "fixed": {"n": 128, "batch": 4096, "side": 1, "trans": 0},
-          "tune": {"block_size": [16, 24, 32, 40, 48, 56, 64]}
-        },
-        {
-          "fixed": {"n": 256, "batch": 2048, "side": 0, "trans": 0},
-          "tune": {"block_size": [16, 24, 32, 40, 48, 56, 64]}
-        },
-        {
-          "fixed": {"n": 256, "batch": 2048, "side": 1, "trans": 0},
-          "tune": {"block_size": [16, 24, 32, 40, 48, 56, 64]}
-        },
-        {
-          "fixed": {"n": 512, "batch": 1024, "side": 0, "trans": 0},
-          "tune": {"block_size": [16, 24, 32, 40, 48, 56, 64]}
-        },
-        {
-          "fixed": {"n": 512, "batch": 1024, "side": 1, "trans": 0},
-          "tune": {"block_size": [16, 24, 32, 40, 48, 56, 64]}
-        },
-        {
-          "fixed": {"n": 1024, "batch": 512, "side": 0, "trans": 0},
-          "tune": {"block_size": [16, 24, 32, 40, 48, 56, 64]}
-        },
-        {
-          "fixed": {"n": 1024, "batch": 512, "side": 1, "trans": 0},
-          "tune": {"block_size": [16, 24, 32, 40, 48, 56, 64]}
-        }
+        { "fixed": { "n": 64,   "batch": 8192, "side": 0, "trans": 0 }, "tune": { "block_size": [4, 8, 12, 16, 24, 32] } },
+        { "fixed": { "n": 64,   "batch": 8192, "side": 1, "trans": 0 }, "tune": { "block_size": [4, 8, 12, 16, 24, 32] } },
+        { "fixed": { "n": 128,  "batch": 4096, "side": 0, "trans": 0 }, "tune": { "block_size": [8, 16, 24, 32, 40, 48, 64] } },
+        { "fixed": { "n": 128,  "batch": 4096, "side": 1, "trans": 0 }, "tune": { "block_size": [8, 16, 24, 32, 40, 48, 64] } },
+        { "fixed": { "n": 256,  "batch": 2048, "side": 0, "trans": 0 }, "tune": { "block_size": [16, 24, 32, 40, 48, 56, 64] } },
+        { "fixed": { "n": 256,  "batch": 2048, "side": 1, "trans": 0 }, "tune": { "block_size": [16, 24, 32, 40, 48, 56, 64] } },
+        { "fixed": { "n": 512,  "batch": 1024, "side": 0, "trans": 0 }, "tune": { "block_size": [16, 24, 32, 40, 48, 56, 64] } },
+        { "fixed": { "n": 512,  "batch": 1024, "side": 1, "trans": 0 }, "tune": { "block_size": [16, 24, 32, 40, 48, 56, 64] } },
+        { "fixed": { "n": 1024, "batch": 512,  "side": 0, "trans": 0 }, "tune": { "block_size": [16, 24, 32, 40, 48, 56, 64] } },
+        { "fixed": { "n": 1024, "batch": 512,  "side": 1, "trans": 0 }, "tune": { "block_size": [16, 24, 32, 40, 48, 56, 64] } }
       ]
     },
+
+    {
+      "bench": "gesvd",
+      "exe": "gesvd_blocked_benchmark",
+      "metric": "Time (µs) / matrix",
+      "direction": "min",
+      "arg_spec": ["n", "batch", "jobu", "jobvh"],
+      "env": { "gebrd_nb": "BATCHLAS_TUNE_GEBRD_BLOCK_SIZE" },
+      "_comment": [
+        "Feeds GEBRD_BLOCK_SIZE_*. gebrd has no positional argument anywhere, so",
+        "it is reached through the tuning accessor's environment override.",
+        "jobu/jobvh are 0 (no vectors) on purpose: that makes gesvd.gebrd ~95% of",
+        "the call, so the measurement is about the parameter being tuned rather",
+        "than about the ormqr backtransforms, which have their own constant.",
+        "Measured optimum at n=512 is 16 with a flat +-2% curve -- if a retune",
+        "moves this far, be suspicious before believing it."
+      ],
+      "cases": [
+        { "fixed": { "n": 128,  "batch": 1024, "jobu": 0, "jobvh": 0 }, "tune": { "gebrd_nb": [8, 12, 16, 24, 32] } },
+        { "fixed": { "n": 256,  "batch": 512,  "jobu": 0, "jobvh": 0 }, "tune": { "gebrd_nb": [8, 12, 16, 24, 32] } },
+        { "fixed": { "n": 512,  "batch": 256,  "jobu": 0, "jobvh": 0 }, "tune": { "gebrd_nb": [8, 12, 16, 24, 32, 48] } },
+        { "fixed": { "n": 1024, "batch": 128,  "jobu": 0, "jobvh": 0 }, "tune": { "gebrd_nb": [8, 12, 16, 24, 32, 48] } }
+      ]
+    },
+
+    {
+      "bench": "latrd_lower_panel",
+      "exe": "latrd_lower_panel_benchmark",
+      "metric": "Time (µs) / matrix",
+      "direction": "min",
+      "arg_spec": ["n", "batch", "ib", "j0", "fuse"],
+      "env": { "wg": "BATCHLAS_TUNE_LATRD_WG_HINT" },
+      "_comment": [
+        "Supplies the LATRD wg-hint fallback the generator looks for. syev's",
+        "coupled 'wg' still wins wherever syev covers the size; this only fills",
+        "the gaps. wg=0 means 'let the kernel choose', which is what ships.",
+        "The benchmark exposes ib/j0/fuse positionally but not wg, so the hint",
+        "goes through the env override."
+      ],
+      "cases": [
+        { "fixed": { "n": 128, "batch": 1024, "ib": 32, "j0": 0, "fuse": 0 }, "tune": { "wg": [64, 128, 256] } },
+        { "fixed": { "n": 256, "batch": 1024, "ib": 32, "j0": 0, "fuse": 0 }, "tune": { "wg": [64, 128, 256] } },
+        { "fixed": { "n": 512, "batch": 1024, "ib": 32, "j0": 0, "fuse": 0 }, "tune": { "wg": [64, 128, 256] } }
+      ]
+    },
+
     {
       "bench": "syev",
       "exe": "syev_benchmark",
       "metric": "Time (µs) / matrix",
       "direction": "min",
       "arg_spec": ["n", "batch", "nb", "wg", "fuse"],
+      "_comment": [
+        "The authority for SYTRD_BLOCK_SIZE_*, LATRD_LOWER_PANEL_WG_HINT_* and",
+        "SYTRD_FUSE_PANEL_UPDATE_*: it optimises the tuple against end-to-end",
+        "eigensolver time rather than against the panel kernel alone.",
+        "Note n>=512 takes the two-stage route, where sb2st_hh is ~53% of the",
+        "time and is tuned by nothing here -- see unwired.json."
+      ],
       "cases": [
-        {
-          "fixed": {"n": 64, "batch": 4096},
-          "tune": {"nb": [8, 12, 16, 24], "wg": [0, 64, 128, 256], "fuse": [0, 1]}
-        },
-        {
-          "fixed": {"n": 128, "batch": 2048},
-          "tune": {"nb": [8, 12, 16, 24, 32], "wg": [0, 64, 128, 256], "fuse": [0, 1]}
-        },
-        {
-          "fixed": {"n": 256, "batch": 1024},
-          "tune": {"nb": [8, 12, 16, 24, 32, 48, 64], "wg": [0, 64, 128, 256], "fuse": [0, 1]}
-        },
-        {
-          "fixed": {"n": 512, "batch": 512},
-          "tune": {"nb": [8, 12, 16, 24, 32, 48, 64], "wg": [0, 64, 128, 256], "fuse": [0, 1]}
-        },
-        {
-          "fixed": {"n": 1024, "batch": 256},
-          "tune": {"nb": [8, 12, 16, 24, 32, 48, 64], "wg": [0, 64, 128, 256], "fuse": [0, 1]}
-        }
+        { "fixed": { "n": 64,   "batch": 4096 }, "tune": { "nb": [8, 12, 16, 24],                 "wg": [0, 64, 128, 256], "fuse": [0, 1] } },
+        { "fixed": { "n": 128,  "batch": 2048 }, "tune": { "nb": [8, 12, 16, 24, 32],             "wg": [0, 64, 128, 256], "fuse": [0, 1] } },
+        { "fixed": { "n": 256,  "batch": 1024 }, "tune": { "nb": [8, 12, 16, 24, 32, 48, 64],     "wg": [0, 64, 128, 256], "fuse": [0, 1] } },
+        { "fixed": { "n": 512,  "batch": 512  }, "tune": { "nb": [8, 12, 16, 24, 32, 48, 64],     "wg": [0, 64, 128, 256], "fuse": [0, 1] } },
+        { "fixed": { "n": 1024, "batch": 256  }, "tune": { "nb": [8, 12, 16, 24, 32, 48, 64],     "wg": [0, 64, 128, 256], "fuse": [0, 1] } }
       ]
     }
   ]

--- a/evaluation/tuning/spaces/unwired.json
+++ b/evaluation/tuning/spaces/unwired.json
@@ -47,7 +47,7 @@
     {
       "bench": "syev_two_stage_kd",
       "exe": "syev_two_stage_benchmark",
-      "metric": "Time (µs) / matrix",
+      "metric": "Time (ms)",
       "direction": "min",
       "arg_spec": ["n", "batch", "kd"],
       "_comment": [
@@ -69,7 +69,7 @@
     {
       "bench": "sb2st",
       "exe": "sb2st_hh_benchmark",
-      "metric": "Time (µs) / matrix",
+      "metric": "Time (ms)",
       "direction": "min",
       "arg_spec": ["n", "batch", "kd"],
       "env": {

--- a/evaluation/tuning/spaces/unwired.json
+++ b/evaluation/tuning/spaces/unwired.json
@@ -10,11 +10,15 @@
     "invocations a run for a result nothing could ever consume, which looked",
     "exactly like tuning.",
     "",
-    "To promote one of these into default.json you must first: add",
+    "sb2st and sy2sb graduated to default.json on 2026-08-07, once",
+    "SB2ST_BACK_TILE_*, SB2ST_BACK_SUBS_* and SY2SB_ORMQR_NB_* existed and the",
+    "call sites read them.",
+    "",
+    "To promote one of these you must do all three, in order: add",
     "<NAME>_{TINY..XLARGE} constants and a *_for_n accessor to",
     "include/batchlas/tuning_params.hh, teach generate_tuning_header.py to",
     "derive them, and make the production call site read the accessor instead",
-    "of its hardcoded default.",
+    "of its hardcoded default. Skipping the third makes the whole thing a no-op.",
     "",
     "Run with:",
     "  python3 evaluation/tuning/tune.py --space evaluation/tuning/spaces/unwired.json \\",
@@ -32,11 +36,10 @@
         "cta_shift_strategy (=Lapack) are plain C++ member initialisers in",
         "include/blas/extensions.hh, and stedc's leaf solve takes them as they",
         "come. Nothing reads a tuning constant.",
-        "A previous run picked wg_multiplier=2 over the shipped 1, so there is",
-        "probably something here.",
-        "shift_kind is 1=Wilkinson, anything else=Lapack. The old grid swept",
-        "[0,1,2], where 0 and 2 are the same run -- it wasted a third of its",
-        "invocations measuring Lapack twice."
+        "Worth doing: measured spreads are 12.2% for shift_kind and 3.1% for",
+        "wg_multiplier, and a sweep picked wg_multiplier=2 over the shipped 1.",
+        "shift_kind is 1=Wilkinson, anything else=Lapack, so the grid is [0,1].",
+        "The old grid swept [0,1,2] and measured Lapack twice."
       ],
       "cases": [
         { "fixed": { "n": 16, "batch": 4096, "n_sweeps": 10 }, "tune": { "wg_multiplier": [1, 2, 4], "shift_kind": [0, 1] } },
@@ -54,8 +57,9 @@
         "Blocked on: the band width is chosen by choose_two_stage_kd() in",
         "src/extensions/two_stage_common.hh, a hand-written table justified by a",
         "comment block, overridable only via BATCHLAS_SYEV_TWO_STAGE_KD.",
-        "It is worth measuring: that comment records 425.8 vs 500.1 ms between",
-        "kd=32 and kd=16 at n=1024, i.e. ~18%.",
+        "Worth measuring: that comment records 425.8 vs 500.1 ms between kd=32",
+        "and kd=16 at n=1024, i.e. ~18%. Note kd also sets the ceiling for",
+        "sy2sb's clamped WY width, so retuning kd invalidates SY2SB_ORMQR_NB_*.",
         "kd is positional here, so no env override is needed."
       ],
       "cases": [
@@ -67,51 +71,20 @@
     },
 
     {
-      "bench": "sb2st",
-      "exe": "sb2st_hh_benchmark",
+      "bench": "sb2st_block",
+      "exe": "syev_two_stage_benchmark",
       "metric": "Time (ms)",
       "direction": "min",
       "arg_spec": ["n", "batch", "kd"],
-      "env": {
-        "back_tile": "BATCHLAS_SB2ST_BACK_TILE",
-        "back_wave": "BATCHLAS_SB2ST_BACK_WAVE"
-      },
+      "env": { "sb2st_block": "BATCHLAS_SYEV_TWO_STAGE_SB2ST_BLOCK" },
       "_comment": [
-        "The biggest single lever in the whole library that nothing tunes:",
-        "syev_two_stage.sb2st_hh is 52.9% of syev at n=1024 batch=256, measured",
-        "by BATCHLAS_KERNEL_TRACE. Its knobs are env-only",
-        "(BATCHLAS_SB2ST_BACK_TILE, BATCHLAS_SB2ST_BACK_WAVE,",
-        "BATCHLAS_SB2ST_SUBGROUP) with no constants behind them.",
-        "Grids are a first probe, not a considered range -- widen once you see",
-        "which direction helps."
+        "Blocked on: choose_two_stage_sb2st_block_size() returns a hardcoded 32.",
+        "This is the chase blocking factor, distinct from the back-transform",
+        "geometry now tuned by the sb2st bench in default.json."
       ],
       "cases": [
-        { "fixed": { "n": 512,  "batch": 512, "kd": 32 }, "tune": { "back_tile": [16, 32, 64], "back_wave": [1, 2, 4] } },
-        { "fixed": { "n": 1024, "batch": 256, "kd": 32 }, "tune": { "back_tile": [16, 32, 64], "back_wave": [1, 2, 4] } }
-      ]
-    },
-
-    {
-      "bench": "sy2sb_ormqr_nb",
-      "exe": "syev_benchmark",
-      "metric": "Time (µs) / matrix",
-      "direction": "min",
-      "arg_spec": ["n", "batch", "nb", "wg", "fuse"],
-      "env": { "sy2sb_nb": "BATCHLAS_SY2SB_ORMQR_NB" },
-      "_comment": [
-        "Blocked on: sy2sb_ormqr_block_size_hint() in sytrd_sy2sb.cc is a",
-        "hand-written shape gate (return kd when n>=1024 && batch>=32, else 0)",
-        "rather than a tuned table. It shadows ORMQR_BLOCK_SIZE_* on syev's hot",
-        "path -- with the gate on, changing the ormqr constant leaves the kernel",
-        "trace bit-identical.",
-        "Measured: with the gate off, nb=56 is 1.21x faster than nb=16 at n=1024",
-        "batch=256, and the gate's own kd=32 is worth about the same. So the",
-        "gate is currently doing the right thing; the question a sweep answers is",
-        "whether its n/batch boundaries are right."
-      ],
-      "cases": [
-        { "fixed": { "n": 512,  "batch": 512, "nb": 8, "wg": 0, "fuse": 0 }, "tune": { "sy2sb_nb": [16, 32, 48, 56] } },
-        { "fixed": { "n": 1024, "batch": 256, "nb": 8, "wg": 0, "fuse": 0 }, "tune": { "sy2sb_nb": [16, 32, 48, 56] } }
+        { "fixed": { "n": 512,  "batch": 512, "kd": 32 }, "tune": { "sb2st_block": [16, 32, 64] } },
+        { "fixed": { "n": 1024, "batch": 128, "kd": 32 }, "tune": { "sb2st_block": [16, 32, 64] } }
       ]
     }
   ]

--- a/evaluation/tuning/spaces/unwired.json
+++ b/evaluation/tuning/spaces/unwired.json
@@ -53,7 +53,10 @@
       "metric": "Time (ms)",
       "direction": "min",
       "arg_spec": ["n", "batch", "kd"],
+      "row": "BM_SYEV_TWO_STAGE",
       "_comment": [
+        "The executable also emits BM_SYEV_BLOCKED_BASELINE, which kd does not",
+        "affect at all; 'row' selects the two-stage path.",
         "Blocked on: the band width is chosen by choose_two_stage_kd() in",
         "src/extensions/two_stage_common.hh, a hand-written table justified by a",
         "comment block, overridable only via BATCHLAS_SYEV_TWO_STAGE_KD.",
@@ -76,6 +79,7 @@
       "metric": "Time (ms)",
       "direction": "min",
       "arg_spec": ["n", "batch", "kd"],
+      "row": "BM_SYEV_TWO_STAGE",
       "env": { "sb2st_block": "BATCHLAS_SYEV_TWO_STAGE_SB2ST_BLOCK" },
       "_comment": [
         "Blocked on: choose_two_stage_sb2st_block_size() returns a hardcoded 32.",

--- a/evaluation/tuning/spaces/unwired.json
+++ b/evaluation/tuning/spaces/unwired.json
@@ -1,0 +1,118 @@
+{
+  "_comment": [
+    "Parameters that measurably matter but that NO constant in",
+    "include/batchlas/tuning_params.hh can carry. generate_tuning_header.py",
+    "ignores every bench in this file -- running it produces a profile for a",
+    "human to read, not a header.",
+    "",
+    "They are split out rather than deleted because the alternative is worse:",
+    "before 2026-08-06 the steqr bench sat in default.json and burned 18",
+    "invocations a run for a result nothing could ever consume, which looked",
+    "exactly like tuning.",
+    "",
+    "To promote one of these into default.json you must first: add",
+    "<NAME>_{TINY..XLARGE} constants and a *_for_n accessor to",
+    "include/batchlas/tuning_params.hh, teach generate_tuning_header.py to",
+    "derive them, and make the production call site read the accessor instead",
+    "of its hardcoded default.",
+    "",
+    "Run with:",
+    "  python3 evaluation/tuning/tune.py --space evaluation/tuning/spaces/unwired.json \\",
+    "      --backend CUDA --type float --out build/tuning/unwired.json --skip-missing"
+  ],
+  "spaces": [
+    {
+      "bench": "steqr_cta",
+      "exe": "steqr_benchmark",
+      "metric": "T(µs)/matrix",
+      "direction": "min",
+      "arg_spec": ["n", "batch", "n_sweeps", "wg_multiplier", "shift_kind"],
+      "_comment": [
+        "Blocked on: SteqrParams::cta_wg_size_multiplier (=1) and",
+        "cta_shift_strategy (=Lapack) are plain C++ member initialisers in",
+        "include/blas/extensions.hh, and stedc's leaf solve takes them as they",
+        "come. Nothing reads a tuning constant.",
+        "A previous run picked wg_multiplier=2 over the shipped 1, so there is",
+        "probably something here.",
+        "shift_kind is 1=Wilkinson, anything else=Lapack. The old grid swept",
+        "[0,1,2], where 0 and 2 are the same run -- it wasted a third of its",
+        "invocations measuring Lapack twice."
+      ],
+      "cases": [
+        { "fixed": { "n": 16, "batch": 4096, "n_sweeps": 10 }, "tune": { "wg_multiplier": [1, 2, 4], "shift_kind": [0, 1] } },
+        { "fixed": { "n": 32, "batch": 4096, "n_sweeps": 10 }, "tune": { "wg_multiplier": [1, 2, 4], "shift_kind": [0, 1] } }
+      ]
+    },
+
+    {
+      "bench": "syev_two_stage_kd",
+      "exe": "syev_two_stage_benchmark",
+      "metric": "Time (µs) / matrix",
+      "direction": "min",
+      "arg_spec": ["n", "batch", "kd"],
+      "_comment": [
+        "Blocked on: the band width is chosen by choose_two_stage_kd() in",
+        "src/extensions/two_stage_common.hh, a hand-written table justified by a",
+        "comment block, overridable only via BATCHLAS_SYEV_TWO_STAGE_KD.",
+        "It is worth measuring: that comment records 425.8 vs 500.1 ms between",
+        "kd=32 and kd=16 at n=1024, i.e. ~18%.",
+        "kd is positional here, so no env override is needed."
+      ],
+      "cases": [
+        { "fixed": { "n": 256,  "batch": 1024 }, "tune": { "kd": [16, 32, 48, 64] } },
+        { "fixed": { "n": 512,  "batch": 512  }, "tune": { "kd": [16, 32, 48, 64] } },
+        { "fixed": { "n": 1024, "batch": 128  }, "tune": { "kd": [16, 32, 48, 64, 96] } },
+        { "fixed": { "n": 2048, "batch": 32   }, "tune": { "kd": [16, 32, 48, 64, 96] } }
+      ]
+    },
+
+    {
+      "bench": "sb2st",
+      "exe": "sb2st_hh_benchmark",
+      "metric": "Time (µs) / matrix",
+      "direction": "min",
+      "arg_spec": ["n", "batch", "kd"],
+      "env": {
+        "back_tile": "BATCHLAS_SB2ST_BACK_TILE",
+        "back_wave": "BATCHLAS_SB2ST_BACK_WAVE"
+      },
+      "_comment": [
+        "The biggest single lever in the whole library that nothing tunes:",
+        "syev_two_stage.sb2st_hh is 52.9% of syev at n=1024 batch=256, measured",
+        "by BATCHLAS_KERNEL_TRACE. Its knobs are env-only",
+        "(BATCHLAS_SB2ST_BACK_TILE, BATCHLAS_SB2ST_BACK_WAVE,",
+        "BATCHLAS_SB2ST_SUBGROUP) with no constants behind them.",
+        "Grids are a first probe, not a considered range -- widen once you see",
+        "which direction helps."
+      ],
+      "cases": [
+        { "fixed": { "n": 512,  "batch": 512, "kd": 32 }, "tune": { "back_tile": [16, 32, 64], "back_wave": [1, 2, 4] } },
+        { "fixed": { "n": 1024, "batch": 256, "kd": 32 }, "tune": { "back_tile": [16, 32, 64], "back_wave": [1, 2, 4] } }
+      ]
+    },
+
+    {
+      "bench": "sy2sb_ormqr_nb",
+      "exe": "syev_benchmark",
+      "metric": "Time (µs) / matrix",
+      "direction": "min",
+      "arg_spec": ["n", "batch", "nb", "wg", "fuse"],
+      "env": { "sy2sb_nb": "BATCHLAS_SY2SB_ORMQR_NB" },
+      "_comment": [
+        "Blocked on: sy2sb_ormqr_block_size_hint() in sytrd_sy2sb.cc is a",
+        "hand-written shape gate (return kd when n>=1024 && batch>=32, else 0)",
+        "rather than a tuned table. It shadows ORMQR_BLOCK_SIZE_* on syev's hot",
+        "path -- with the gate on, changing the ormqr constant leaves the kernel",
+        "trace bit-identical.",
+        "Measured: with the gate off, nb=56 is 1.21x faster than nb=16 at n=1024",
+        "batch=256, and the gate's own kd=32 is worth about the same. So the",
+        "gate is currently doing the right thing; the question a sweep answers is",
+        "whether its n/batch boundaries are right."
+      ],
+      "cases": [
+        { "fixed": { "n": 512,  "batch": 512, "nb": 8, "wg": 0, "fuse": 0 }, "tune": { "sy2sb_nb": [16, 32, 48, 56] } },
+        { "fixed": { "n": 1024, "batch": 256, "nb": 8, "wg": 0, "fuse": 0 }, "tune": { "sy2sb_nb": [16, 32, 48, 56] } }
+      ]
+    }
+  ]
+}

--- a/evaluation/tuning/tune.py
+++ b/evaluation/tuning/tune.py
@@ -443,6 +443,16 @@ def _tune_one_bench(
         "best": best,
         "top": leaderboard,
         "per_case_best": [x for x in per_case_best if x is not None],
+        # Every distinct configuration measured, so sensitivity.py can ask which
+        # parameters actually moved the metric. `top` is truncated and
+        # `per_case_best` keeps only winners, so neither can answer that. Env
+        # params are invisible in the benchmark's own CSV output, which makes
+        # this the only complete record of them.
+        "env_spec": dict(space.env),
+        "measurements": [
+            {"args": list(args_key), "env": dict(env_key), "value": value}
+            for (args_key, env_key), value in measured.items()
+        ],
     }
 
 

--- a/evaluation/tuning/tune.py
+++ b/evaluation/tuning/tune.py
@@ -98,6 +98,19 @@ def _normalize_case_indices(total_cases: int, selected: Optional[Sequence[Any]])
 
 
 def _collect_tune_keys(cases: Sequence[Dict[str, Any]], *, exclude: Optional[Sequence[str]] = None) -> Dict[str, List[int]]:
+    """Union of every case's grid for each tuned key.
+
+    Deliberately a union, not an intersection. The generated header is
+    bucket-first: it reads `per_case_best`, so each case must be free to search
+    its own declared grid. Intersecting first silently shrinks that search --
+    with the shipped default space, ormqr's per-case grids intersect to the
+    single value {16}, so every ORMQR_BLOCK_SIZE_* bucket was "tuned" without
+    ever comparing a second candidate.
+
+    Cross-case aggregation (`best`/`top`) is unaffected: `_case_allows` keeps a
+    case out of any combo its own grid excludes, and only combos that cover
+    every case are scored -- which is exactly the old intersection.
+    """
     tune_keys: Dict[str, List[int]] = {}
     excluded = set(exclude or [])
     for case in cases:
@@ -107,11 +120,24 @@ def _collect_tune_keys(cases: Sequence[Dict[str, Any]], *, exclude: Optional[Seq
             if k not in tune_keys:
                 tune_keys[k] = list(vs)
             else:
-                existing = set(tune_keys[k])
-                new = set(vs)
-                inter = existing.intersection(new)
-                tune_keys[k] = sorted(inter) if inter else sorted(existing.union(new))
+                tune_keys[k] = sorted(set(tune_keys[k]).union(vs))
     return tune_keys
+
+
+def _case_allows(case: Dict[str, Any], params: Dict[str, int]) -> bool:
+    """True when `params` lies inside this case's own declared grid.
+
+    A key the case does not declare is unconstrained -- it is resolved from
+    `fixed` (or a pre-tuned value) exactly as before.
+    """
+    case_tune = case.get("tune") or {}
+    for key, value in params.items():
+        allowed = case_tune.get(key)
+        if allowed is None:
+            continue
+        if int(value) not in {int(v) for v in allowed}:
+            return False
+    return True
 
 
 def _tune_pre_phases(
@@ -259,6 +285,7 @@ def _tune_one_bench(
     verbose: bool,
 ) -> Dict[str, Any]:
     best: Optional[Dict[str, Any]] = None
+    partial_best: Optional[Dict[str, Any]] = None
     leaderboard: List[Dict[str, Any]] = []
     per_case_best: List[Optional[Dict[str, Any]]] = [None for _ in space.cases]
 
@@ -276,25 +303,40 @@ def _tune_one_bench(
 
     tune_keys = _collect_tune_keys(space.cases, exclude=resolved_pre_tune.keys())
 
+    # Widening the grid to a union means different combos can collapse to the
+    # same argument vector for a case that does not tune every key. Measure each
+    # distinct vector once.
+    measured: Dict[Tuple[int, ...], float] = {}
+
     for params in _iter_grid(tune_keys):
         effective_params = {**resolved_pre_tune, **params}
         values: List[float] = []
         per_case: List[Dict[str, Any]] = []
+        covers_all_cases = True
 
         for case_idx, case in enumerate(space.cases):
+            if not _case_allows(case, effective_params):
+                covers_all_cases = False
+                continue
+
             fixed = {k: int(v) for k, v in (case.get("fixed") or {}).items()}
             args = _args_from_spec(space.arg_spec, fixed=fixed, params=effective_params)
-            v = _run_one_case(
-                exe=exe,
-                backend=backend,
-                dtype=dtype,
-                metric=space.metric,
-                warmup=warmup,
-                min_time_ms=min_time_ms,
-                min_iters=min_iters,
-                max_iters=max_iters,
-                args=args,
-            )
+            key = tuple(args)
+            if key in measured:
+                v = measured[key]
+            else:
+                v = _run_one_case(
+                    exe=exe,
+                    backend=backend,
+                    dtype=dtype,
+                    metric=space.metric,
+                    warmup=warmup,
+                    min_time_ms=min_time_ms,
+                    min_iters=min_iters,
+                    max_iters=max_iters,
+                    args=args,
+                )
+                measured[key] = v
             values.append(v)
             per_case.append({"fixed": fixed, "args": args, "value": v})
 
@@ -316,8 +358,21 @@ def _tune_one_bench(
                     "params": dict(effective_params),
                 }
 
+        if not values:
+            continue
+
         s = _score(values, space.direction)
         entry = {"params": effective_params, "score": s, "values": values, "cases": per_case}
+
+        # Only combos legal for every case are comparable across cases, so the
+        # cross-case leaderboard still ranks exactly the old intersected grid.
+        # Per-case winners above are already recorded either way. Partial-coverage
+        # combos are kept aside purely so a space with fully disjoint per-case
+        # grids still yields a profile instead of tripping the assert below.
+        if not covers_all_cases:
+            if partial_best is None or s < partial_best["score"]:
+                partial_best = entry
+            continue
 
         if verbose:
             # Print minimal progress; keep stdout readable.
@@ -333,6 +388,8 @@ def _tune_one_bench(
         if best is None or entry["score"] < best["score"]:
             best = entry
 
+    if best is None:
+        best = partial_best
     assert best is not None
     return {
         "bench": space.bench,

--- a/evaluation/tuning/tune.py
+++ b/evaluation/tuning/tune.py
@@ -26,6 +26,12 @@ class BenchSpace:
     arg_spec: List[str]
     cases: List[Dict[str, Any]]  # each has {"fixed": {..}, "tune": {..}}
     pre_tune: List[Dict[str, Any]]  # optional bench-level phases: {"params": {..}, "cases": [..]}
+    # {param_name: ENV_VAR}. Params listed here are passed to the benchmark as
+    # environment variables instead of positional arguments, which is the only
+    # way to reach knobs no benchmark exposes in its arg list (gebrd's panel
+    # width, the sy2sb ormqr hint, the sb2st block size...). They must NOT
+    # appear in arg_spec.
+    env: Dict[str, str]
 
 
 def _repo_root() -> Path:
@@ -54,6 +60,23 @@ def _iter_grid(tune: Dict[str, List[int]]) -> Iterable[Dict[str, int]]:
     value_lists = [tune[k] for k in keys]
     for combo in itertools.product(*value_lists):
         yield {k: int(v) for k, v in zip(keys, combo)}
+
+
+def _env_from_spec(env_spec: Dict[str, str],
+                   fixed: Dict[str, int],
+                   params: Dict[str, int]) -> Dict[str, str]:
+    """Environment overrides for this combo, as {ENV_VAR: "value"}.
+
+    A param with no value in either params or fixed is simply left unset, which
+    means the benchmark keeps its compiled default.
+    """
+    out: Dict[str, str] = {}
+    for name, env_var in env_spec.items():
+        if name in params:
+            out[str(env_var)] = str(int(params[name]))
+        elif name in fixed:
+            out[str(env_var)] = str(int(fixed[name]))
+    return out
 
 
 def _args_from_spec(arg_spec: List[str], fixed: Dict[str, int], params: Dict[str, int]) -> List[int]:
@@ -172,10 +195,11 @@ def _tune_pre_phases(
                 case = space.cases[case_idx]
                 fixed = {k: int(v) for k, v in (case.get("fixed") or {}).items()}
                 case_defaults = _representative_case_params(case, exclude=effective_params.keys())
+                phase_params = {**case_defaults, **effective_params}
                 args = _args_from_spec(
                     space.arg_spec,
                     fixed=fixed,
-                    params={**case_defaults, **effective_params},
+                    params=phase_params,
                 )
                 values.append(
                     _run_one_case(
@@ -188,6 +212,7 @@ def _tune_pre_phases(
                         min_iters=min_iters,
                         max_iters=max_iters,
                         args=args,
+                        env_overrides=_env_from_spec(space.env, fixed=fixed, params=phase_params),
                     )
                 )
 
@@ -226,7 +251,13 @@ def _run_one_case(
     min_iters: int,
     max_iters: int,
     args: List[int],
+    env_overrides: Optional[Dict[str, str]] = None,
 ) -> float:
+    # Merge, never replace: run_minibench_csv hands this straight to
+    # subprocess.run, and a bare dict would drop PATH / LD_LIBRARY_PATH and the
+    # CUDA and SYCL runtime variables the benchmark needs to start at all.
+    env = {**os.environ, **env_overrides} if env_overrides else None
+
     rows = run_minibench_csv(
         exe,
         backend=backend,
@@ -238,6 +269,7 @@ def _run_one_case(
         max_iters=max_iters,
         args=args,
         prefix="batchlas-tune-",
+        env=env,
     )
     if not rows:
         raise RuntimeError(
@@ -266,6 +298,7 @@ def _load_spaces(path: Path) -> List[BenchSpace]:
                 arg_spec=list(s["arg_spec"]),
                 cases=list(s["cases"]),
                 pre_tune=list(s.get("pre_tune") or []),
+                env={str(k): str(v) for k, v in (s.get("env") or {}).items()},
             )
         )
     return spaces
@@ -306,7 +339,7 @@ def _tune_one_bench(
     # Widening the grid to a union means different combos can collapse to the
     # same argument vector for a case that does not tune every key. Measure each
     # distinct vector once.
-    measured: Dict[Tuple[int, ...], float] = {}
+    measured: Dict[Tuple[Any, ...], float] = {}
 
     for params in _iter_grid(tune_keys):
         effective_params = {**resolved_pre_tune, **params}
@@ -321,7 +354,12 @@ def _tune_one_bench(
 
             fixed = {k: int(v) for k, v in (case.get("fixed") or {}).items()}
             args = _args_from_spec(space.arg_spec, fixed=fixed, params=effective_params)
-            key = tuple(args)
+            env_overrides = _env_from_spec(space.env, fixed=fixed, params=effective_params)
+            # The env vars are part of the measured configuration, so they must
+            # be part of the cache key -- otherwise every env-tuned combo would
+            # collide on an identical argument vector and return the first
+            # measurement for all of them.
+            key = (tuple(args), tuple(sorted(env_overrides.items())))
             if key in measured:
                 v = measured[key]
             else:
@@ -335,10 +373,14 @@ def _tune_one_bench(
                     min_iters=min_iters,
                     max_iters=max_iters,
                     args=args,
+                    env_overrides=env_overrides,
                 )
                 measured[key] = v
             values.append(v)
-            per_case.append({"fixed": fixed, "args": args, "value": v})
+            entry_case: Dict[str, Any] = {"fixed": fixed, "args": args, "value": v}
+            if env_overrides:
+                entry_case["env"] = env_overrides
+            per_case.append(entry_case)
 
             current = per_case_best[case_idx]
             better = False

--- a/evaluation/tuning/tune.py
+++ b/evaluation/tuning/tune.py
@@ -219,9 +219,9 @@ def _run_one_case(
             "This usually means the benchmark wasn't registered for that backend/type (compiled out)"
         )
 
-        # Usually there is exactly one row after backend/type filtering.
-        # If multiple appear, choose the first.
-        return float(rows[0]["value"])
+    # Usually there is exactly one row after backend/type filtering.
+    # If multiple appear, choose the first.
+    return float(rows[0]["value"])
 
 
 def _load_spaces(path: Path) -> List[BenchSpace]:
@@ -373,7 +373,7 @@ def main() -> int:
     args = parser.parse_args()
 
     repo_root = _repo_root()
-    build_dir = args.build_dir or _default_build_dir(repo_root)
+    build_dir = args.build_dir or default_build_dir(repo_root)
     space_path = args.space or _default_space_path(repo_root)
     out_path = args.out or _default_output_path(build_dir)
 
@@ -381,7 +381,7 @@ def main() -> int:
 
     results: List[Dict[str, Any]] = []
     for space in spaces:
-        exe = _default_benchmark_path(build_dir, space.exe)
+        exe = default_benchmark_path(build_dir, space.exe)
         if not exe.exists() or not os.access(exe, os.X_OK):
             msg = f"Missing benchmark executable: {exe}"
             if args.skip_missing:

--- a/evaluation/tuning/tune.py
+++ b/evaluation/tuning/tune.py
@@ -468,6 +468,16 @@ def main() -> int:
     parser.add_argument("--skip-missing", action="store_true", help="Skip benches whose executables are missing")
     parser.add_argument("--skip-failed", action="store_true", help="Skip benches that fail to run (e.g., unsupported backend)")
     parser.add_argument("--verbose", action="store_true")
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help=(
+            "Run one cheap invocation per bench to check the executable exists and the "
+            "metric column parses, then exit without tuning. Do this before a real "
+            "sweep: benches run sequentially, so a wrong metric name in the last one "
+            "otherwise surfaces after every earlier bench has already been measured."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -477,6 +487,46 @@ def main() -> int:
     out_path = args.out or _default_output_path(build_dir)
 
     spaces = _load_spaces(space_path)
+
+    if args.validate:
+        problems: List[str] = []
+        for space in spaces:
+            exe = default_benchmark_path(build_dir, space.exe)
+            if not exe.exists() or not os.access(exe, os.X_OK):
+                problems.append(f"{space.bench}: missing executable {exe}")
+                continue
+            case = space.cases[0]
+            fixed = {k: int(v) for k, v in (case.get("fixed") or {}).items()}
+            # pre_tune params are resolved before the main sweep and so are
+            # absent from any case's `tune` grid; take their first candidate.
+            pre: Dict[str, int] = {}
+            for phase in space.pre_tune:
+                for key, values in (phase.get("params") or {}).items():
+                    if isinstance(values, list) and values:
+                        pre[str(key)] = int(values[0])
+            params = {**pre, **_representative_case_params(case)}
+            try:
+                _run_one_case(
+                    exe=exe,
+                    backend=args.backend,
+                    dtype=args.dtype,
+                    metric=space.metric,
+                    warmup=0,
+                    min_time_ms=0.0,
+                    min_iters=1,
+                    max_iters=1,
+                    args=_args_from_spec(space.arg_spec, fixed=fixed, params=params),
+                    env_overrides=_env_from_spec(space.env, fixed=fixed, params=params),
+                )
+            except Exception as exc:  # noqa: BLE001 - report every bench, not just the first
+                problems.append(f"{space.bench}: {exc}")
+            else:
+                print(f"[ok] {space.bench} via {exe.name} (metric {space.metric!r})")
+
+        for problem in problems:
+            print(f"[FAIL] {problem}")
+        print(f"\n{len(spaces) - len(problems)}/{len(spaces)} benches OK")
+        return 1 if problems else 0
 
     results: List[Dict[str, Any]] = []
     for space in spaces:

--- a/evaluation/tuning/tune.py
+++ b/evaluation/tuning/tune.py
@@ -32,6 +32,12 @@ class BenchSpace:
     # width, the sy2sb ormqr hint, the sb2st block size...). They must NOT
     # appear in arg_spec.
     env: Dict[str, str]
+    # Substring selecting which benchmark row to read when the executable
+    # registers more than one. sb2st_hh_benchmark emits BM_SB2ST_HH_CHASE and
+    # BM_SB2ST_HH_BACK from a single invocation; the back-transform knobs move
+    # only the latter, so reading the first row measured a kernel the tuned
+    # parameters cannot affect and reported the resulting noise as a winner.
+    row: str
 
 
 def _repo_root() -> Path:
@@ -213,6 +219,7 @@ def _tune_pre_phases(
                         max_iters=max_iters,
                         args=args,
                         env_overrides=_env_from_spec(space.env, fixed=fixed, params=phase_params),
+                        row=space.row,
                     )
                 )
 
@@ -252,6 +259,7 @@ def _run_one_case(
     max_iters: int,
     args: List[int],
     env_overrides: Optional[Dict[str, str]] = None,
+    row: str = "",
 ) -> float:
     # Merge, never replace: run_minibench_csv hands this straight to
     # subprocess.run, and a bare dict would drop PATH / LD_LIBRARY_PATH and the
@@ -277,8 +285,23 @@ def _run_one_case(
             "This usually means the benchmark wasn't registered for that backend/type (compiled out)"
         )
 
-    # Usually there is exactly one row after backend/type filtering.
-    # If multiple appear, choose the first.
+    if row:
+        matching = [r for r in rows if row in str(r.get("name", ""))]
+        if not matching:
+            names = ", ".join(sorted({str(r.get("name", "")) for r in rows}))
+            raise RuntimeError(f"No row of {exe.name} matches row filter {row!r}. Rows: {names}")
+        return float(matching[0]["value"])
+
+    # Never silently pick one of several kernels: an executable that registers
+    # more than one benchmark is measuring more than one thing, and the tuned
+    # parameters usually move only one of them. Make the space say which.
+    if len(rows) > 1:
+        names = ", ".join(sorted({str(r.get("name", "")) for r in rows}))
+        raise RuntimeError(
+            f"{exe.name} produced {len(rows)} rows for args={args}; set \"row\" in the "
+            f"tuning space to select one. Rows: {names}"
+        )
+
     return float(rows[0]["value"])
 
 
@@ -299,6 +322,7 @@ def _load_spaces(path: Path) -> List[BenchSpace]:
                 cases=list(s["cases"]),
                 pre_tune=list(s.get("pre_tune") or []),
                 env={str(k): str(v) for k, v in (s.get("env") or {}).items()},
+                row=str(s.get("row") or ""),
             )
         )
     return spaces
@@ -374,6 +398,7 @@ def _tune_one_bench(
                     max_iters=max_iters,
                     args=args,
                     env_overrides=env_overrides,
+                    row=space.row,
                 )
                 measured[key] = v
             values.append(v)
@@ -527,6 +552,7 @@ def main() -> int:
                     max_iters=1,
                     args=_args_from_spec(space.arg_spec, fixed=fixed, params=params),
                     env_overrides=_env_from_spec(space.env, fixed=fixed, params=params),
+                    row=space.row,
                 )
             except Exception as exc:  # noqa: BLE001 - report every bench, not just the first
                 problems.append(f"{space.bench}: {exc}")

--- a/include/batchlas/tuning_params.hh
+++ b/include/batchlas/tuning_params.hh
@@ -65,6 +65,37 @@ inline constexpr int32_t GEBRD_BLOCK_SIZE_MEDIUM = 16;
 inline constexpr int32_t GEBRD_BLOCK_SIZE_LARGE = 16;
 inline constexpr int32_t GEBRD_BLOCK_SIZE_XLARGE = 16;
 
+// sb2st back-transform geometry, for the wave-parallel path that is ~53% of
+// syev at n=1024. 0 means "keep the shape-adaptive heuristic in
+// sytrd_sb2st_hh.cc", which is what ships, so these are inert until tuned.
+//
+// Only the instantiated (tile, subs) combinations exist: tile in {1,2,4,8} and
+// subs in {4,8,16}. Any other pair silently falls through to the slower tiled
+// kernel, so a tuning grid must not leave that set.
+inline constexpr int32_t SB2ST_BACK_TILE_TINY = 0;
+inline constexpr int32_t SB2ST_BACK_TILE_SMALL = 0;
+inline constexpr int32_t SB2ST_BACK_TILE_MEDIUM = 0;
+inline constexpr int32_t SB2ST_BACK_TILE_LARGE = 0;
+inline constexpr int32_t SB2ST_BACK_TILE_XLARGE = 0;
+
+inline constexpr int32_t SB2ST_BACK_SUBS_TINY = 0;
+inline constexpr int32_t SB2ST_BACK_SUBS_SMALL = 0;
+inline constexpr int32_t SB2ST_BACK_SUBS_MEDIUM = 0;
+inline constexpr int32_t SB2ST_BACK_SUBS_LARGE = 0;
+inline constexpr int32_t SB2ST_BACK_SUBS_XLARGE = 0;
+
+// WY block width for the sy2sb panel back-transform. 0 means "keep the shape
+// gate in sytrd_sy2sb.cc" (return kd when n >= 1024 and batch >= 32), which is
+// what ships. A positive value is clamped to kd at the call site.
+//
+// This is the knob that shadows ORMQR_BLOCK_SIZE_* on syev's hot path: with the
+// gate active, changing the ormqr constant leaves the kernel trace identical.
+inline constexpr int32_t SY2SB_ORMQR_NB_TINY = 0;
+inline constexpr int32_t SY2SB_ORMQR_NB_SMALL = 0;
+inline constexpr int32_t SY2SB_ORMQR_NB_MEDIUM = 0;
+inline constexpr int32_t SY2SB_ORMQR_NB_LARGE = 0;
+inline constexpr int32_t SY2SB_ORMQR_NB_XLARGE = 0;
+
 inline constexpr int32_t SYTRD_BLOCK_SIZE_TINY = 8;
 inline constexpr int32_t SYTRD_BLOCK_SIZE_SMALL = 8;
 inline constexpr int32_t SYTRD_BLOCK_SIZE_MEDIUM = 16;
@@ -149,6 +180,30 @@ inline constexpr int32_t gebrd_block_size_default_for_n(int32_t n) {
     return GEBRD_BLOCK_SIZE_XLARGE;
 }
 
+inline constexpr int32_t sb2st_back_tile_default_for_n(int32_t n) {
+    if (n <= 64) return SB2ST_BACK_TILE_TINY;
+    if (n <= 128) return SB2ST_BACK_TILE_SMALL;
+    if (n <= 256) return SB2ST_BACK_TILE_MEDIUM;
+    if (n <= 512) return SB2ST_BACK_TILE_LARGE;
+    return SB2ST_BACK_TILE_XLARGE;
+}
+
+inline constexpr int32_t sb2st_back_subs_default_for_n(int32_t n) {
+    if (n <= 64) return SB2ST_BACK_SUBS_TINY;
+    if (n <= 128) return SB2ST_BACK_SUBS_SMALL;
+    if (n <= 256) return SB2ST_BACK_SUBS_MEDIUM;
+    if (n <= 512) return SB2ST_BACK_SUBS_LARGE;
+    return SB2ST_BACK_SUBS_XLARGE;
+}
+
+inline constexpr int32_t sy2sb_ormqr_nb_default_for_n(int32_t n) {
+    if (n <= 64) return SY2SB_ORMQR_NB_TINY;
+    if (n <= 128) return SY2SB_ORMQR_NB_SMALL;
+    if (n <= 256) return SY2SB_ORMQR_NB_MEDIUM;
+    if (n <= 512) return SY2SB_ORMQR_NB_LARGE;
+    return SY2SB_ORMQR_NB_XLARGE;
+}
+
 inline constexpr int32_t sytrd_block_size_default_for_n(int32_t n) {
     if (n <= 64) return SYTRD_BLOCK_SIZE_TINY;
     if (n <= 128) return SYTRD_BLOCK_SIZE_SMALL;
@@ -210,6 +265,25 @@ inline int32_t ormqr_block_size_for_n(int32_t n) {
 inline int32_t gebrd_block_size_for_n(int32_t n) {
     return detail::tuning_env_override("BATCHLAS_TUNE_GEBRD_BLOCK_SIZE",
                                        gebrd_block_size_default_for_n(n));
+}
+
+// These three return 0 to mean "no opinion, keep the call site's heuristic".
+// tuning_env_override treats a non-positive *environment* value as unset, so 0
+// is reachable only from the compiled constant -- which is what we want: the
+// env vars exist to force a specific geometry, not to force auto.
+inline int32_t sb2st_back_tile_for_n(int32_t n) {
+    return detail::tuning_env_override("BATCHLAS_TUNE_SB2ST_BACK_TILE",
+                                       sb2st_back_tile_default_for_n(n));
+}
+
+inline int32_t sb2st_back_subs_for_n(int32_t n) {
+    return detail::tuning_env_override("BATCHLAS_TUNE_SB2ST_BACK_SUBS",
+                                       sb2st_back_subs_default_for_n(n));
+}
+
+inline int32_t sy2sb_ormqr_nb_for_n(int32_t n) {
+    return detail::tuning_env_override("BATCHLAS_TUNE_SY2SB_ORMQR_NB",
+                                       sy2sb_ormqr_nb_default_for_n(n));
 }
 
 inline int32_t sytrd_block_size_for_n(int32_t n) {

--- a/include/batchlas/tuning_params.hh
+++ b/include/batchlas/tuning_params.hh
@@ -48,6 +48,23 @@ inline constexpr int32_t ORMQR_BLOCK_SIZE_MEDIUM = 16;
 inline constexpr int32_t ORMQR_BLOCK_SIZE_LARGE = 16;
 inline constexpr int32_t ORMQR_BLOCK_SIZE_XLARGE = 16;
 
+// gebrd's panel width. Split out of ORMQR_BLOCK_SIZE_* on 2026-08-06: gesvd
+// used the ormqr constant to size its bidiagonal reduction, an unrelated kernel,
+// and the two have opposite gradients. Measured on gesvd_blocked n=512
+// batch=256 via the gesvd.gebrd stage timer, nb across:
+//
+//     8: 234.9   12: 232.1   16: 230.7   24: 235.5   32: 240.9   48: 256.6 ms
+//
+// gebrd's optimum is 16 and its curve is flat (+-2%); ormqr's is steep (2.16x
+// between 16 and 56). Sharing one knob therefore pinned the steep parameter at
+// the flat one's optimum. These values preserve the behaviour that was shipped
+// while the constants were shared, so the split is a no-op until retuned.
+inline constexpr int32_t GEBRD_BLOCK_SIZE_TINY = 16;
+inline constexpr int32_t GEBRD_BLOCK_SIZE_SMALL = 16;
+inline constexpr int32_t GEBRD_BLOCK_SIZE_MEDIUM = 16;
+inline constexpr int32_t GEBRD_BLOCK_SIZE_LARGE = 16;
+inline constexpr int32_t GEBRD_BLOCK_SIZE_XLARGE = 16;
+
 inline constexpr int32_t SYTRD_BLOCK_SIZE_TINY = 8;
 inline constexpr int32_t SYTRD_BLOCK_SIZE_SMALL = 8;
 inline constexpr int32_t SYTRD_BLOCK_SIZE_MEDIUM = 16;
@@ -124,6 +141,14 @@ inline constexpr int32_t ormqr_block_size_default_for_n(int32_t n) {
     return ORMQR_BLOCK_SIZE_XLARGE;
 }
 
+inline constexpr int32_t gebrd_block_size_default_for_n(int32_t n) {
+    if (n <= 64) return GEBRD_BLOCK_SIZE_TINY;
+    if (n <= 128) return GEBRD_BLOCK_SIZE_SMALL;
+    if (n <= 256) return GEBRD_BLOCK_SIZE_MEDIUM;
+    if (n <= 512) return GEBRD_BLOCK_SIZE_LARGE;
+    return GEBRD_BLOCK_SIZE_XLARGE;
+}
+
 inline constexpr int32_t sytrd_block_size_default_for_n(int32_t n) {
     if (n <= 64) return SYTRD_BLOCK_SIZE_TINY;
     if (n <= 128) return SYTRD_BLOCK_SIZE_SMALL;
@@ -180,6 +205,11 @@ inline constexpr int32_t stedc_wg_multiplier_default_for_n(int32_t n) {
 inline int32_t ormqr_block_size_for_n(int32_t n) {
     return detail::tuning_env_override("BATCHLAS_TUNE_ORMQR_BLOCK_SIZE",
                                        ormqr_block_size_default_for_n(n));
+}
+
+inline int32_t gebrd_block_size_for_n(int32_t n) {
+    return detail::tuning_env_override("BATCHLAS_TUNE_GEBRD_BLOCK_SIZE",
+                                       gebrd_block_size_default_for_n(n));
 }
 
 inline int32_t sytrd_block_size_for_n(int32_t n) {

--- a/include/batchlas/tuning_params.hh
+++ b/include/batchlas/tuning_params.hh
@@ -44,9 +44,9 @@ inline int32_t tuning_env_override(const char* name, int32_t fallback) {
 
 inline constexpr int32_t ORMQR_BLOCK_SIZE_TINY = 16;
 inline constexpr int32_t ORMQR_BLOCK_SIZE_SMALL = 16;
-inline constexpr int32_t ORMQR_BLOCK_SIZE_MEDIUM = 16;
-inline constexpr int32_t ORMQR_BLOCK_SIZE_LARGE = 16;
-inline constexpr int32_t ORMQR_BLOCK_SIZE_XLARGE = 16;
+inline constexpr int32_t ORMQR_BLOCK_SIZE_MEDIUM = 24;
+inline constexpr int32_t ORMQR_BLOCK_SIZE_LARGE = 48;
+inline constexpr int32_t ORMQR_BLOCK_SIZE_XLARGE = 56;
 
 // gebrd's panel width. Split out of ORMQR_BLOCK_SIZE_* on 2026-08-06: gesvd
 // used the ormqr constant to size its bidiagonal reduction, an unrelated kernel,
@@ -55,13 +55,17 @@ inline constexpr int32_t ORMQR_BLOCK_SIZE_XLARGE = 16;
 //
 //     8: 234.9   12: 232.1   16: 230.7   24: 235.5   32: 240.9   48: 256.6 ms
 //
-// gebrd's optimum is 16 and its curve is flat (+-2%); ormqr's is steep (2.16x
-// between 16 and 56). Sharing one knob therefore pinned the steep parameter at
-// the flat one's optimum. These values preserve the behaviour that was shipped
-// while the constants were shared, so the split is a no-op until retuned.
+// gebrd's optimum is 16 at n=512 and its curve is flat there (+-2%); ormqr's is
+// steep (2.16x between 16 and 56). Sharing one knob pinned the steep parameter
+// at the flat one's optimum.
+//
+// Retuned 2026-08-07 with the knobs separate: the small sizes want 8, not 16.
+// Per-case winners at jobu=jobvh=0, where gesvd.gebrd is ~95% of the call --
+// n=128: 8, n=256: 8, n=512: 16, n=1024: 16. The axis is worth 3.5-48%
+// depending on n, so it is not a flat parameter everywhere.
 inline constexpr int32_t GEBRD_BLOCK_SIZE_TINY = 16;
-inline constexpr int32_t GEBRD_BLOCK_SIZE_SMALL = 16;
-inline constexpr int32_t GEBRD_BLOCK_SIZE_MEDIUM = 16;
+inline constexpr int32_t GEBRD_BLOCK_SIZE_SMALL = 8;
+inline constexpr int32_t GEBRD_BLOCK_SIZE_MEDIUM = 8;
 inline constexpr int32_t GEBRD_BLOCK_SIZE_LARGE = 16;
 inline constexpr int32_t GEBRD_BLOCK_SIZE_XLARGE = 16;
 
@@ -72,6 +76,18 @@ inline constexpr int32_t GEBRD_BLOCK_SIZE_XLARGE = 16;
 // Only the instantiated (tile, subs) combinations exist: tile in {1,2,4,8} and
 // subs in {4,8,16}. Any other pair silently falls through to the slower tiled
 // kernel, so a tuning grid must not leave that set.
+//
+// DELIBERATELY LEFT AT 0 after the 2026-08-07 sweep. The geometry matters a lot
+// -- 3.6x across the grid at n=1024 -- but the heuristic already picks the
+// winner, so freezing it into buckets buys nothing and costs adaptivity on
+// shapes nobody measured:
+//
+//   n=256 b=1024   heuristic 0.012428   tuned (8,4)  0.012415   1.001x
+//   n=512 b=512    heuristic 0.050644   tuned (8,8)  0.050706   0.999x
+//   n=1024 b=256   heuristic 0.20701    tuned (8,16) 0.20575    1.006x
+//
+// The sb2st bench stays in the default space as a tripwire: if a kernel change
+// ever makes the heuristic wrong, the sweep will show a gap here.
 inline constexpr int32_t SB2ST_BACK_TILE_TINY = 0;
 inline constexpr int32_t SB2ST_BACK_TILE_SMALL = 0;
 inline constexpr int32_t SB2ST_BACK_TILE_MEDIUM = 0;
@@ -93,19 +109,19 @@ inline constexpr int32_t SB2ST_BACK_SUBS_XLARGE = 0;
 inline constexpr int32_t SY2SB_ORMQR_NB_TINY = 0;
 inline constexpr int32_t SY2SB_ORMQR_NB_SMALL = 0;
 inline constexpr int32_t SY2SB_ORMQR_NB_MEDIUM = 0;
-inline constexpr int32_t SY2SB_ORMQR_NB_LARGE = 0;
+inline constexpr int32_t SY2SB_ORMQR_NB_LARGE = 32;
 inline constexpr int32_t SY2SB_ORMQR_NB_XLARGE = 0;
 
 inline constexpr int32_t SYTRD_BLOCK_SIZE_TINY = 8;
 inline constexpr int32_t SYTRD_BLOCK_SIZE_SMALL = 8;
 inline constexpr int32_t SYTRD_BLOCK_SIZE_MEDIUM = 16;
-inline constexpr int32_t SYTRD_BLOCK_SIZE_LARGE = 24;
-inline constexpr int32_t SYTRD_BLOCK_SIZE_XLARGE = 32;
+inline constexpr int32_t SYTRD_BLOCK_SIZE_LARGE = 8;
+inline constexpr int32_t SYTRD_BLOCK_SIZE_XLARGE = 48;
 
 inline constexpr int32_t LATRD_LOWER_PANEL_WG_HINT_TINY = 0;
 inline constexpr int32_t LATRD_LOWER_PANEL_WG_HINT_SMALL = 0;
 inline constexpr int32_t LATRD_LOWER_PANEL_WG_HINT_MEDIUM = 0;
-inline constexpr int32_t LATRD_LOWER_PANEL_WG_HINT_LARGE = 0;
+inline constexpr int32_t LATRD_LOWER_PANEL_WG_HINT_LARGE = 128;
 inline constexpr int32_t LATRD_LOWER_PANEL_WG_HINT_XLARGE = 0;
 
 inline constexpr int32_t SYTRD_FUSE_PANEL_UPDATE_TINY = 0;
@@ -114,7 +130,7 @@ inline constexpr int32_t SYTRD_FUSE_PANEL_UPDATE_MEDIUM = 0;
 inline constexpr int32_t SYTRD_FUSE_PANEL_UPDATE_LARGE = 0;
 inline constexpr int32_t SYTRD_FUSE_PANEL_UPDATE_XLARGE = 0;
 
-inline constexpr int32_t STEDC_RECURSION_THRESHOLD_TINY = 16;
+inline constexpr int32_t STEDC_RECURSION_THRESHOLD_TINY = 32;
 inline constexpr int32_t STEDC_RECURSION_THRESHOLD_SMALL = 32;
 inline constexpr int32_t STEDC_RECURSION_THRESHOLD_MEDIUM = 32;
 inline constexpr int32_t STEDC_RECURSION_THRESHOLD_LARGE = 32;
@@ -148,10 +164,26 @@ inline constexpr int32_t STEDC_MERGE_VARIANT_MEDIUM = 2;
 inline constexpr int32_t STEDC_MERGE_VARIANT_LARGE = 2;
 inline constexpr int32_t STEDC_MERGE_VARIANT_XLARGE = 2;
 
-inline constexpr int32_t STEDC_THREADS_PER_ROOT_TINY = 4;
-inline constexpr int32_t STEDC_THREADS_PER_ROOT_SMALL = 4;
-inline constexpr int32_t STEDC_THREADS_PER_ROOT_MEDIUM = 4;
-inline constexpr int32_t STEDC_THREADS_PER_ROOT_LARGE = 4;
+// threads_per_root and wg_multiplier are set from syev, NOT from the stedc
+// bench, which disagrees with its own consumer. The 2026-08-07 sweep picked
+// wg_multiplier 2-4 and threads_per_root 4-8 on stedc alone; measured through
+// syev with everything else fixed, 8/8 wins nearly everywhere:
+//
+//   syev n     wgm=2    wgm=4    wgm=8   |   tpr=4    tpr=8   tpr=16
+//     64      0.9987   0.9225   0.9227   |  0.9937   0.9229   0.9422
+//    128       4.626    4.535    4.514   |   4.518    4.469    4.534
+//    256      23.067   22.110   21.383   |  21.557   21.332   21.330
+//    512      151.54   151.46   151.84   |  151.63   151.62   151.67
+//   1024      903.40   900.12   903.01   |  902.35   904.74   903.35
+//
+// Adopting stedc's own winners cost syev 2.7% at n=256. The stedc benchmark
+// measures the merge in isolation; syev pays for the whole tridiagonal solve,
+// and the two objectives do not agree. Below n=512 the difference is real
+// (up to 7.6% at n=64); at n>=512 every value is within noise.
+inline constexpr int32_t STEDC_THREADS_PER_ROOT_TINY = 8;
+inline constexpr int32_t STEDC_THREADS_PER_ROOT_SMALL = 8;
+inline constexpr int32_t STEDC_THREADS_PER_ROOT_MEDIUM = 8;
+inline constexpr int32_t STEDC_THREADS_PER_ROOT_LARGE = 8;
 inline constexpr int32_t STEDC_THREADS_PER_ROOT_XLARGE = 8;
 
 inline constexpr int32_t STEDC_WG_MULTIPLIER_TINY = 8;

--- a/src/extensions/gesvd_blocked.cc
+++ b/src/extensions/gesvd_blocked.cc
@@ -750,7 +750,7 @@ Event gesvd_native_impl(Queue& ctx,
         const bool need_vecs = want_u || want_vh;
         const bool tridiag_returns_vectors = (mode == GesvdNativeMode::Blocked) || need_vecs;
         const bool use_blocked_gebrd = gesvd_use_blocked_gebrd(k, mode);
-        const int32_t gebrd_block_size = tuning::ormqr_block_size_for_n(k);
+        const int32_t gebrd_block_size = tuning::gebrd_block_size_for_n(k);
         const int32_t max_order = want_u ? std::max(m, k) : k;
 
         auto& a = const_cast<MatrixView<T, MatrixFormat::Dense>&>(a_in);
@@ -1045,7 +1045,7 @@ size_t gesvd_native_buffer_size(Queue& ctx,
         const int32_t k_i32 = static_cast<int32_t>(k);
         const int32_t m_i32 = static_cast<int32_t>(m);
         const bool use_blocked_gebrd = gesvd_use_blocked_gebrd(k_i32, mode);
-        const int32_t gebrd_block_size = tuning::ormqr_block_size_for_n(k_i32);
+        const int32_t gebrd_block_size = tuning::gebrd_block_size_for_n(k_i32);
 
         if (tridiag_returns_vectors) {
             bytes += BumpAllocator::allocation_size<T>(ctx, k * k * batch);              // right singular vectors

--- a/src/extensions/sytrd_sb2st_hh.cc
+++ b/src/extensions/sytrd_sb2st_hh.cc
@@ -11,6 +11,7 @@
 #include <sycl/sycl.hpp>
 
 #include <batchlas/backend_config.h>
+#include <batchlas/tuning_params.hh>
 
 #include "../math-helpers.hh"
 #include "../queue.hh"
@@ -779,7 +780,10 @@ Event unmqr_hb2st(Queue& ctx,
         // no longer costs occupancy the way it did at S=1; C is chosen to keep
         // the footprint near a budget rather than as small as possible. Measured
         // best at 8 columns for every n tried (see the subs table below).
+        // Precedence: the legacy env knob forces a value, then the tuned
+        // constant (0 = no opinion), then the budget heuristic below.
         int tile = env_positive_int_or("BATCHLAS_SB2ST_BACK_TILE_W", 0);
+        if (tile <= 0) tile = tuning::sb2st_back_tile_for_n(n);
         if (tile <= 0) {
             constexpr size_t kTargetLocalBytes = 32768;
             tile = 1;
@@ -801,6 +805,7 @@ Event unmqr_hb2st(Queue& ctx,
         //   subs=16     20.6    58.5    103.5    207.1
         // -- 8 wins where waves hold ~8, 16 wins where they hold ~16.
         int subs = env_positive_int_or("BATCHLAS_SB2ST_BACK_SUBS", 0);
+        if (subs <= 0) subs = tuning::sb2st_back_subs_for_n(n);
         if (subs <= 0) {
             const int32_t avg = (num_waves > 0) ? (nrefl + num_waves - 1) / num_waves : 1;
             subs = (avg >= 12) ? 16 : (avg >= 6 ? 8 : 4);

--- a/src/extensions/sytrd_sy2sb.cc
+++ b/src/extensions/sytrd_sy2sb.cc
@@ -6,6 +6,7 @@
 #include <sycl/sycl.hpp>
 
 #include <batchlas/backend_config.h>
+#include <batchlas/tuning_params.hh>
 
 #include "../math-helpers.hh"
 #include "../queue.hh"
@@ -80,6 +81,10 @@ inline int32_t sy2sb_ormqr_block_size_hint(int n, int batch, int kd) {
         return std::min<int32_t>(forced, std::max(1, kd));
     }
     if (kd <= 0) return 0;
+    // Tuned constant next: 0 means "no opinion, use the shape gate below".
+    // Clamped to kd because a WY block wider than the panel is meaningless.
+    const int32_t tuned = tuning::sy2sb_ormqr_nb_for_n(n);
+    if (tuned > 0) return std::min<int32_t>(tuned, std::max(1, kd));
     // Shape gate: only where the win was measured.
     if (n >= 1024 && batch >= 32) return kd;
     return 0;


### PR DESCRIPTION
The tuning harness could not run at all on `main`. This fixes it, corrects what
it was measuring, and retunes — with every adopted value A/B'd end to end.

## Results

No regressions anywhere; measured before → after on CUDA/float, RTX 4090:

| case | before | after | |
|---|---|---|---|
| syev n=64 b=4096 | 1.0798 | 0.9938 | **1.087x** |
| syev n=512 b=512 | 166.95 | 151.01 | **1.106x** |
| gesvd n=128 b=1024 | 9.2465 | 8.0684 | **1.146x** |
| gesvd n=256 b=512 | 94.99 | 92.02 | 1.032x |
| gesvd n=512 b=256 (vectors) | 1143.3 | 1110.3 | 1.030x |

Everything else within 1%.

## The harness was broken

Three defects, all fallout from the refactor that moved minibench plumbing into
`evaluation/common/benchmark_runner.py`:

1. `tune.py` and `perf_eval.py` called `_default_build_dir` / `_default_benchmark_path`,
   which are exported without the underscore → `NameError` before any benchmark ran.
2. `_run_one_case` had its `return` indented inside `if not rows:` after the `raise`,
   so it returned `None` on every successful measurement. Under `--skip-failed`
   (which the CMake target passes) this silently skipped every bench and still
   wrote a successful-looking profile.
3. `_collect_tune_keys` **intersected** the per-case grids. For ormqr,
   `{4,8,12,16} ∩ {16,24,…,64} = {16}` — a single candidate, so all five
   `ORMQR_BLOCK_SIZE_*` buckets were "tuned" without a second value ever being
   timed. That result was already committed.

Also: the generator wrote two raw NUL bytes into the header (`'\0'` inside an
f-string), so `file` reported its output as `data`, not C++.

## It was measuring the wrong things

- **The documented CMake path is a no-op.** `-I<repo>/include` precedes
  `-I<repo>/build/include`, so the checked-in header always shadows the generated
  one. `cmake --build build --target batchlas_tuning_header` changes nothing.
  Proven with a `static_assert`; README now documents the working path.
- **One constant drove two unrelated kernels.** `gesvd_blocked.cc` read
  `ormqr_block_size_for_n` as `gebrd_block_size`. The two have opposite gradients
  and gebrd is 6.3x the bigger term, so one knob pinned the steep parameter at the
  flat one's optimum. Split into `GEBRD_BLOCK_SIZE_*`; verified orthogonal.
- **A knob can be dead code on its hot path.** sy2sb's shape gate shadows
  `ORMQR_BLOCK_SIZE_*` in syev — the kernel trace is bit-identical at nb=16 and
  nb=56. "No change" ≠ "doesn't matter".
- **One executable can register several benchmarks.** `sb2st_hh_benchmark` emits
  `CHASE` and `BACK`; reading `rows[0]` tuned the chase and reported 1.4% noise as
  a winner where the intended kernel spans 3.6x. Added a `row` field —
  `tune.py` now errors rather than guessing, which immediately caught the same
  bug in `syev_two_stage_benchmark`.

## Space rebuilt around what the header can carry

`default.json` holds only benches the generator names, with the dependency order
documented. New `unwired.json` holds parameters that measurably matter but have
no constant to land in — `steqr` lived in the default space for its whole life
burning 18 invocations a run for a result nothing could consume.

**sb2st and sy2sb are now wired** (constants + accessors + generator + call
sites, all three steps). sy2sb immediately found a win the hand-written gate
misses: it fires only at `n>=1024 && batch>=32`, so n=512 got no hint at all —
worth 1.10–1.12x.

**Dead axes removed** via the new `sensitivity.py`, which reports how far the
metric moves when one axis is swept with the rest held fixed. It deleted the
`latrd_lower_panel` bench outright (its only parameter moved the metric ≤0.38% —
sampling, not tuning), plus values that never won. Net **609 → 265 invocations
while adding sb2st and sy2sb coverage**; sweep time 14 min → under 7.

Also added `--validate`, which checks every bench's executable and metric column
in seconds. Benches run sequentially, so a wrong metric string otherwise
surfaces ~365 invocations in, with nothing written.

## Two things deliberately not adopted

- **sb2st constants stay 0.** The geometry spans 3.6x across its grid, but the
  existing shape-adaptive heuristic already picks the winner at every size
  (within 0.6%). Freezing buckets buys nothing and loses adaptivity. The bench
  stays as a tripwire.
- **stedc's own bench was overruled.** It picked `wg_multiplier` 2–4 and
  `threads_per_root` 4–8; adopting that cost **syev 2.7% at n=256**. Through
  syev, 8/8 wins nearly everywhere (7.6% at n=64). Its own sensitivity number
  (0.56% median) understated the real cost by an order of magnitude — the stedc
  bench measures the merge in isolation, syev pays for the whole solve.

## Testing

`syev`, `syev_blocked`, `syev_two_stage`, `stedc`, `gesvd`, `ormqr_blocked` on
CUDA: **109 passed, 0 failed**. Skips are the NETLIB half, filtered by
`BATCHLAS_TEST_BACKEND=CUDA`.

Reproduce:

```
cmake --build build -j --target syev_benchmark gesvd_blocked_benchmark stedc_benchmark \
      sytrd_blocked_benchmark ormqr_blocked_benchmark sb2st_hh_benchmark
python3 evaluation/tuning/tune.py --space evaluation/tuning/spaces/default.json \
      --backend CUDA --type float --validate
python3 evaluation/tuning/tune.py --space evaluation/tuning/spaces/default.json \
      --backend CUDA --type float --out build/tuning/profile.json
python3 evaluation/tuning/sensitivity.py build/tuning/profile.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf9fm2hatfjYajmW8SotAM
