### PR TITLE
feat(gesvd): thin vectors, Jacobi routing and n=64, and the blocked bidiagonalization at every n (PR #66 follow-ups 1-7)

### DIFF
--- a/benchmarks/gesvd_blocked_benchmark.cc
+++ b/benchmarks/gesvd_blocked_benchmark.cc
@@ -14,14 +14,20 @@ using namespace batchlas;
 
 namespace {
 
+// Args: m, n, batch, jobu, jobvh.
+//
+// m is separate from n so tall-skinny shapes are expressible at all. The body
+// used to read a single size and build Random(n, n, ...), which made the whole
+// m >> n regime -- the one the tall-skinny route exists for -- unmeasurable.
+// The registered set stays square; positional CLI args override it wholesale
+// (minibench.hh), so a sweep is `<m-list> <n> <batch> <jobu> <jobvh>`.
 template <typename Benchmark>
 inline void GesvdBlockedBenchSizes(Benchmark* b) {
-    // Args: n, batch, jobu_all, jobvh_all
     for (int n : {8, 16, 32, 64, 128, 256}) {
         for (int bs : {1, 2, 4, 8, 16, 32, 64}) {
             for (int jobu : {0, 1}) {
                 for (int jobvh : {0, 1}) {
-                    b->Args({n, bs, jobu, jobvh});
+                    b->Args({n, n, bs, jobu, jobvh});
                 }
             }
         }
@@ -34,32 +40,52 @@ inline void GesvdBlockedBenchSizesNetlib(Benchmark* b) {
         for (int bs : {1, 2, 4, 8, 16}) {
             for (int jobu : {0, 1}) {
                 for (int jobvh : {0, 1}) {
-                    b->Args({n, bs, jobu, jobvh});
+                    b->Args({n, n, bs, jobu, jobvh});
                 }
             }
         }
     }
 }
 
+// 0 -> None, 1 -> All, 2 -> Thin. Thin is what makes a tall-skinny U
+// expressible: at m >> n an All U is m x m and cannot be allocated.
 inline SvdVectors parse_job(int v) {
-    return (v == 0) ? SvdVectors::None : SvdVectors::All;
+    switch (v) {
+        case 0:  return SvdVectors::None;
+        case 2:  return SvdVectors::Thin;
+        default: return SvdVectors::All;
+    }
+}
+
+// When a factor is not requested its view is never written, so allocate the
+// THIN extent rather than the full one. Sizing U as m x m under jobu=None costs
+// 137 GB at m=16384/batch=128 and kills the process before the first timing --
+// which is how the large-m arm of the tall-skinny sweep first failed.
+inline int64_t u_cols_for(SvdVectors job, int64_t m, int64_t k) {
+    return job == SvdVectors::None ? k : svd_u_cols(job, m, k);
+}
+
+inline int64_t vh_rows_for(SvdVectors job, int64_t n, int64_t k) {
+    return job == SvdVectors::None ? k : svd_vh_rows(job, n, k);
 }
 
 } // namespace
 
 template <typename T, Backend B>
 static void BM_GESVD_BLOCKED(minibench::State& state) {
-    const size_t n = state.range(0);
-    const size_t batch = state.range(1);
-    const SvdVectors jobu = parse_job(static_cast<int>(state.range(2)));
-    const SvdVectors jobvh = parse_job(static_cast<int>(state.range(3)));
+    const size_t m = state.range(0);
+    const size_t n = state.range(1);
+    const size_t batch = state.range(2);
+    const SvdVectors jobu = parse_job(static_cast<int>(state.range(3)));
+    const SvdVectors jobvh = parse_job(static_cast<int>(state.range(4)));
+    const size_t k = std::min(m, n);
 
     auto q = std::make_shared<Queue>(Device(B == Backend::NETLIB ? "cpu" : "gpu"), B);
 
-    auto A = Matrix<T>::Random(n, n, /*hermitian=*/false, batch);
-    Matrix<T> U(n, n, batch);
-    Matrix<T> Vh(n, n, batch);
-    UnifiedVector<typename base_type<T>::type> s(n * batch);
+    auto A = Matrix<T>::Random(m, n, /*hermitian=*/false, batch);
+    Matrix<T> U(m, u_cols_for(jobu, m, k), batch);
+    Matrix<T> Vh(vh_rows_for(jobvh, n, k), n, batch);
+    UnifiedVector<typename base_type<T>::type> s(k * batch);
 
     const size_t ws_size = gesvd_blocked_buffer_size(*q,
                                                             A.view(),

--- a/include/blas/dispatch/env.hh
+++ b/include/blas/dispatch/env.hh
@@ -5,6 +5,7 @@
 #include <cctype>
 #include <cstdlib>
 #include <string>
+#include <string_view>
 
 #include <blas/dispatch/provider.hh>
 
@@ -63,8 +64,54 @@ inline constexpr std::array<Provider, 6> default_order_cta_blocked_vendor_netlib
     Provider::Netlib,
 };
 
-inline constexpr std::array<Provider, 6> default_order_for_op(const char* /*opname*/) {
-    // Phase 0: keep a single default order. Extend per-op later.
+// GESVD gets its own order because the one-sided Jacobi kernel (gesvdj_cta)
+// dominates the older CTA path on the axis that matters, and the shared order
+// buried it behind exactly the path it replaces.
+//
+// The two paths were measured head-to-head on this tree (RTX 4090, float,
+// n = 32, 256 samples, uncontended). Singular-value relative error against the
+// known spectrum, `max_relerr` from benchmarks/gesvd_relacc:
+//
+//   log10(kappa) |     1      2       3       4      5      6
+//   CTA          | 1.4e-6 4.7e-5  3.1e-3   0.235  1.046  1.857
+//   gesvdj_cta   | 4.8e-6 5.9e-6  1.2e-5  7.1e-5 6.3e-4 5.6e-3
+//
+// The CTA path forms the normal equations, so it squares the condition number
+// and loses the singular VALUES, not merely the vectors -- its orthogonality
+// over the same sweep runs 2.8e-6 -> 0.879 -> 4.371 while Jacobi stays flat at
+// ~1.3e-5. It is ahead only at kappa = 1e1, where both are ~1e-6 and the
+// difference cannot matter.
+//
+// Speed points the same way wherever U is requested, because the CTA path
+// builds U through an assembly + back-transform chain while Jacobi gets it for
+// free (U *is* the rotated, normalised A). Time per matrix, float, saturated
+// batch, jobu = All: n=8 23x, n=16 4.1x, n=32 parity. Adding U costs CTA 17x at
+// n=8 (0.065 -> 1.126 us) and costs Jacobi nothing (0.0448 -> 0.0452 us).
+//
+// The one regime where CTA is genuinely faster is values-only at n >= 16
+// (2.2x at n=32), and that is precisely where it has no correct digits past
+// kappa = 1e3. A 2.2x that returns 1.857 relative error is not a default worth
+// keeping; it stays reachable via BATCHLAS_GESVD_PROVIDER=cta for callers who
+// know their input is well conditioned.
+//
+// Hermitian input is unaffected: gesvd_supports_jacobi returns false when
+// hermitian_uplo is set, so those calls still fall through to the CTA path.
+inline constexpr std::array<Provider, 6> default_order_gesvd = {
+    Provider::BatchLAS_Jacobi,
+    Provider::BatchLAS_CTA,
+    Provider::BatchLAS_Blocked,
+    Provider::BatchLAS_TwoStage,
+    Provider::Vendor,
+    Provider::Netlib,
+};
+
+// Per-op default order. Ops that do not name themselves here keep the shared
+// order; note that Provider::BatchLAS_Jacobi is matched by no chooser other
+// than gesvd's, so moving it only affects gesvd.
+inline constexpr std::array<Provider, 6> default_order_for_op(const char* opname) {
+    if (opname && std::string_view(opname) == "GESVD") {
+        return default_order_gesvd;
+    }
     return default_order_cta_blocked_vendor_netlib;
 }
 

--- a/include/blas/dispatch/provider.hh
+++ b/include/blas/dispatch/provider.hh
@@ -16,12 +16,13 @@ enum class Provider {
 
 struct DispatchPolicy {
     Provider forced = Provider::Auto;
-    // BatchLAS_Jacobi sits AFTER the CTA/Blocked paths deliberately. For real
-    // input CTA precedes it and accepts every shape it accepts, so it is
-    // reachable in exactly two useful ways: forced via BATCHLAS_GESVD_PROVIDER,
-    // and automatically for complex GENERAL input, where the CTA and Blocked
-    // predicates return false and dispatch currently falls through to Vendor and
-    // throws. Promoting it ahead of CTA is a separate, measured change.
+    // This is the SHARED fallback order, used by every op that does not name
+    // itself in default_order_for_op (blas/dispatch/env.hh).
+    //
+    // BatchLAS_Jacobi sits after the CTA/Blocked paths here, which is harmless:
+    // gesvd is the only op whose chooser matches BatchLAS_Jacobi at all, and
+    // gesvd no longer uses this array -- it has its own order, with Jacobi
+    // first, and env.hh carries the measurement that put it there.
     std::array<Provider, 6> order = {
         Provider::BatchLAS_CTA,
         Provider::BatchLAS_Blocked,

--- a/include/blas/enums.hh
+++ b/include/blas/enums.hh
@@ -1,6 +1,7 @@
 #pragma once
 #include <complex>
 #include <concepts>
+#include <cstdint>
 #include <type_traits>
 namespace batchlas {
     template<typename T>
@@ -85,11 +86,60 @@ namespace batchlas {
         NoEigenVectors
     };
 
-    // SVD vector output policy (LAPACK-style semantics, simplified for now).
+    // SVD vector output policy, LAPACK jobu/jobvt semantics.
+    //
+    // With k = min(m, n), for an m x n input:
+    //   None  -- the factor is not computed and its MatrixView is not touched.
+    //   All   -- LAPACK 'A'. U is m x m, V^H is n x n.
+    //   Thin  -- LAPACK 'S'. U is m x k (the first k left singular vectors),
+    //            V^H is k x n (the first k right singular vectors, conjugated).
+    //
+    // Thin exists because All is unusable on tall-skinny input: a 10000 x 32
+    // problem has to materialise a 10000 x 10000 U, 400 MB per matrix in float,
+    // so batch=4 needs 1.6 GB for a factor whose last 9968 columns are an
+    // arbitrary orthonormal completion the caller did not ask for.
+    //
+    // The key identity, which most of the implementation rests on: Thin and All
+    // DIFFER ON AT MOST ONE SIDE. For m <= n, k == m, so a thin U (m x k) is
+    // exactly a full U (m x m); for m >= n, k == n, so a thin V^H is exactly a
+    // full V^H. Square input has Thin == All on both sides. Entry points
+    // therefore canonicalise Thin to All whenever the shapes coincide (see
+    // canonical_jobu / canonical_jobvh below) and only the genuinely thinner
+    // side has to be handled -- or rejected -- by any given route.
+    //
+    // LAPACK's 'O' (overwrite A with one of the factors) is deliberately absent;
+    // add it as a further enumerator if it is ever wanted, since appending keeps
+    // the existing ordinals stable for the benchmarks that pass jobs as ints.
     enum class SvdVectors {
         None,
-        All
+        All,
+        Thin
     };
+
+    // Number of columns of U / rows of V^H implied by a job, given the input
+    // shape and k = min(m, n). None yields 0: nothing is written.
+    inline constexpr int64_t svd_u_cols(SvdVectors job, int64_t m, int64_t k) {
+        return job == SvdVectors::All ? m : (job == SvdVectors::Thin ? k : 0);
+    }
+
+    inline constexpr int64_t svd_vh_rows(SvdVectors job, int64_t n, int64_t k) {
+        return job == SvdVectors::All ? n : (job == SvdVectors::Thin ? k : 0);
+    }
+
+    // Rewrite Thin to All when the two request the same shape, so that a route
+    // which cannot produce a genuinely thin factor still serves every request
+    // where "thin" is not actually asking for anything smaller. Call these once
+    // at each entry point, and pass the canonical values onward -- in
+    // particular, the buffer_size and the run path must canonicalise
+    // identically or the workspace is sized for a different computation than
+    // the one performed.
+    inline constexpr SvdVectors canonical_jobu(SvdVectors job, int64_t m, int64_t k) {
+        return (job == SvdVectors::Thin && k == m) ? SvdVectors::All : job;
+    }
+
+    inline constexpr SvdVectors canonical_jobvh(SvdVectors job, int64_t n, int64_t k) {
+        return (job == SvdVectors::Thin && k == n) ? SvdVectors::All : job;
+    }
 
     enum class Uplo {
         Upper,

--- a/include/blas/extra.hh
+++ b/include/blas/extra.hh
@@ -75,6 +75,41 @@ namespace batchlas
 
     // Create a batch of random dense matrices with a specified log10 conditioning metric.
     // log10_kappa is log10(κ2) or log10(κF) depending on metric (Spectral or Frobenius only).
+    //
+    // `algo` orthonormalises the two random factors. It defaults to CGS2, NOT to
+    // one of the Cholesky variants, and that is deliberate: Chol-QR forms the
+    // Gram matrix and so squares the condition number of its input. The input
+    // here is a raw Matrix::Random, whose conditioning is NOT controlled (the
+    // requested kappa is imposed afterwards, by the diagonal), and in float the
+    // squared Gram goes numerically indefinite once kappa exceeds about 1e4 --
+    // which ordinary random draws reach a few times in a batch of 32 at n=64.
+    // potrf then fails, its info code is discarded (see the note in
+    // src/extra/random_cond.cc), the following trsm back-substitutes through a
+    // garbage diagonal, and the two gemms smear the resulting NaN across every
+    // entry of that batch item. That is the "generator intermittently emits an
+    // entirely non-finite matrix" defect reported against PR #66.
+    //
+    // Measured at n=64, float, batch=32, seed 1, requesting log10(kappa_F) = 5;
+    // "ortho err" is ||Q^H Q - I||_max and the bracket is the range of log10 of
+    // the ACHIEVED condition number over the batch:
+    //
+    //   Chol2 (old default)  3.9e-7   [5.000,  5.000]   2/32 non-finite
+    //   Cholesky             3.2e-2   [4.992,  5.003]   2/32 non-finite
+    //   ShiftChol3           3.4e-7   [5.000,  5.000]   0/32
+    //   Householder          4.3e-7   [5.000, 17.390]   0/32
+    //   CGS2                 2.3e-7   [5.000,  5.000]   0/32
+    //   SVQB2                4.0e-6   [5.000,  5.000]   0/32
+    //
+    // Householder is the obvious candidate and is the WRONG one: it removes the
+    // NaNs but returns a factor that leaves some batch items numerically
+    // singular, so the generator silently stops honouring the requested kappa --
+    // a worse failure than the one being fixed, because it is invisible. That is
+    // a latent defect in ortho's geqrf+orgqr path, not in this generator.
+    //
+    // CGS2 has the best orthogonality of the six, honours the requested kappa
+    // exactly, and uses no potrf at all, so it cannot be caught by the unchecked
+    // info code. Callers who want the faster Cholesky path on input they know to
+    // be well conditioned can still ask for it explicitly.
     template <Backend B, typename T>
     Matrix<T, MatrixFormat::Dense> random_with_log10_cond_metric(Queue &ctx,
                                                                   int n,
@@ -82,10 +117,11 @@ namespace batchlas
                                                                   NormType metric,
                                                                   int batch_size = 1,
                                                                   unsigned int seed = 42,
-                                                                  OrthoAlgorithm algo = OrthoAlgorithm::Chol2);
+                                                                  OrthoAlgorithm algo = OrthoAlgorithm::CGS2);
 
     // Create a batch of random symmetric/Hermitian dense matrices with a specified log10 conditioning metric.
     // log10_kappa is log10(κ2) or log10(κF) depending on metric (Spectral or Frobenius only).
+    // See random_with_log10_cond_metric above for why `algo` defaults to CGS2.
     template <Backend B, typename T>
     Matrix<T, MatrixFormat::Dense> random_hermitian_with_log10_cond_metric(Queue &ctx,
                                                                            int n,
@@ -93,7 +129,7 @@ namespace batchlas
                                                                            NormType metric,
                                                                            int batch_size = 1,
                                                                            unsigned int seed = 42,
-                                                                           OrthoAlgorithm algo = OrthoAlgorithm::Chol2);
+                                                                           OrthoAlgorithm algo = OrthoAlgorithm::CGS2);
 
     // Create a batch of random dense banded matrices (general) with a specified log10 conditioning metric.
     // The resulting bandwidth is <= kd. For small kd, this may produce diagonal matrices.

--- a/include/blas/functions/gesvd.hh
+++ b/include/blas/functions/gesvd.hh
@@ -241,10 +241,27 @@ inline bool gesvd_supports_cta(const DeviceCaps& caps,
     return true;
 }
 
+// Largest max(m, n) gesvdj_cta accepts, per scalar type. Mirrors
+// gesvdj_cta_max_dim in src/extensions/gesvdj_cta.cc.
+//
+// The kernel keeps P = 32 lanes above n = 32 and grows the tile capacity C to
+// 64, so each lane owns two rows. The limit is local memory: per problem with
+// the V tile resident, C=64 costs 37,952 B for float, 71,744 B for double and
+// complex<float>, and 138,816 B for complex<double>, against a measured device
+// limit of 101,376 B. Values-only drops the V tile and halves it.
+template <typename T>
+inline constexpr int64_t gesvd_jacobi_max_dim(bool want_vectors) {
+    if constexpr (std::is_same_v<T, std::complex<double>>) {
+        return want_vectors ? 32 : 64;
+    } else {
+        return 64;
+    }
+}
+
 // gesvdj_cta supports complex GENERAL input natively, unlike the two predicates
 // below, which both return false for non-real T outside the Hermitian branch.
-// That is the Tier 4 coverage gap: complex general SVD on GPU currently falls
-// through to Vendor and throws. Do NOT copy the RealScalar gate here.
+// That is the Tier 4 coverage gap: complex general SVD on GPU used to fall
+// through to Vendor and throw. Do NOT copy the RealScalar gate here.
 template <typename T>
 inline bool gesvd_supports_jacobi(const DeviceCaps& caps,
                                   const MatrixView<T, MatrixFormat::Dense>& A,
@@ -255,7 +272,8 @@ inline bool gesvd_supports_jacobi(const DeviceCaps& caps,
     if (!caps.is_gpu) return false;
     if (caps.max_sub_group < 32) return false;
     if (A.rows() < 1 || A.cols() < 1 || A.batch_size() < 1) return false;
-    if (std::max(A.rows(), A.cols()) > 32) return false;
+    const bool want_vectors = (jobu != SvdVectors::None) || (jobvh != SvdVectors::None);
+    if (std::max(A.rows(), A.cols()) > gesvd_jacobi_max_dim<T>(want_vectors)) return false;
     // Every job combination is served, Thin included: one-sided Jacobi produces
     // the thin U natively -- it IS the rotated, normalised A -- and the full-U
     // columns are the extra work, manufactured by an in-kernel Gram-Schmidt
@@ -309,7 +327,31 @@ inline Provider choose_gesvd_provider(const DispatchPolicy& policy,
     for (Provider p : policy.order) {
         p = normalize_gesvd_vendor_like(p);
         if (p == Provider::BatchLAS_Jacobi && gesvd_supports_jacobi(caps, A, jobu, jobvh, hermitian_uplo)) {
-            return p;
+            // The 33..64 band is served by Jacobi only where the alternative
+            // cannot serve it at all -- that is, complex GENERAL input, which
+            // gesvd_supports_blocked declines, leaving Vendor and a throw.
+            //
+            // For REAL input in that band the blocked path is the better
+            // default, and this is the one place the two disagree. Measured at
+            // n=64, batch=4096, float, full vectors: blocked 4.86 us/matrix
+            // against Jacobi's 7.25, and at low conditioning blocked is also
+            // the more accurate of the two (kappa=1e1: 1.1e-6 vs 1.2e-5).
+            //
+            // Jacobi wins decisively at HIGH conditioning -- kappa=1e6, n=64:
+            // singular-value relative error 6.2e-3 vs 0.526, orthogonality
+            // 3.7e-5 vs 0.144, i.e. the blocked path returns no correct digits
+            // and a U that is not a basis. But which regime a caller is in is
+            // not knowable from the shape, and unlike the n <= 32 case (where
+            // the CTA path was worse from kappa=1e2 up) blocked is genuinely
+            // better below ~1e4. So the default stays blocked and the accurate
+            // route is opt-in via BATCHLAS_GESVD_PROVIDER=jacobi, which is
+            // checked ahead of this loop and so is unaffected by this rule.
+            const bool wide_band = std::max(A.rows(), A.cols()) > 32;
+            if constexpr (RealScalar<T>) {
+                if (!wide_band) return p;
+            } else {
+                return p;
+            }
         }
         if (p == Provider::BatchLAS_CTA && gesvd_supports_cta(caps, A, jobu, jobvh, hermitian_uplo)) {
             return p;

--- a/include/blas/functions/gesvd.hh
+++ b/include/blas/functions/gesvd.hh
@@ -219,8 +219,18 @@ inline bool gesvd_supports_cta(const DeviceCaps& caps,
     if (caps.max_sub_group < 32) return false;
     if (A.rows() < 1 || A.cols() < 1 || A.batch_size() < 1) return false;
     if (std::max(A.rows(), A.cols()) > 32) return false;
-    if (jobu != SvdVectors::None && jobu != SvdVectors::All) return false;
-    if (jobvh != SvdVectors::None && jobvh != SvdVectors::All) return false;
+    // Canonicalise here too, not only at the dispatch entry point: these
+    // predicates are the contract, and one that disagreed with the caller about
+    // what "Thin" means would reject shapes it can serve.
+    {
+        const int64_t k = std::min<int64_t>(A.rows(), A.cols());
+        jobu = canonical_jobu(jobu, A.rows(), k);
+        jobvh = canonical_jobvh(jobvh, A.cols(), k);
+    }
+    // A genuinely thin factor is out of reach for this route: mode CTA always
+    // takes the normal-equations branch, whose patch_zero_left_vectors writes m
+    // columns of U unconditionally.
+    if (jobu == SvdVectors::Thin || jobvh == SvdVectors::Thin) return false;
     if (hermitian_uplo.has_value()) {
         if (A.rows() != A.cols()) return false;
         return *hermitian_uplo == Uplo::Lower || *hermitian_uplo == Uplo::Upper;
@@ -246,8 +256,10 @@ inline bool gesvd_supports_jacobi(const DeviceCaps& caps,
     if (caps.max_sub_group < 32) return false;
     if (A.rows() < 1 || A.cols() < 1 || A.batch_size() < 1) return false;
     if (std::max(A.rows(), A.cols()) > 32) return false;
-    if (jobu != SvdVectors::None && jobu != SvdVectors::All) return false;
-    if (jobvh != SvdVectors::None && jobvh != SvdVectors::All) return false;
+    // Every job combination is served, Thin included: one-sided Jacobi produces
+    // the thin U natively -- it IS the rotated, normalised A -- and the full-U
+    // columns are the extra work, manufactured by an in-kernel Gram-Schmidt
+    // that a Thin request skips outright.
     return true;
 }
 
@@ -257,12 +269,11 @@ inline bool gesvd_supports_blocked(const DeviceCaps& caps,
                                    SvdVectors jobu,
                                    SvdVectors jobvh,
                                    std::optional<Uplo> hermitian_uplo = std::nullopt) {
-    // Current native path supports real matrices with optional full U and/or
-    // V^H backtransforms via ORMBR. Hermitian support remains square-only.
+    // Current native path supports real matrices with optional full, thin, or
+    // absent U and/or V^H backtransforms via ORMBR. Hermitian support remains
+    // square-only, where Thin canonicalises to All anyway.
     if (!caps.is_gpu) return false;
     if (A.rows() < 1 || A.cols() < 1 || A.batch_size() < 1) return false;
-    if (jobu != SvdVectors::None && jobu != SvdVectors::All) return false;
-    if (jobvh != SvdVectors::None && jobvh != SvdVectors::All) return false;
     if (hermitian_uplo.has_value()) {
         if (A.rows() != A.cols()) return false;
         return *hermitian_uplo == Uplo::Lower;
@@ -324,6 +335,16 @@ inline Event gesvd_dispatch(Queue& ctx,
                             SvdVectors jobvh,
                             std::optional<Uplo> hermitian_uplo,
                             Span<std::byte> workspace) {
+    // Canonicalise before anything else, and identically to
+    // gesvd_buffer_size_dispatch below: these two independently repeat the
+    // provider choice, and a divergence in what they think "Thin" means sizes
+    // the workspace for a different computation than the one that runs.
+    {
+        const int64_t k = std::min<int64_t>(A.rows(), A.cols());
+        jobu = canonical_jobu(jobu, A.rows(), k);
+        jobvh = canonical_jobvh(jobvh, A.cols(), k);
+    }
+
     const DeviceCaps caps = query_caps(ctx);
     const DispatchPolicy policy = policy_from_env("GESVD");
     Provider chosen = detail::choose_gesvd_provider(policy, caps, A, jobu, jobvh, hermitian_uplo);
@@ -398,6 +419,13 @@ inline size_t gesvd_buffer_size_dispatch(Queue& ctx,
                                          SvdVectors jobu,
                                          SvdVectors jobvh,
                                          std::optional<Uplo> hermitian_uplo) {
+    // Must match gesvd_dispatch's canonicalisation exactly -- see the note there.
+    {
+        const int64_t k = std::min<int64_t>(A.rows(), A.cols());
+        jobu = canonical_jobu(jobu, A.rows(), k);
+        jobvh = canonical_jobvh(jobvh, A.cols(), k);
+    }
+
     const DeviceCaps caps = query_caps(ctx);
     const DispatchPolicy policy = policy_from_env("GESVD");
     Provider chosen = detail::choose_gesvd_provider(policy, caps, A, jobu, jobvh, hermitian_uplo);

--- a/src/backends/cusolver.cc
+++ b/src/backends/cusolver.cc
@@ -316,6 +316,19 @@ namespace batchlas {
                 const int m = static_cast<int>(A.rows());
                 const int n = static_cast<int>(A.cols());
                 const int batch = static_cast<int>(A.batch_size());
+                // cusolverDnXgesvdjBatched has no `econ` flag -- econ belongs
+                // to the non-batched cusolverDnXgesvdj, and gesvdaStridedBatched
+                // is a different, rank-truncated algorithm. Refuse rather than
+                // silently mis-serve: want_u below is `== All`, so a Thin
+                // request would quietly mean "no vectors" and the shape checks
+                // would pass with U never written. Costs nothing in practice --
+                // this route caps at 32x32, where canonicalisation has already
+                // rewritten Thin to All for every square case.
+                if (jobu == SvdVectors::Thin || jobvh == SvdVectors::Thin) {
+                    throw std::runtime_error(
+                        "gesvd_vendor (CUSOLVER): thin singular vectors are not supported by the "
+                        "gesvdjBatched route");
+                }
                 const bool want_u = (jobu == SvdVectors::All);
                 const bool want_vh = (jobvh == SvdVectors::All);
                 const bool vectors = want_u || want_vh;
@@ -377,6 +390,19 @@ namespace batchlas {
                 const int n = static_cast<int>(A.cols());
                 const int k = std::min(m, n);
                 const int batch = static_cast<int>(A.batch_size());
+                // cusolverDnXgesvdjBatched has no `econ` flag -- econ belongs
+                // to the non-batched cusolverDnXgesvdj, and gesvdaStridedBatched
+                // is a different, rank-truncated algorithm. Refuse rather than
+                // silently mis-serve: want_u below is `== All`, so a Thin
+                // request would quietly mean "no vectors" and the shape checks
+                // would pass with U never written. Costs nothing in practice --
+                // this route caps at 32x32, where canonicalisation has already
+                // rewritten Thin to All for every square case.
+                if (jobu == SvdVectors::Thin || jobvh == SvdVectors::Thin) {
+                    throw std::runtime_error(
+                        "gesvd_vendor (CUSOLVER): thin singular vectors are not supported by the "
+                        "gesvdjBatched route");
+                }
                 const bool want_u = (jobu == SvdVectors::All);
                 const bool want_vh = (jobvh == SvdVectors::All);
                 const bool vectors = want_u || want_vh;

--- a/src/backends/netlib_lapack.cc
+++ b/src/backends/netlib_lapack.cc
@@ -858,17 +858,35 @@ namespace batchlas{
             throw std::invalid_argument("gesvd_vendor (NETLIB): singular_values span too small");
         }
 
-        const char lapack_jobu = (jobu == SvdVectors::All) ? 'A' : 'N';
-        const char lapack_jobvt = (jobvh == SvdVectors::All) ? 'A' : 'N';
+        // NETLIB implements Thin rather than refusing it. gesvd_dispatch pins
+        // this backend to Vendor unconditionally, so refusing would leave the
+        // whole CPU backend unable to serve Thin -- and this is the reference
+        // the GPU thin results are checked against.
+        jobu = canonical_jobu(jobu, m, k);
+        jobvh = canonical_jobvh(jobvh, n, k);
 
-        if (jobu == SvdVectors::All) {
-            if (U.rows() != m || U.cols() != m || U.batch_size() != batch) {
-                throw std::invalid_argument("gesvd_vendor (NETLIB): U must be (m x m) with matching batch");
+        const auto lapack_job = [](SvdVectors j) -> char {
+            switch (j) {
+                case SvdVectors::All:  return 'A';
+                case SvdVectors::Thin: return 'S';
+                default:               return 'N';
+            }
+        };
+        const char lapack_jobu = lapack_job(jobu);
+        const char lapack_jobvt = lapack_job(jobvh);
+
+        if (jobu != SvdVectors::None) {
+            const int want_cols = static_cast<int>(svd_u_cols(jobu, m, k));
+            if (U.rows() != m || U.cols() != want_cols || U.batch_size() != batch) {
+                throw std::invalid_argument("gesvd_vendor (NETLIB): U must be (m x " +
+                                            std::to_string(want_cols) + ") with matching batch");
             }
         }
-        if (jobvh == SvdVectors::All) {
-            if (Vh.rows() != n || Vh.cols() != n || Vh.batch_size() != batch) {
-                throw std::invalid_argument("gesvd_vendor (NETLIB): Vh must be (n x n) with matching batch");
+        if (jobvh != SvdVectors::None) {
+            const int want_rows = static_cast<int>(svd_vh_rows(jobvh, n, k));
+            if (Vh.rows() != want_rows || Vh.cols() != n || Vh.batch_size() != batch) {
+                throw std::invalid_argument("gesvd_vendor (NETLIB): Vh must be (" +
+                                            std::to_string(want_rows) + " x n) with matching batch");
             }
         }
 
@@ -886,34 +904,34 @@ namespace batchlas{
             if constexpr (std::is_same_v<T, float>) {
                 info = LAPACKE_sgesvd(LAPACK_COL_MAJOR, lapack_jobu, lapack_jobvt, m, n,
                                       Ab.data_ptr(), Ab.ld(), sb,
-                                      (jobu == SvdVectors::All) ? Ub.data_ptr() : nullptr,
-                                      (jobu == SvdVectors::All) ? Ub.ld() : 1,
-                                      (jobvh == SvdVectors::All) ? Vhb.data_ptr() : nullptr,
-                                      (jobvh == SvdVectors::All) ? Vhb.ld() : 1,
+                                      (jobu != SvdVectors::None) ? Ub.data_ptr() : nullptr,
+                                      (jobu != SvdVectors::None) ? Ub.ld() : 1,
+                                      (jobvh != SvdVectors::None) ? Vhb.data_ptr() : nullptr,
+                                      (jobvh != SvdVectors::None) ? Vhb.ld() : 1,
                                       superb.data());
             } else if constexpr (std::is_same_v<T, double>) {
                 info = LAPACKE_dgesvd(LAPACK_COL_MAJOR, lapack_jobu, lapack_jobvt, m, n,
                                       Ab.data_ptr(), Ab.ld(), sb,
-                                      (jobu == SvdVectors::All) ? Ub.data_ptr() : nullptr,
-                                      (jobu == SvdVectors::All) ? Ub.ld() : 1,
-                                      (jobvh == SvdVectors::All) ? Vhb.data_ptr() : nullptr,
-                                      (jobvh == SvdVectors::All) ? Vhb.ld() : 1,
+                                      (jobu != SvdVectors::None) ? Ub.data_ptr() : nullptr,
+                                      (jobu != SvdVectors::None) ? Ub.ld() : 1,
+                                      (jobvh != SvdVectors::None) ? Vhb.data_ptr() : nullptr,
+                                      (jobvh != SvdVectors::None) ? Vhb.ld() : 1,
                                       superb.data());
             } else if constexpr (std::is_same_v<T, std::complex<float>>) {
                 info = LAPACKE_cgesvd(LAPACK_COL_MAJOR, lapack_jobu, lapack_jobvt, m, n,
                                       reinterpret_cast<lapack_complex_float*>(Ab.data_ptr()), Ab.ld(), sb,
-                                      (jobu == SvdVectors::All) ? reinterpret_cast<lapack_complex_float*>(Ub.data_ptr()) : nullptr,
-                                      (jobu == SvdVectors::All) ? Ub.ld() : 1,
-                                      (jobvh == SvdVectors::All) ? reinterpret_cast<lapack_complex_float*>(Vhb.data_ptr()) : nullptr,
-                                      (jobvh == SvdVectors::All) ? Vhb.ld() : 1,
+                                      (jobu != SvdVectors::None) ? reinterpret_cast<lapack_complex_float*>(Ub.data_ptr()) : nullptr,
+                                      (jobu != SvdVectors::None) ? Ub.ld() : 1,
+                                      (jobvh != SvdVectors::None) ? reinterpret_cast<lapack_complex_float*>(Vhb.data_ptr()) : nullptr,
+                                      (jobvh != SvdVectors::None) ? Vhb.ld() : 1,
                                       superb.data());
             } else if constexpr (std::is_same_v<T, std::complex<double>>) {
                 info = LAPACKE_zgesvd(LAPACK_COL_MAJOR, lapack_jobu, lapack_jobvt, m, n,
                                       reinterpret_cast<lapack_complex_double*>(Ab.data_ptr()), Ab.ld(), sb,
-                                      (jobu == SvdVectors::All) ? reinterpret_cast<lapack_complex_double*>(Ub.data_ptr()) : nullptr,
-                                      (jobu == SvdVectors::All) ? Ub.ld() : 1,
-                                      (jobvh == SvdVectors::All) ? reinterpret_cast<lapack_complex_double*>(Vhb.data_ptr()) : nullptr,
-                                      (jobvh == SvdVectors::All) ? Vhb.ld() : 1,
+                                      (jobu != SvdVectors::None) ? reinterpret_cast<lapack_complex_double*>(Ub.data_ptr()) : nullptr,
+                                      (jobu != SvdVectors::None) ? Ub.ld() : 1,
+                                      (jobvh != SvdVectors::None) ? reinterpret_cast<lapack_complex_double*>(Vhb.data_ptr()) : nullptr,
+                                      (jobvh != SvdVectors::None) ? Vhb.ld() : 1,
                                       superb.data());
             } else {
                 throw std::runtime_error("gesvd_vendor (NETLIB): unsupported scalar type");

--- a/src/extensions/bdsdc.cc
+++ b/src/extensions/bdsdc.cc
@@ -356,10 +356,54 @@ void bdsdc_repair_degenerate(Queue& ctx,
         // relative at n=256 in float, which sweeps in singular values that carry
         // real information: their vectors get thrown away and rebuilt as
         // arbitrary orthonormal ones. It also made this kernel fire on ordinary
-        // random matrices. 16*eps sits an order of magnitude above where an exact
-        // zero lands (measured 1.2e-16 relative in double) and orders below any
-        // sigma worth keeping.
-        const T tol_factor = static_cast<T>(16) * std::numeric_limits<T>::epsilon();
+        // random matrices.
+        //
+        // The multiplier is DERIVED rather than tuned. It was 16, on the grounds
+        // that this sits an order of magnitude above where an exact zero lands
+        // (measured 1.2e-16 relative in double) and orders below any sigma worth
+        // keeping. That is the right criterion for detecting an exact zero and
+        // the wrong one for keeping U orthogonal, because the damage is not
+        // confined to sigma = 0.
+        //
+        // stedc's eigenvectors for a cluster of gap g carry error ~eps*||T||/g.
+        // The +sigma_i / -sigma_i pair has gap 2*sigma_i, so once that pair stops
+        // being resolvable the two eigenvectors are an arbitrary basis of the
+        // pair's 2-D eigenspace -- and BOTH halves then normalise to the same
+        // (v, u), giving U two parallel columns. The orthogonality error
+        // contributed by column i is therefore about eps*sigma_max/(2*sigma_i).
+        // Holding that below a target `tau` requires
+        //     sigma_i >= eps*sigma_max / (2*tau),
+        // i.e. a threshold of (1/(2*tau)) * eps * sigma_max. With tau = 1e-3 the
+        // multiplier is 500.
+        //
+        // Measured end-to-end (gesvd_relacc, float, n=64, 128 samples), 16 -> 500,
+        // orthogonality / reconstruction by log10(kappa):
+        //
+        //   kappa   1e1        1e3        1e4        1e5        1e6
+        //   ortho   unchanged  unchanged  unchanged  5.2e-4 ->  0.143 ->
+        //                                            4.6e-5     1.1e-4
+        //   recon   unchanged  unchanged  unchanged  1.3e-6 ->  3.1e-6 ->
+        //                                            7.2e-5     7.3e-5
+        //
+        // So it is a real trade and this is the knee of it: kappa <= 1e4 is
+        // untouched, and above it ~1300x of orthogonality costs ~20x of
+        // reconstruction, from 1e-6 to 1e-5 -- both still far inside any
+        // tolerance the suite applies. Pushing further does keep helping
+        // orthogonality (3000 -> 6.6e-5) but starts discarding vectors that carry
+        // information at kappa=1e4 too (recon 1.3e-6 -> 4.2e-4), which is the
+        // failure the paragraph above warns about.
+        //
+        // n=128 behaves identically (ortho 0.200 -> 2.5e-4). DOUBLE is completely
+        // unchanged at every kappa measured -- its resolution limit is never
+        // reached in this range -- and 500*eps in double is 1.1e-13 relative,
+        // still three orders above where an exact zero lands.
+        //
+        // This does NOT fix the singular VALUES, which stay at 0.52 relative
+        // error at kappa=1e6: that is gebrd's own eps*||A|| floor, unreachable
+        // from here. Use the one-sided Jacobi route (n <= 64) for those.
+        constexpr T kOrthTarget = T(1e-3);
+        const T tol_factor =
+            (T(1) / (T(2) * kOrthTarget)) * std::numeric_limits<T>::epsilon();
 
         h.parallel_for<BdsdcRepair<B, T>>(
             sycl::nd_range<1>(sycl::range<1>(static_cast<size_t>(batch) * kGroup),

--- a/src/extensions/gesvd_blocked.cc
+++ b/src/extensions/gesvd_blocked.cc
@@ -47,11 +47,31 @@ enum class GesvdNativeMode {
 // the CTA cutoff. Accuracy is unchanged: at n=64, kappa=1e4, float, 512 samples,
 // orthogonality 1.78e-5 -> 1.79e-5 and residual 1.29e-6 -> 1.32e-6.
 //
-// BATCHLAS_GESVD_BLOCKED_GEBRD_MIN overrides it, which is how the table above was
-// taken; set it above the largest n to get the old behaviour back.
+// The threshold is now 1, not 33. 33 was chosen on the reasoning that the CTA
+// path takes over below it -- but that is only true for SQUARE input. The CTA
+// and Jacobi predicates both require max(m, n) <= 32, so a TALL matrix with
+// n <= 32 satisfies neither and lands here, on the level-2 path, where it is
+// the m rows that make it ruinous. Nothing covered that band: it needs
+// min(m,n) <= 32 to reach it and m > 32 to be slow, and every gesvd benchmark
+// built a square Random(n, n) until the m/n split.
+//
+// Measured, float, m=1024, batch=128, jobu=None jobvh=All, us per matrix:
+//
+//   n              8      16      24      32
+//   unblocked  138.73  604.48  1535.2  2537.2
+//   blocked      2.15    5.69     9.42   14.15
+//   speedup       64x    106x     163x    179x
+//
+// And it is not only the tall case. Square input through this provider is
+// faster blocked too -- 8x8 0.935 -> 0.370 us, 32x32 48.67 -> 1.84 us (26x) --
+// so there is no n at which the unblocked path is the right choice, and the
+// threshold is a floor of 1 rather than a tuned constant.
+//
+// BATCHLAS_GESVD_BLOCKED_GEBRD_MIN overrides it, which is how the tables above
+// were taken; set it above the largest n to get the old behaviour back.
 inline bool gesvd_use_blocked_gebrd(int32_t n, GesvdNativeMode mode) {
     const char* v = std::getenv("BATCHLAS_GESVD_BLOCKED_GEBRD_MIN");
-    const int32_t threshold = (v != nullptr) ? std::atoi(v) : 33;
+    const int32_t threshold = (v != nullptr) ? std::atoi(v) : 1;
     return mode == GesvdNativeMode::Blocked && n >= threshold;
 }
 

--- a/src/extensions/gesvd_blocked.cc
+++ b/src/extensions/gesvd_blocked.cc
@@ -115,6 +115,24 @@ inline bool gesvd_direct_bidiag(GesvdNativeMode mode) {
         && gesvd_bidiag_solver() != GesvdBidiagSolver::NormalEquations;
 }
 
+// A thin tall U forces a direct bidiagonal solve even under
+// BATCHLAS_GESVD_BIDIAG=normal.
+//
+// This is deliberate and it overrides the environment variable. The
+// normal-equations path allocates an m x m left_vecs and runs a second
+// order-m eigensolve, and patch_zero_left_vectors writes m columns of U
+// unconditionally. Honouring "normal" for a thin tall request would therefore
+// pay the whole m x m cost the caller asked to avoid -- in the workspace
+// instead of in U, so it would look like it worked -- and then overrun a U that
+// only has k columns.
+//
+// The override depends only on the arguments, never on the environment, so
+// gesvd_native_buffer_size and gesvd_native_impl cannot reach different
+// conclusions about which path runs.
+inline bool gesvd_direct_bidiag(GesvdNativeMode mode, bool thin_tall_u) {
+    return gesvd_direct_bidiag(mode) || (mode == GesvdNativeMode::Blocked && thin_tall_u);
+}
+
 inline bool gesvd_stage_profile_enabled() {
     return env_truthy(std::getenv("BATCHLAS_GESVD_PROFILE"));
 }
@@ -173,11 +191,26 @@ void validate_gesvd_dims(const MatrixView<T, MatrixFormat::Dense>& a,
         throw std::invalid_argument(std::string(where) + ": singular_values span too small");
     }
 
-    if (jobu == SvdVectors::All && (u.rows() != m || u.cols() != m || u.batch_size() != batch)) {
-        throw std::invalid_argument(std::string(where) + ": U must be (m x m) with matching batch size");
+    // Guard on "computed at all" and take the expected extent from the job, so
+    // Thin is validated against m x k / k x n. Testing `== All` would let a
+    // Thin request through unvalidated with a wrongly-sized output view.
+    jobu = canonical_jobu(jobu, m, k);
+    jobvh = canonical_jobvh(jobvh, n, k);
+    if (jobu != SvdVectors::None) {
+        const int64_t want_cols = svd_u_cols(jobu, m, k);
+        if (u.rows() != m || u.cols() != want_cols || u.batch_size() != batch) {
+            throw std::invalid_argument(std::string(where) + ": U must be (" +
+                                        std::to_string(m) + " x " + std::to_string(want_cols) +
+                                        ") with matching batch size");
+        }
     }
-    if (jobvh == SvdVectors::All && (vh.rows() != n || vh.cols() != n || vh.batch_size() != batch)) {
-        throw std::invalid_argument(std::string(where) + ": Vh must be (n x n) with matching batch size");
+    if (jobvh != SvdVectors::None) {
+        const int64_t want_rows = svd_vh_rows(jobvh, n, k);
+        if (vh.rows() != want_rows || vh.cols() != n || vh.batch_size() != batch) {
+            throw std::invalid_argument(std::string(where) + ": Vh must be (" +
+                                        std::to_string(want_rows) + " x " + std::to_string(n) +
+                                        ") with matching batch size");
+        }
     }
 }
 
@@ -763,8 +796,15 @@ Event gesvd_native_impl(Queue& ctx,
         const int32_t n = static_cast<int32_t>(a_in.cols());
         const int32_t k = std::min(m, n);
         const int32_t batch = static_cast<int32_t>(a_in.batch_size());
-        const bool want_u = jobu == SvdVectors::All;
-        const bool want_vh = jobvh == SvdVectors::All;
+        jobu = canonical_jobu(jobu, m, k);
+        jobvh = canonical_jobvh(jobvh, n, k);
+        // `!= None`, not `== All`. Keeping the old idiom here is the silent
+        // degrade: a Thin request would compute nothing and hand back an
+        // untouched U without raising anything.
+        const bool want_u = jobu != SvdVectors::None;
+        const bool want_vh = jobvh != SvdVectors::None;
+        const int32_t u_cols = static_cast<int32_t>(svd_u_cols(jobu, m, k));
+        const int32_t vh_rows = static_cast<int32_t>(svd_vh_rows(jobvh, n, k));
         const GesvdStageProfiler profiler{ctx, where, std::max(m, n), batch, gesvd_stage_profile_enabled()};
 
         if (m < n) {
@@ -782,13 +822,23 @@ Event gesvd_native_impl(Queue& ctx,
             MatrixView<T, MatrixFormat::Dense> ut_view;
             MatrixView<T, MatrixFormat::Dense> vht_view;
 
+            // With m < n we have k == m, so U is never the thin side here --
+            // jobu has already canonicalised to All. V^H is: n x n for All,
+            // m x n for Thin. Its transposed counterpart ut_view is therefore
+            // n x n or n x m, and sizing it n x n unconditionally would
+            // reintroduce, in the workspace, exactly the allocation Thin exists
+            // to avoid.
+            const SvdVectors trans_jobu = jobvh;   // U of A^T <-> V^H of A
+            const SvdVectors trans_jobvh = jobu;   // V^H of A^T <-> U of A
+            const int32_t ut_cols = static_cast<int32_t>(svd_u_cols(trans_jobu, n, m));
+
             if (want_vh) {
-                auto ut_span = pool.allocate<T>(ctx, static_cast<size_t>(n) * static_cast<size_t>(n) * static_cast<size_t>(batch));
+                auto ut_span = pool.allocate<T>(ctx, static_cast<size_t>(n) * static_cast<size_t>(ut_cols) * static_cast<size_t>(batch));
                 ut_view = MatrixView<T, MatrixFormat::Dense>(ut_span.data(),
                                                              n,
+                                                             ut_cols,
                                                              n,
-                                                             n,
-                                                             static_cast<int64_t>(n) * static_cast<int64_t>(n),
+                                                             static_cast<int64_t>(n) * static_cast<int64_t>(ut_cols),
                                                              batch);
             } else {
                 auto ut_dummy = pool.allocate<T>(ctx, static_cast<size_t>(batch));
@@ -812,8 +862,10 @@ Event gesvd_native_impl(Queue& ctx,
                 transpose(ctx, a_in, at_view);
             });
 
-            const SvdVectors trans_jobu = want_vh ? SvdVectors::All : SvdVectors::None;
-            const SvdVectors trans_jobvh = want_u ? SvdVectors::All : SvdVectors::None;
+            // trans_jobu / trans_jobvh are computed above, next to ut_view's
+            // extent, so the view and the job it is sized for cannot drift.
+            // They propagate the job VALUE rather than collapsing it to
+            // All/None, which is what carries Thin into the inner solve.
             const size_t inner_ws_bytes = gesvd_native_buffer_size<B, T>(ctx,
                                                                          at_view,
                                                                          singular_values,
@@ -856,7 +908,14 @@ Event gesvd_native_impl(Queue& ctx,
         const bool tridiag_returns_vectors = (mode == GesvdNativeMode::Blocked) || need_vecs;
         const bool use_blocked_gebrd = gesvd_use_blocked_gebrd(k, mode);
         const int32_t gebrd_block_size = tuning::gebrd_block_size_for_n(k);
-        const int32_t max_order = want_u ? std::max(m, k) : k;
+        const bool thin_tall_u = want_u && u_cols < m;
+        const bool direct_bidiag = gesvd_direct_bidiag(mode, thin_tall_u);
+        // Only a FULL U needs the order-m tridiagonal buffers; with a thin U the
+        // normal-equations branch is unreachable (see gesvd_direct_bidiag's
+        // two-argument overload), so these shrink from max(m,k) to k. That is
+        // the point of the exercise on a 10000 x 32 problem: without it the
+        // m x m cost simply moves from U into the workspace.
+        const int32_t max_order = (want_u && u_cols == m) ? std::max(m, k) : k;
 
         auto& a = const_cast<MatrixView<T, MatrixFormat::Dense>&>(a_in);
         Span<std::byte> ws_mut(const_cast<std::byte*>(ws.data()), ws.size());
@@ -884,7 +943,7 @@ Event gesvd_native_impl(Queue& ctx,
         // Not needed on the Blocked (bdsqr) path: bdsqr writes its rotations
         // straight into u_out / vh_out, so there is no intermediate k x k
         // eigenvector matrix to hold.
-        if (tridiag_returns_vectors && !gesvd_direct_bidiag(mode)) {
+        if (tridiag_returns_vectors && !direct_bidiag) {
             auto vecs_span = pool.allocate<T>(ctx, static_cast<size_t>(k) * static_cast<size_t>(k) * static_cast<size_t>(batch));
             vecs_view = MatrixView<T, MatrixFormat::Dense>(vecs_span.data(), k, k, k, static_cast<int64_t>(k) * static_cast<int64_t>(k), batch);
         }
@@ -896,7 +955,7 @@ Event gesvd_native_impl(Queue& ctx,
         // skipping it is a real saving, not just tidiness. The sizing function is
         // an upper bound that still covers both shapes.
         Span<std::byte> solver_ws;
-        if (!gesvd_direct_bidiag(mode)) {
+        if (!direct_bidiag) {
             size_t solver_ws_bytes = gesvd_solver_workspace_size<B, T>(ctx, k, batch, tridiag_job, mode);
             if (want_u) {
                 solver_ws_bytes = std::max(solver_ws_bytes,
@@ -940,7 +999,7 @@ Event gesvd_native_impl(Queue& ctx,
         //     A = (Q_B Q) S (P^T P_B^H)
         // which is exactly what the two back-transforms below apply (ormbr 'Q' on
         // the left, ormbr 'P' on the right) -- unchanged.
-        if (gesvd_direct_bidiag(mode)) {
+        if (direct_bidiag) {
             const bool use_bdsdc = gesvd_bidiag_solver() == GesvdBidiagSolver::Bdsdc;
             const size_t bidiag_ws_bytes =
                 use_bdsdc ? bdsdc_buffer_size<B, T>(ctx, d_view, e_view, singular_values, need_vecs)
@@ -1157,29 +1216,39 @@ size_t gesvd_native_buffer_size(Queue& ctx,
         const size_t n = static_cast<size_t>(a.cols());
         const size_t k = std::min(m, n);
         const size_t batch = static_cast<size_t>(a.batch_size());
-        const bool want_u = jobu == SvdVectors::All;
-        const bool want_vh = jobvh == SvdVectors::All;
+        // Every line below must mirror gesvd_native_impl exactly. The two are
+        // separate functions over the same decisions, and a divergence is a
+        // silent workspace overrun rather than a compile error.
+        jobu = canonical_jobu(jobu, static_cast<int64_t>(m), static_cast<int64_t>(k));
+        jobvh = canonical_jobvh(jobvh, static_cast<int64_t>(n), static_cast<int64_t>(k));
+        const bool want_u = jobu != SvdVectors::None;
+        const bool want_vh = jobvh != SvdVectors::None;
+        const size_t u_cols = static_cast<size_t>(svd_u_cols(jobu, static_cast<int64_t>(m), static_cast<int64_t>(k)));
         if (m < n) {
-            const SvdVectors trans_jobu = want_vh ? SvdVectors::All : SvdVectors::None;
-            const SvdVectors trans_jobvh = want_u ? SvdVectors::All : SvdVectors::None;
+            const SvdVectors trans_jobu = jobvh;
+            const SvdVectors trans_jobvh = jobu;
+            const size_t ut_cols = static_cast<size_t>(
+                svd_u_cols(trans_jobu, static_cast<int64_t>(n), static_cast<int64_t>(m)));
 
             MatrixView<T, MatrixFormat::Dense> ut_view(nullptr,
                                                        static_cast<int64_t>(n),
-                                                       trans_jobu == SvdVectors::All ? static_cast<int64_t>(n) : 1,
+                                                       want_vh ? static_cast<int64_t>(ut_cols) : 1,
                                                        static_cast<int64_t>(n),
-                                                       static_cast<int64_t>(n) * static_cast<int64_t>(std::max<size_t>(1, n)),
+                                                       static_cast<int64_t>(n) * static_cast<int64_t>(std::max<size_t>(1, ut_cols)),
                                                        static_cast<int64_t>(batch));
+            // m < n means k == m, so the transposed problem's V^H (which is A's
+            // U) is m x m either way -- Thin never shrinks it.
             MatrixView<T, MatrixFormat::Dense> vht_view(nullptr,
-                                                        trans_jobvh == SvdVectors::All ? static_cast<int64_t>(m) : 1,
-                                                        trans_jobvh == SvdVectors::All ? static_cast<int64_t>(m) : 1,
-                                                        trans_jobvh == SvdVectors::All ? static_cast<int64_t>(m) : 1,
+                                                        trans_jobvh != SvdVectors::None ? static_cast<int64_t>(m) : 1,
+                                                        trans_jobvh != SvdVectors::None ? static_cast<int64_t>(m) : 1,
+                                                        trans_jobvh != SvdVectors::None ? static_cast<int64_t>(m) : 1,
                                                         static_cast<int64_t>(std::max<size_t>(1, m)) * static_cast<int64_t>(std::max<size_t>(1, m)),
                                                         static_cast<int64_t>(batch));
 
             size_t bytes = 0;
             bytes += BumpAllocator::allocation_size<T>(ctx, n * m * batch);
             if (want_vh) {
-                bytes += BumpAllocator::allocation_size<T>(ctx, n * n * batch);
+                bytes += BumpAllocator::allocation_size<T>(ctx, n * ut_cols * batch);
             } else {
                 bytes += BumpAllocator::allocation_size<T>(ctx, batch);
             }
@@ -1210,7 +1279,11 @@ size_t gesvd_native_buffer_size(Queue& ctx,
         const bool tridiag_returns_vectors = (mode == GesvdNativeMode::Blocked) || need_vecs;
 
         size_t bytes = 0;
-        const size_t max_order = want_u ? std::max(m, k) : k;
+        // Mirrors gesvd_native_impl: thin tall U forces the direct bidiagonal
+        // solve, which makes the order-m buffers unreachable.
+        const bool thin_tall_u = want_u && u_cols < m;
+        const bool direct_bidiag = gesvd_direct_bidiag(mode, thin_tall_u);
+        const size_t max_order = (want_u && u_cols == m) ? std::max(m, k) : k;
         bytes += BumpAllocator::allocation_size<T>(ctx, k * batch);                                // d
         bytes += BumpAllocator::allocation_size<T>(ctx, (k > 0 ? k - 1 : 0) * batch);             // e
         bytes += BumpAllocator::allocation_size<T>(ctx, k * batch);                                // tauq
@@ -1232,7 +1305,7 @@ size_t gesvd_native_buffer_size(Queue& ctx,
         // tridiagonal path reserves. bdsqr's is small enough that it used to fit
         // inside the over-allocation here by accident; bdsdc's does not, so this
         // branch is what keeps buffer_size an actual upper bound.
-        if (gesvd_direct_bidiag(mode)) {
+        if (direct_bidiag) {
             VectorView<T> d_dummy(nullptr, k_i32, static_cast<int32_t>(batch), 1, k_i32);
             const int32_t e_size = static_cast<int32_t>(k > 0 ? k - 1 : 0);
             VectorView<T> e_dummy(nullptr, e_size, static_cast<int32_t>(batch), 1, std::max<int32_t>(1, e_size));
@@ -1428,6 +1501,19 @@ Event gesvd_cta(Queue& ctx,
     if (std::max(a_in.rows(), a_in.cols()) > 32) {
         throw std::invalid_argument("gesvd_cta: currently supports max(m, n) <= 32");
     }
+    // Mode CTA always takes the normal-equations branch, whose
+    // patch_zero_left_vectors writes m columns of U unconditionally. Refuse a
+    // genuinely thin request rather than overrun. Dispatch never gets here --
+    // gesvd_supports_cta already declines, and a forced-but-unsupported
+    // provider resets to Auto -- so this guards DIRECT callers.
+    {
+        const int64_t k = std::min<int64_t>(a_in.rows(), a_in.cols());
+        if (canonical_jobu(jobu, a_in.rows(), k) == SvdVectors::Thin ||
+            canonical_jobvh(jobvh, a_in.cols(), k) == SvdVectors::Thin) {
+            throw std::invalid_argument(
+                "gesvd_cta: thin singular vectors are not supported (use gesvd_blocked or gesvdj_cta)");
+        }
+    }
     return gesvd_native_impl<B, T>(ctx,
                                    a_in,
                                    singular_values,
@@ -1457,6 +1543,19 @@ Event gesvd_cta(Queue& ctx,
     if (std::max(a_in.rows(), a_in.cols()) > 32) {
         throw std::invalid_argument("gesvd_cta: currently supports max(m, n) <= 32");
     }
+    // Mode CTA always takes the normal-equations branch, whose
+    // patch_zero_left_vectors writes m columns of U unconditionally. Refuse a
+    // genuinely thin request rather than overrun. Dispatch never gets here --
+    // gesvd_supports_cta already declines, and a forced-but-unsupported
+    // provider resets to Auto -- so this guards DIRECT callers.
+    {
+        const int64_t k = std::min<int64_t>(a_in.rows(), a_in.cols());
+        if (canonical_jobu(jobu, a_in.rows(), k) == SvdVectors::Thin ||
+            canonical_jobvh(jobvh, a_in.cols(), k) == SvdVectors::Thin) {
+            throw std::invalid_argument(
+                "gesvd_cta: thin singular vectors are not supported (use gesvd_blocked or gesvdj_cta)");
+        }
+    }
     return gesvd_native_hermitian_impl<B, T>(ctx,
                                              a_in,
                                              singular_values,
@@ -1481,6 +1580,14 @@ size_t gesvd_cta_buffer_size(Queue& ctx,
     validate_gesvd_dims(a, singular_values, u_out, vh_out, jobu, jobvh, "gesvd_cta_buffer_size");
     if (std::max(a.rows(), a.cols()) > 32) {
         throw std::invalid_argument("gesvd_cta_buffer_size: currently supports max(m, n) <= 32");
+    }
+    {
+        const int64_t k = std::min<int64_t>(a.rows(), a.cols());
+        if (canonical_jobu(jobu, a.rows(), k) == SvdVectors::Thin ||
+            canonical_jobvh(jobvh, a.cols(), k) == SvdVectors::Thin) {
+            throw std::invalid_argument(
+                "gesvd_cta_buffer_size: thin singular vectors are not supported");
+        }
     }
     return gesvd_native_buffer_size<B, T>(ctx,
                                           a,
@@ -1508,6 +1615,14 @@ size_t gesvd_cta_buffer_size(Queue& ctx,
     }
     if (std::max(a.rows(), a.cols()) > 32) {
         throw std::invalid_argument("gesvd_cta_buffer_size: currently supports max(m, n) <= 32");
+    }
+    {
+        const int64_t k = std::min<int64_t>(a.rows(), a.cols());
+        if (canonical_jobu(jobu, a.rows(), k) == SvdVectors::Thin ||
+            canonical_jobvh(jobvh, a.cols(), k) == SvdVectors::Thin) {
+            throw std::invalid_argument(
+                "gesvd_cta_buffer_size: thin singular vectors are not supported");
+        }
     }
     return gesvd_native_hermitian_buffer_size<B, T>(ctx,
                                                     a,

--- a/src/extensions/gesvdj_cta.cc
+++ b/src/extensions/gesvdj_cta.cc
@@ -160,6 +160,7 @@ inline void gesvdj_cta_impl(Queue& ctx,
                             bool transposed,
                             int32_t rows,     // R = max(m,n), rows of the solved matrix
                             int32_t cols,     // C = min(m,n), cols of the solved matrix
+                            int32_t left_cols,// columns of the left factor to emit: R (All) or C (Thin)
                             GesvdjParams<T> params) {
     using Real = typename base_type<T>::type;
 
@@ -238,6 +239,10 @@ inline void gesvdj_cta_impl(Queue& ctx,
 
         const int32_t RR = rows;
         const int32_t CC = cols;
+        // Columns of the left factor actually emitted: RR for All, CC for Thin.
+        // Kernel-uniform, so every partition-wide reduction below stays uniform
+        // and no barrier structure depends on it.
+        const int32_t LC = left_cols;
         // Pivot index space padded to even so the round-robin schedule is well
         // defined; a padded index is never paired with a real one because pairs
         // touching index >= CC are skipped.
@@ -734,7 +739,11 @@ inline void gesvdj_cta_impl(Queue& ctx,
                         (lane < CC) && (inv_beta * sycl::sqrt(Nrm_local[base_n + lane]) <= tol_zero);
                     const int32_t any_def = part_sum_g(part, deficient_lane ? int32_t(1) : int32_t(0));
 
-                    if (any_def > 0 || RR > CC) {
+                    // LC, not RR: a Thin request wants only the CC columns the
+                    // solve already produced, so the completion block is skipped
+                    // outright unless a column came out numerically deficient
+                    // (any_def > 0), which still has to be repaired.
+                    if (any_def > 0 || LC > CC) {
                         // The trial index cursor RUNS ACROSS dst; it is not reset
                         // per column. That is what makes this terminate.
                         //
@@ -755,8 +764,10 @@ inline void gesvdj_cta_impl(Queue& ctx,
                         const Real accept_tol = Real(1) / (Real(2) * static_cast<Real>(RR));
                         int32_t jcur = 0;
 
-                        for (int32_t dst = 0; dst < RR; ++dst) {
+                        for (int32_t dst = 0; dst < LC; ++dst) {
                             const int32_t cdst = static_cast<int32_t>(Inv_local[base_p + dst]);
+                            // With LC == CC this never fires, so only genuinely
+                            // deficient columns are rebuilt.
                             bool needs = (dst >= CC);
                             if (!needs) {
                                 needs = (inv_beta * sycl::sqrt(Nrm_local[base_n + cdst])) <= tol_zero;
@@ -797,8 +808,9 @@ inline void gesvdj_cta_impl(Queue& ctx,
                     if (!transposed_f) {
                         // U(lane, dst): global address dst*ld + lane, so
                         // consecutive lanes are contiguous.
+                        // dst is the output COLUMN, so Thin truncates the loop.
                         if (lane < RR) {
-                            for (int32_t dst = 0; dst < RR; ++dst) {
+                            for (int32_t dst = 0; dst < LC; ++dst) {
                                 const int32_t c = static_cast<int32_t>(Inv_local[base_p + dst]);
                                 U_prob(lane, dst) = A_local[base_a + lane + c * LD];
                             }
@@ -807,7 +819,13 @@ inline void gesvdj_cta_impl(Queue& ctx,
                         // Vh(lane, r) = conj(L(r, c_lane)): lane is the OUTPUT
                         // ROW. The LDS read [r + c*LD] is conflict-free because
                         // LD is odd and c is a permutation.
-                        if (lane < RR) {
+                        //
+                        // In THIS orientation lane is the rank index (what dst
+                        // is above) while r runs over the output's columns, so
+                        // the thin restriction lands on `lane`, not on `r`.
+                        // Truncating r instead would emit a factor of the wrong
+                        // shape while still writing something plausible.
+                        if (lane < LC) {
                             const int32_t c = static_cast<int32_t>(Inv_local[base_p + lane]);
                             for (int32_t r = 0; r < RR; ++r) {
                                 Vh_prob(lane, r) = conj_if_complex_g(A_local[base_a + r + c * LD]);
@@ -858,11 +876,27 @@ void validate_gesvdj_dims(const MatrixView<T, MatrixFormat::Dense>& a,
     if (singular_values.size() < static_cast<std::size_t>(k) * static_cast<std::size_t>(batch)) {
         throw std::invalid_argument(std::string(where) + ": singular_values span too small");
     }
-    if (jobu == SvdVectors::All && (u.rows() != m || u.cols() != m || u.batch_size() != batch)) {
-        throw std::invalid_argument(std::string(where) + ": U must be (m x m) with matching batch size");
+    // Guard on "is computed at all" rather than "== All", and take the expected
+    // column/row count from the job, so Thin is checked against m x k / k x n.
+    // Testing `== All` here would let a Thin request through with an
+    // unvalidated, probably wrongly-sized, output view.
+    jobu = canonical_jobu(jobu, m, k);
+    jobvh = canonical_jobvh(jobvh, n, k);
+    if (jobu != SvdVectors::None) {
+        const int64_t want_cols = svd_u_cols(jobu, m, k);
+        if (u.rows() != m || u.cols() != want_cols || u.batch_size() != batch) {
+            throw std::invalid_argument(std::string(where) + ": U must be (" +
+                                        std::to_string(m) + " x " + std::to_string(want_cols) +
+                                        ") with matching batch size");
+        }
     }
-    if (jobvh == SvdVectors::All && (vh.rows() != n || vh.cols() != n || vh.batch_size() != batch)) {
-        throw std::invalid_argument(std::string(where) + ": Vh must be (n x n) with matching batch size");
+    if (jobvh != SvdVectors::None) {
+        const int64_t want_rows = svd_vh_rows(jobvh, n, k);
+        if (vh.rows() != want_rows || vh.cols() != n || vh.batch_size() != batch) {
+            throw std::invalid_argument(std::string(where) + ": Vh must be (" +
+                                        std::to_string(want_rows) + " x " + std::to_string(n) +
+                                        ") with matching batch size");
+        }
     }
 }
 
@@ -882,15 +916,13 @@ Event gesvdj_cta(Queue& ctx,
 
     validate_gesvdj_dims(a_in, singular_values, u_out, vh_out, jobu, jobvh, "gesvdj_cta");
 
-    if (jobu != SvdVectors::None && jobu != SvdVectors::All) {
-        throw std::invalid_argument("gesvdj_cta: unsupported jobu");
-    }
-    if (jobvh != SvdVectors::None && jobvh != SvdVectors::All) {
-        throw std::invalid_argument("gesvdj_cta: unsupported jobvh");
-    }
-
     const int32_t m = static_cast<int32_t>(a_in.rows());
     const int32_t n = static_cast<int32_t>(a_in.cols());
+    {
+        const int64_t k = std::min<int64_t>(m, n);
+        jobu = canonical_jobu(jobu, m, k);
+        jobvh = canonical_jobvh(jobvh, n, k);
+    }
     if (std::max(m, n) > 32) {
         throw std::invalid_argument("gesvdj_cta: currently supports max(m, n) <= 32");
     }
@@ -911,21 +943,33 @@ Event gesvdj_cta(Queue& ctx,
     const int32_t RR = transposed ? n : m;
     const int32_t CC = transposed ? m : n;
 
-    const bool want_u = (jobu == SvdVectors::All);
-    const bool want_vh = (jobvh == SvdVectors::All);
+    const bool want_u = (jobu != SvdVectors::None);
+    const bool want_vh = (jobvh != SvdVectors::None);
     // The R-sized factor lands in U when m >= n and in Vh when m < n, because
     // A^T = U' S V'^H gives A = V' S U'^H.
     const bool want_left = transposed ? want_vh : want_u;
     const bool want_right = transposed ? want_u : want_vh;
+
+    // How many columns of the RR-sized left factor to produce. The solve yields
+    // CC of them for free -- they are the rotated, normalised columns of A --
+    // and any beyond that have to be manufactured by an in-kernel Gram-Schmidt
+    // against canonical basis vectors. A Thin request wants exactly those CC, so
+    // left_cols == CC skips that block entirely.
+    //
+    // Only the left factor can be thin: the right factor is CC x CC, and Thin
+    // never shrinks it (the same m<=n / m>=n coincidence that canonicalisation
+    // exploits).
+    const SvdVectors job_left = transposed ? jobvh : jobu;
+    const int32_t left_cols = (job_left == SvdVectors::All) ? RR : CC;
 
     auto* s_ptr = singular_values.data();
 
     auto launch = [&](auto P_tag) {
         constexpr size_t Pv = decltype(P_tag)::value;
         if (want_right) {
-            gesvdj_cta_impl<T, Pv, true>(ctx, a_in, s_ptr, u_out, vh_out, want_left, transposed, RR, CC, params);
+            gesvdj_cta_impl<T, Pv, true>(ctx, a_in, s_ptr, u_out, vh_out, want_left, transposed, RR, CC, left_cols, params);
         } else {
-            gesvdj_cta_impl<T, Pv, false>(ctx, a_in, s_ptr, u_out, vh_out, want_left, transposed, RR, CC, params);
+            gesvdj_cta_impl<T, Pv, false>(ctx, a_in, s_ptr, u_out, vh_out, want_left, transposed, RR, CC, left_cols, params);
         }
     };
 

--- a/src/extensions/gesvdj_cta.cc
+++ b/src/extensions/gesvdj_cta.cc
@@ -195,6 +195,12 @@ inline void gesvdj_cta_impl(Queue& ctx,
         constexpr size_t kTileElems = static_cast<size_t>(LD) * C;
         constexpr size_t kRotSlots = (C / 2 > 0) ? (C / 2) : 1;
         constexpr size_t kPairSlots = (C - 1) * kRotSlots;
+        // Pairs processed per Gram reduce-scatter. Fixed at P/2 (capped by the
+        // slot count for the small rungs) because the scatter lands pair k in
+        // lanes 2k, 2k+1 -- more than P/2 pairs in flight has nowhere to land.
+        constexpr size_t kGramChunk = (kRotSlots < P / 2) ? kRotSlots : (P / 2 > 0 ? P / 2 : 1);
+        constexpr size_t kChunks = kRotSlots / kGramChunk;
+        static_assert(kChunks * kGramChunk == kRotSlots, "round must split evenly into Gram chunks");
         constexpr bool kNeedPhase = internal::is_complex<T>::value;
 
         // Local-memory budget. Note this clamps probs_per_wg DIRECTLY rather
@@ -348,20 +354,27 @@ inline void gesvdj_cta_impl(Queue& ctx,
                 // gesvd_blocked's out-of-place transpose + recursion.
                 // The pad region is written as exact zero so a padded pair's
                 // Gram is identically 0 and falls below any threshold.
-                for (int32_t c = 0; c < static_cast<int32_t>(C); ++c) {
-                    T v = T(0);
-                    if (lane < RR && c < CC) {
-                        // For m < n we solve A^H, not A^T. A^H = U' S V'^H gives
-                        // A = V' S U'^H, so U = V' and Vh = U'^H -- the SAME role
-                        // mapping as the m >= n case, just swapped between the
-                        // two outputs. Solving A^T instead would give
-                        // A = conj(V') S U'^T, whose conjugations differ, and is
-                        // wrong for complex (it is invisible in real arithmetic).
-                        v = transposed_f ? conj_if_complex_g(A_prob(c, lane)) : A_prob(lane, c);
-                    }
-                    A_local[base_a + lane + c * LD] = v;
-                    if constexpr (ComputeV) {
-                        V_local[base_v + lane + c * LD] = (lane == c && lane < CC) ? T(1) : T(0);
+                // Lane owns rows lane, lane+P, lane+2P, ... At kRPL == 1 this
+                // is textually the single-row loop it replaces. The global read
+                // stays coalesced for every rr: A_prob(row, c) is at
+                // c*ld + lane + rr*P, contiguous across lanes.
+                for (int32_t rr = 0; rr < static_cast<int32_t>(kRPL); ++rr) {
+                    const int32_t row = lane + rr * static_cast<int32_t>(P);
+                    for (int32_t c = 0; c < static_cast<int32_t>(C); ++c) {
+                        T v = T(0);
+                        if (row < RR && c < CC) {
+                            // For m < n we solve A^H, not A^T. A^H = U' S V'^H gives
+                            // A = V' S U'^H, so U = V' and Vh = U'^H -- the SAME role
+                            // mapping as the m >= n case, just swapped between the
+                            // two outputs. Solving A^T instead would give
+                            // A = conj(V') S U'^T, whose conjugations differ, and is
+                            // wrong for complex (it is invisible in real arithmetic).
+                            v = transposed_f ? conj_if_complex_g(A_prob(c, row)) : A_prob(row, c);
+                        }
+                        A_local[base_a + row + c * LD] = v;
+                        if constexpr (ComputeV) {
+                            V_local[base_v + row + c * LD] = (row == c && row < CC) ? T(1) : T(0);
+                        }
                     }
                 }
                 group_barrier(part);
@@ -370,26 +383,41 @@ inline void gesvdj_cta_impl(Queue& ctx,
                 // Reduce-scatter of P values over P lanes: 5 steps, no trailing
                 // all-reduce needed because V == L here. Leaves lane c holding
                 // ||A_c||^2.
+                // x stays Real[P], NOT Real[C]. Widening it to 64 would cost 64
+                // Real registers per lane and force a sixth reduction step; the
+                // hardcoded 5 steps are correct because the LANE count is still
+                // 32. Instead the C columns are covered in C/P passes of the
+                // unchanged 32-wide reduce-scatter, and each lane's kRPL rows are
+                // summed into x[c] before the butterfly runs.
                 auto exact_norms = [&]() {
-                    Real x[P];
+                    for (int32_t h = 0; h < static_cast<int32_t>(kRPL); ++h) {
+                        const int32_t col0 = h * static_cast<int32_t>(P);
+                        Real x[P];
 #pragma unroll
-                    for (int32_t c = 0; c < static_cast<int32_t>(P); ++c) {
-                        x[c] = norm2_g(A_local[base_a + lane + c * LD]);
-                    }
+                        for (int32_t c = 0; c < static_cast<int32_t>(P); ++c) {
+                            Real acc = Real(0);
 #pragma unroll
-                    for (int32_t step = 0; step < 5; ++step) {
-                        const uint32_t mask = static_cast<uint32_t>(P) >> (step + 1);
-                        if (mask == 0u) break;
-                        const bool hi = (static_cast<uint32_t>(lane) & mask) != 0u;
-                        const int32_t half = static_cast<int32_t>(mask);
-#pragma unroll
-                        for (int32_t j = 0; j < half; ++j) {
-                            const Real own = hi ? x[j + half] : x[j];
-                            const Real send = hi ? x[j] : x[j + half];
-                            x[j] = own + permute_group_by_xor(part, send, mask);
+                            for (int32_t rr = 0; rr < static_cast<int32_t>(kRPL); ++rr) {
+                                acc += norm2_g(A_local[base_a + lane + rr * static_cast<int32_t>(P)
+                                                       + (col0 + c) * LD]);
+                            }
+                            x[c] = acc;
                         }
+#pragma unroll
+                        for (int32_t step = 0; step < 5; ++step) {
+                            const uint32_t mask = static_cast<uint32_t>(P) >> (step + 1);
+                            if (mask == 0u) break;
+                            const bool hi = (static_cast<uint32_t>(lane) & mask) != 0u;
+                            const int32_t half = static_cast<int32_t>(mask);
+#pragma unroll
+                            for (int32_t j = 0; j < half; ++j) {
+                                const Real own = hi ? x[j + half] : x[j];
+                                const Real send = hi ? x[j] : x[j + half];
+                                x[j] = own + permute_group_by_xor(part, send, mask);
+                            }
+                        }
+                        Nrm_local[base_n + col0 + lane] = x[0];
                     }
-                    Nrm_local[base_n + lane] = x[0];
                 };
 
                 exact_norms();
@@ -439,8 +467,11 @@ inline void gesvdj_cta_impl(Queue& ctx,
                 // pressure, so it is not worth keeping behind a runtime flag
                 // either. See GESVD_PLAN.md Tier 2.
                 if (beta != Real(1)) {
-                    for (int32_t c = 0; c < static_cast<int32_t>(C); ++c) {
-                        A_local[base_a + lane + c * LD] = A_local[base_a + lane + c * LD] * T(beta);
+                    for (int32_t rr = 0; rr < static_cast<int32_t>(kRPL); ++rr) {
+                        const int32_t row = lane + rr * static_cast<int32_t>(P);
+                        for (int32_t c = 0; c < static_cast<int32_t>(C); ++c) {
+                            A_local[base_a + row + c * LD] = A_local[base_a + row + c * LD] * T(beta);
+                        }
                     }
                     group_barrier(part);
                     exact_norms();
@@ -472,32 +503,61 @@ inline void gesvdj_cta_impl(Queue& ctx,
                     for (int32_t t = 0; t < rounds; ++t) {
                         const int32_t tab_base = t * static_cast<int32_t>(kRotSlots);
 
-                        // Pair indices for the whole round, held in registers.
+                        // The round is processed in CHUNKS of kGramChunk = P/2
+                        // pairs. That constant is what keeps the Gram
+                        // reduce-scatter, the k_of_lane = lane>>1 mapping and
+                        // the `lane % 2 == 0` guards below EXACTLY as they were:
+                        // the scatter lands chunk-local pair k in lanes 2k and
+                        // 2k+1, which needs at most P/2 pairs in flight. A round
+                        // at C=64 has 32 pairs, so it takes two chunks; at C=32
+                        // there is one chunk and this loop disappears.
+                        //
+                        // Chunking is safe because a round's pairs are a perfect
+                        // matching: chunks touch disjoint columns, so the
+                        // Gram/apply of one cannot disturb another, and the Nrm
+                        // writes never collide.
+                        //
+                        // It is also what stops the register arrays growing with
+                        // C. Holding a whole C=64 round would need
+                        // ap[32][2] + aq[32][2] + g[32] = 160 live T; chunked it
+                        // is 16*2 + 16*2 + 16 = 80, against 48 at C=32.
+                        for (int32_t ch = 0; ch < static_cast<int32_t>(kChunks); ++ch) {
+                        const int32_t tab_base = t * static_cast<int32_t>(kRotSlots)
+                                               + ch * static_cast<int32_t>(kGramChunk);
+
+                        // Pair indices for the chunk, held in registers.
                         // Every index into pk/qk/ap/aq/g must be compile-time or
                         // the arrays spill to local memory.
-                        int32_t pk[kRotSlots];
-                        int32_t qk[kRotSlots];
-                        T ap[kRotSlots];
-                        T aq[kRotSlots];
-                        T g[kRotSlots];
+                        int32_t pk[kGramChunk];
+                        int32_t qk[kGramChunk];
+                        T ap[kGramChunk][kRPL];
+                        T aq[kGramChunk][kRPL];
+                        T g[kGramChunk];
 
 #pragma unroll
-                        for (int32_t k = 0; k < static_cast<int32_t>(kRotSlots); ++k) {
+                        for (int32_t k = 0; k < static_cast<int32_t>(kGramChunk); ++k) {
                             const int32_t pq = static_cast<int32_t>(Pair_local[tab_base + k]);
                             pk[k] = pq & 0xFF;
                             qk[k] = (pq >> 8) & 0xFF;
                             const bool ok = (pk[k] < CC) && (qk[k] < CC);
                             const int32_t ip = ok ? pk[k] : 0;
                             const int32_t iq = ok ? qk[k] : 0;
-                            ap[k] = A_local[base_a + lane + ip * LD];
-                            aq[k] = A_local[base_a + lane + iq * LD];
-                            // conj(A_p) * A_q, summed over rows below.
-                            g[k] = ok ? (conj_if_complex_g(ap[k]) * aq[k]) : T(0);
+                            // conj(A_p) * A_q, accumulated over this lane's rows
+                            // BEFORE the butterfly, which then sums across lanes.
+                            T acc = T(0);
+#pragma unroll
+                            for (int32_t rr = 0; rr < static_cast<int32_t>(kRPL); ++rr) {
+                                const int32_t row = lane + rr * static_cast<int32_t>(P);
+                                ap[k][rr] = A_local[base_a + row + ip * LD];
+                                aq[k][rr] = A_local[base_a + row + iq * LD];
+                                acc = acc + conj_if_complex_g(ap[k][rr]) * aq[k][rr];
+                            }
+                            g[k] = ok ? acc : T(0);
                         }
 
-                        // Reduce-scatter: kRotSlots dot products in
-                        // log2(kRotSlots) scatter steps PLUS log2(P/kRotSlots)
-                        // all-reduce steps. At P=32 that is 4 + 1.
+                        // Reduce-scatter: kGramChunk dot products in
+                        // log2(kGramChunk) scatter steps PLUS log2(P/kGramChunk)
+                        // all-reduce steps. At P=32, kGramChunk=16, that is 4 + 1.
                         //
                         // Writing it as five halving steps is WRONG and silently
                         // sums each dot product over only half the rows: the
@@ -506,7 +566,7 @@ inline void gesvdj_cta_impl(Queue& ctx,
                         // written; see GESVD_IMPL_SPEC.md C.5 G3.
 #pragma unroll
                         for (int32_t step = 0; step < 4; ++step) {
-                            const uint32_t mask = static_cast<uint32_t>(kRotSlots) >> step;
+                            const uint32_t mask = static_cast<uint32_t>(kGramChunk) >> step;
                             if (mask == 0u) break;
                             const bool hi = (static_cast<uint32_t>(lane) & mask) != 0u;
                             const int32_t half = static_cast<int32_t>(mask) / 2;
@@ -525,6 +585,9 @@ inline void gesvdj_cta_impl(Queue& ctx,
                         // in lanes 2k and 2k+1.
 
                         const int32_t k_of_lane = lane >> 1;
+                        // Slot index within the ROUND, which is what
+                        // pairs_per_round counts.
+                        const int32_t slot = ch * static_cast<int32_t>(kGramChunk) + k_of_lane;
                         // Re-read the pair from LDS rather than indexing pk[]
                         // with the runtime index k_of_lane: a runtime index into
                         // a register array spills the whole array.
@@ -532,7 +595,7 @@ inline void gesvdj_cta_impl(Queue& ctx,
                         const int32_t kp = pq_l & 0xFF;
                         const int32_t kq = (pq_l >> 8) & 0xFF;
 
-                        bool active = (k_of_lane < pairs_per_round) && (kp < CC) && (kq < CC);
+                        bool active = (slot < pairs_per_round) && (kp < CC) && (kq < CC);
 
                         Real c_rot = Real(1);
                         Real s_rot = Real(0);
@@ -602,10 +665,10 @@ inline void gesvdj_cta_impl(Queue& ctx,
                             Nrm_local[base_n + kq] = sycl::fmax(aqq + tt * gr, Real(0));
                         }
 
-                        if (lane % 2 == 0 && k_of_lane < static_cast<int32_t>(kRotSlots)) {
-                            Rcs_local[base_r + k_of_lane] = sycl::vec<Real, 2>(c_rot, s_rot);
+                        if (lane % 2 == 0 && slot < static_cast<int32_t>(kRotSlots)) {
+                            Rcs_local[base_r + slot] = sycl::vec<Real, 2>(c_rot, s_rot);
                             if constexpr (kNeedPhase) {
-                                Rd_local[base_r + k_of_lane] = d_rot;
+                                Rd_local[base_r + slot] = d_rot;
                             }
                         }
                         group_barrier(part);
@@ -618,16 +681,17 @@ inline void gesvdj_cta_impl(Queue& ctx,
                         rot_count += round_active;
                         if (round_active == 0) continue;
 
-                        // ---- A <- A*U, V <- V*U. lane owns row `lane`. ----
-                        // ap[k]/aq[k] are still live from the Gram phase; that
-                        // is 32 LDS loads per round this mapping saves and no
-                        // other does. There is deliberately NO second phase:
-                        // syev_jacobi_cta's A <- U^H A row update is what makes
-                        // it two-sided, and deleting it is what makes this
+                        // ---- A <- A*U, V <- V*U. lane owns rows lane+rr*P. ----
+                        // ap[k][rr]/aq[k][rr] are still live from the Gram phase;
+                        // that is kRPL*32 LDS loads per chunk this mapping saves
+                        // and no other does. There is deliberately NO second
+                        // phase: syev_jacobi_cta's A <- U^H A row update is what
+                        // makes it two-sided, and deleting it is what makes this
                         // one-sided.
 #pragma unroll
-                        for (int32_t k = 0; k < static_cast<int32_t>(kRotSlots); ++k) {
-                            const sycl::vec<Real, 2> cs = Rcs_local[base_r + k];
+                        for (int32_t k = 0; k < static_cast<int32_t>(kGramChunk); ++k) {
+                            const sycl::vec<Real, 2> cs =
+                                Rcs_local[base_r + ch * static_cast<int32_t>(kGramChunk) + k];
                             const Real ck = cs[0];
                             const Real sk = cs[1];
                             // Warp-uniform skip: every lane reads the same slot,
@@ -641,24 +705,29 @@ inline void gesvdj_cta_impl(Queue& ctx,
                             T u21 = T(-sk);
                             T u22 = T(ck);
                             if constexpr (kNeedPhase) {
-                                const T dk = Rd_local[base_r + k];
+                                const T dk = Rd_local[base_r + ch * static_cast<int32_t>(kGramChunk) + k];
                                 u21 = -(dk * T(sk));
                                 u22 = dk * T(ck);
                             }
 
-                            A_local[base_a + lane + pk[k] * LD] = ap[k] * u11 + aq[k] * u21;
-                            A_local[base_a + lane + qk[k] * LD] = ap[k] * u12 + aq[k] * u22;
+#pragma unroll
+                            for (int32_t rr = 0; rr < static_cast<int32_t>(kRPL); ++rr) {
+                                const int32_t row = lane + rr * static_cast<int32_t>(P);
+                                A_local[base_a + row + pk[k] * LD] = ap[k][rr] * u11 + aq[k][rr] * u21;
+                                A_local[base_a + row + qk[k] * LD] = ap[k][rr] * u12 + aq[k][rr] * u22;
 
-                            if constexpr (ComputeV) {
-                                const int32_t vp = base_v + lane + pk[k] * LD;
-                                const int32_t vq = base_v + lane + qk[k] * LD;
-                                const T vpv = V_local[vp];
-                                const T vqv = V_local[vq];
-                                V_local[vp] = vpv * u11 + vqv * u21;
-                                V_local[vq] = vpv * u12 + vqv * u22;
+                                if constexpr (ComputeV) {
+                                    const int32_t vp = base_v + row + pk[k] * LD;
+                                    const int32_t vq = base_v + row + qk[k] * LD;
+                                    const T vpv = V_local[vp];
+                                    const T vqv = V_local[vq];
+                                    V_local[vp] = vpv * u11 + vqv * u21;
+                                    V_local[vq] = vpv * u12 + vqv * u22;
+                                }
                             }
                         }
                         group_barrier(part);
+                        }
                     }
 
                     if (rot_count == 0) {
@@ -678,8 +747,6 @@ inline void gesvdj_cta_impl(Queue& ctx,
                 exact_norms();
                 group_barrier(part);
 
-                const Real n2 = Nrm_local[base_n + lane];
-                const Real sigma_lane = (lane < CC) ? (inv_beta * sycl::sqrt(n2)) : Real(0);
 
                 // Rank sort, descending, ties broken on index so the
                 // permutation is a bijection. Descending is the gesvd contract:
@@ -696,23 +763,35 @@ inline void gesvdj_cta_impl(Queue& ctx,
                 // finite input, but a defensive identity means a hypothetical
                 // rank collision degrades to a wrong permutation rather than to
                 // a garbage column index used to address local memory.
-                Inv_local[base_p + lane] = static_cast<int16_t>(lane);
+                // This is the ONE place where lane is a COLUMN index rather
+                // than a row index, so it is the only place that needs a
+                // columns-per-lane loop: lane owns columns lane, lane+P, ...
+                for (int32_t cc = 0; cc < static_cast<int32_t>(kRPL); ++cc) {
+                    const int32_t col = lane + cc * static_cast<int32_t>(P);
+                    Inv_local[base_p + col] = static_cast<int16_t>(col);
+                }
                 group_barrier(part);
 
-                if (lane < CC) {
-                    int32_t rank = 0;
-                    for (int32_t j = 0; j < CC; ++j) {
-                        const Real sj = inv_beta * sycl::sqrt(Nrm_local[base_n + j]);
-                        const bool before = (sj > sigma_lane) || (sj == sigma_lane && j < lane);
-                        if (before) ++rank;
+                for (int32_t cc = 0; cc < static_cast<int32_t>(kRPL); ++cc) {
+                    const int32_t col = lane + cc * static_cast<int32_t>(P);
+                    const Real sigma_col =
+                        (col < CC) ? (inv_beta * sycl::sqrt(Nrm_local[base_n + col])) : Real(0);
+                    if (col < CC) {
+                        int32_t rank = 0;
+                        for (int32_t j = 0; j < CC; ++j) {
+                            const Real sj = inv_beta * sycl::sqrt(Nrm_local[base_n + j]);
+                            const bool before = (sj > sigma_col) || (sj == sigma_col && j < col);
+                            if (before) ++rank;
+                        }
+                        Inv_local[base_p + rank] = static_cast<int16_t>(col);
                     }
-                    Inv_local[base_p + rank] = static_cast<int16_t>(lane);
-                }
-                // Output columns CC..RR-1 of the left factor have no source
-                // column; park them on the free tile columns CC..RR-1, which the
-                // pad guarantees are zero and which no real column occupies.
-                if (lane >= CC && lane < RR) {
-                    Inv_local[base_p + lane] = static_cast<int16_t>(lane);
+                    // Output columns CC..RR-1 of the left factor have no source
+                    // column; park them on the free tile columns CC..RR-1, which
+                    // the pad guarantees are zero and which no real column
+                    // occupies. Disjoint from the rank slots above (0..CC-1).
+                    if (col >= CC && col < RR) {
+                        Inv_local[base_p + col] = static_cast<int16_t>(col);
+                    }
                 }
                 group_barrier(part);
 
@@ -723,17 +802,23 @@ inline void gesvdj_cta_impl(Queue& ctx,
                 // U column.
                 const Real tol_zero = zero_mult * std::numeric_limits<Real>::epsilon() * sigma_max;
 
-                if (lane < CC) {
-                    const int32_t src = static_cast<int32_t>(Inv_local[base_p + lane]);
-                    S[static_cast<int64_t>(prob_id) * CC + lane] = inv_beta * sycl::sqrt(Nrm_local[base_n + src]);
+                for (int32_t cc = 0; cc < static_cast<int32_t>(kRPL); ++cc) {
+                    const int32_t col = lane + cc * static_cast<int32_t>(P);
+                    if (col < CC) {
+                        const int32_t src = static_cast<int32_t>(Inv_local[base_p + col]);
+                        S[static_cast<int64_t>(prob_id) * CC + col] =
+                            inv_beta * sycl::sqrt(Nrm_local[base_n + src]);
+                    }
                 }
 
                 // ---- Left factor: U_c = A_c / sigma_c ----
                 if (want_left_f) {
                     // Normalise the accepted columns in place. A has been fully
                     // consumed into sigma by now, so overwriting it is safe.
-                    if (lane < CC) {
-                        const Real n2_c = Nrm_local[base_n + lane];
+                    for (int32_t cc = 0; cc < static_cast<int32_t>(kRPL); ++cc) {
+                        const int32_t col = lane + cc * static_cast<int32_t>(P);
+                        if (col >= CC) continue;
+                        const Real n2_c = Nrm_local[base_n + col];
                         const Real s_c = inv_beta * sycl::sqrt(n2_c);
                         if (s_c > tol_zero && n2_c > Real(0)) {
                             // Divide by the norm of the SCALED column, which is
@@ -741,7 +826,7 @@ inline void gesvdj_cta_impl(Queue& ctx,
                             // 1/beta.
                             const Real inv_s = Real(1) / sycl::sqrt(n2_c);
                             for (int32_t r = 0; r < static_cast<int32_t>(C); ++r) {
-                                A_local[base_a + r + lane * LD] = A_local[base_a + r + lane * LD] * T(inv_s);
+                                A_local[base_a + r + col * LD] = A_local[base_a + r + col * LD] * T(inv_s);
                             }
                         }
                     }
@@ -756,9 +841,14 @@ inline void gesvdj_cta_impl(Queue& ctx,
                     //
                     // Gated on a warp-uniform predicate: a well-conditioned
                     // square input pays one compare and skips the branch.
-                    const bool deficient_lane =
-                        (lane < CC) && (inv_beta * sycl::sqrt(Nrm_local[base_n + lane]) <= tol_zero);
-                    const int32_t any_def = part_sum_g(part, deficient_lane ? int32_t(1) : int32_t(0));
+                    int32_t deficient_here = 0;
+                    for (int32_t cc = 0; cc < static_cast<int32_t>(kRPL); ++cc) {
+                        const int32_t col = lane + cc * static_cast<int32_t>(P);
+                        if (col < CC && inv_beta * sycl::sqrt(Nrm_local[base_n + col]) <= tol_zero) {
+                            ++deficient_here;
+                        }
+                    }
+                    const int32_t any_def = part_sum_g(part, deficient_here);
 
                     // LC, not RR: a Thin request wants only the CC columns the
                     // solve already produced, so the completion block is skipped
@@ -798,7 +888,16 @@ inline void gesvdj_cta_impl(Queue& ctx,
                             bool filled = false;
                             while (jcur < RR && !filled) {
                                 const int32_t j = jcur++;
-                                T v = (lane == j) ? T(1) : T(0);
+                                // The trial vector is distributed over the
+                                // lane's kRPL rows. Each lane sums its own rows
+                                // FIRST and the butterfly then sums across
+                                // lanes -- the butterfly itself stays 32-wide.
+                                T v[kRPL];
+#pragma unroll
+                                for (int32_t rr = 0; rr < static_cast<int32_t>(kRPL); ++rr) {
+                                    const int32_t row = lane + rr * static_cast<int32_t>(P);
+                                    v[rr] = (row == j) ? T(1) : T(0);
+                                }
                                 // TWO passes of classical Gram-Schmidt. One pass
                                 // against an ill-conditioned accepted set loses
                                 // exactly the orthogonality this patch exists to
@@ -807,15 +906,35 @@ inline void gesvdj_cta_impl(Queue& ctx,
                                 for (int32_t pass = 0; pass < 2; ++pass) {
                                     for (int32_t d2 = 0; d2 < dst; ++d2) {
                                         const int32_t c2 = static_cast<int32_t>(Inv_local[base_p + d2]);
-                                        const T qv = (lane < RR) ? A_local[base_a + lane + c2 * LD] : T(0);
-                                        const T dot = part_sum_g(part, conj_if_complex_g(qv) * v);
-                                        v = v - qv * dot;
+                                        T part_dot = T(0);
+                                        T qv[kRPL];
+#pragma unroll
+                                        for (int32_t rr = 0; rr < static_cast<int32_t>(kRPL); ++rr) {
+                                            const int32_t row = lane + rr * static_cast<int32_t>(P);
+                                            qv[rr] = (row < RR) ? A_local[base_a + row + c2 * LD] : T(0);
+                                            part_dot = part_dot + conj_if_complex_g(qv[rr]) * v[rr];
+                                        }
+                                        const T dot = part_sum_g(part, part_dot);
+#pragma unroll
+                                        for (int32_t rr = 0; rr < static_cast<int32_t>(kRPL); ++rr) {
+                                            v[rr] = v[rr] - qv[rr] * dot;
+                                        }
                                     }
                                 }
-                                const Real nrm2 = part_sum_g(part, (lane < RR) ? norm2_g(v) : Real(0));
+                                Real part_n2 = Real(0);
+#pragma unroll
+                                for (int32_t rr = 0; rr < static_cast<int32_t>(kRPL); ++rr) {
+                                    const int32_t row = lane + rr * static_cast<int32_t>(P);
+                                    if (row < RR) part_n2 += norm2_g(v[rr]);
+                                }
+                                const Real nrm2 = part_sum_g(part, part_n2);
                                 if (nrm2 > accept_tol) {
                                     const Real inv_nr = Real(1) / sycl::sqrt(nrm2);
-                                    A_local[base_a + lane + cdst * LD] = v * T(inv_nr);
+#pragma unroll
+                                    for (int32_t rr = 0; rr < static_cast<int32_t>(kRPL); ++rr) {
+                                        const int32_t row = lane + rr * static_cast<int32_t>(P);
+                                        A_local[base_a + row + cdst * LD] = v[rr] * T(inv_nr);
+                                    }
                                     filled = true;
                                 }
                             }
@@ -830,10 +949,12 @@ inline void gesvdj_cta_impl(Queue& ctx,
                         // U(lane, dst): global address dst*ld + lane, so
                         // consecutive lanes are contiguous.
                         // dst is the output COLUMN, so Thin truncates the loop.
-                        if (lane < RR) {
+                        for (int32_t rr = 0; rr < static_cast<int32_t>(kRPL); ++rr) {
+                            const int32_t row = lane + rr * static_cast<int32_t>(P);
+                            if (row >= RR) continue;
                             for (int32_t dst = 0; dst < LC; ++dst) {
                                 const int32_t c = static_cast<int32_t>(Inv_local[base_p + dst]);
-                                U_prob(lane, dst) = A_local[base_a + lane + c * LD];
+                                U_prob(row, dst) = A_local[base_a + row + c * LD];
                             }
                         }
                     } else {
@@ -846,10 +967,12 @@ inline void gesvdj_cta_impl(Queue& ctx,
                         // the thin restriction lands on `lane`, not on `r`.
                         // Truncating r instead would emit a factor of the wrong
                         // shape while still writing something plausible.
-                        if (lane < LC) {
-                            const int32_t c = static_cast<int32_t>(Inv_local[base_p + lane]);
+                        for (int32_t cc = 0; cc < static_cast<int32_t>(kRPL); ++cc) {
+                            const int32_t dst = lane + cc * static_cast<int32_t>(P);
+                            if (dst >= LC) continue;
+                            const int32_t c = static_cast<int32_t>(Inv_local[base_p + dst]);
                             for (int32_t r = 0; r < RR; ++r) {
-                                Vh_prob(lane, r) = conj_if_complex_g(A_local[base_a + r + c * LD]);
+                                Vh_prob(dst, r) = conj_if_complex_g(A_local[base_a + r + c * LD]);
                             }
                         }
                     }
@@ -859,24 +982,53 @@ inline void gesvdj_cta_impl(Queue& ctx,
                 if constexpr (ComputeV) {
                     if (!transposed_f) {
                         // Vh(lane, r) = conj(V(r, c_lane))
-                        if (lane < CC) {
-                            const int32_t c = static_cast<int32_t>(Inv_local[base_p + lane]);
+                        for (int32_t cc = 0; cc < static_cast<int32_t>(kRPL); ++cc) {
+                            const int32_t dst = lane + cc * static_cast<int32_t>(P);
+                            if (dst >= CC) continue;
+                            const int32_t c = static_cast<int32_t>(Inv_local[base_p + dst]);
                             for (int32_t r = 0; r < CC; ++r) {
-                                Vh_prob(lane, r) = conj_if_complex_g(V_local[base_v + r + c * LD]);
+                                Vh_prob(dst, r) = conj_if_complex_g(V_local[base_v + r + c * LD]);
                             }
                         }
                     } else {
-                        // U = V' directly.
-                        if (lane < CC) {
+                        // U = V' directly. Here lane is the output ROW.
+                        for (int32_t rr = 0; rr < static_cast<int32_t>(kRPL); ++rr) {
+                            const int32_t row = lane + rr * static_cast<int32_t>(P);
+                            if (row >= CC) continue;
                             for (int32_t dst = 0; dst < CC; ++dst) {
                                 const int32_t c = static_cast<int32_t>(Inv_local[base_p + dst]);
-                                U_prob(lane, dst) = V_local[base_v + lane + c * LD];
+                                U_prob(row, dst) = V_local[base_v + row + c * LD];
                             }
                         }
                     }
                 }
             });
     });
+}
+
+// Largest max(m, n) this kernel accepts, per scalar type.
+//
+// The limit is local memory, and the binding constraint is OCCUPANCY rather
+// than the hard cap. Per-problem LDS at C=64 with the V tile resident is
+// 37,952 B for float, 71,744 B for double and complex<float>, and 138,816 B
+// for complex<double>; this device reports 101,376 B, so complex<double> with
+// vectors does not launch at all and the others fall to 2 or 1 work-groups per
+// SM against 10 at C=32.
+//
+// Values-only halves it (no V tile), which is why the cap is job-dependent.
+// The specific numbers here are set by measurement, not by the limit -- see
+// the table in gesvd_supports_jacobi.
+template <typename T>
+constexpr int32_t gesvdj_cta_max_dim(bool want_vectors) {
+    if constexpr (std::is_same_v<T, std::complex<double>>) {
+        return want_vectors ? 32 : 64;
+    } else {
+        return 64;
+    }
+}
+
+inline bool want_vectors_for_cap(SvdVectors jobu, SvdVectors jobvh) {
+    return jobu != SvdVectors::None || jobvh != SvdVectors::None;
 }
 
 template <typename T>
@@ -944,8 +1096,10 @@ Event gesvdj_cta(Queue& ctx,
         jobu = canonical_jobu(jobu, m, k);
         jobvh = canonical_jobvh(jobvh, n, k);
     }
-    if (std::max(m, n) > 32) {
-        throw std::invalid_argument("gesvdj_cta: currently supports max(m, n) <= 32");
+    if (std::max(m, n) > gesvdj_cta_max_dim<T>(want_vectors_for_cap(jobu, jobvh))) {
+        throw std::invalid_argument(
+            "gesvdj_cta: max(m, n) exceeds the supported cap for this scalar type "
+            "(see gesvdj_cta_max_dim)");
     }
 
     {
@@ -1001,7 +1155,10 @@ Event gesvdj_cta(Queue& ctx,
     constexpr auto k8 = std::integral_constant<size_t, 8>{};
     constexpr auto k16 = std::integral_constant<size_t, 16>{};
     constexpr auto k32 = std::integral_constant<size_t, 32>{};
+    constexpr auto k64 = std::integral_constant<size_t, 64>{};
 
+    // P is capped at 32 by the sub-group width; above that the tile capacity C
+    // grows instead and each lane takes kRPL = C/P rows.
     const int32_t md = std::max(m, n);
     if (md <= 4) {
         launch(k4, k4);
@@ -1009,8 +1166,10 @@ Event gesvdj_cta(Queue& ctx,
         launch(k8, k8);
     } else if (md <= 16) {
         launch(k16, k16);
-    } else {
+    } else if (md <= 32) {
         launch(k32, k32);
+    } else {
+        launch(k32, k64);
     }
 
     return ctx.get_event();
@@ -1028,8 +1187,9 @@ size_t gesvdj_cta_buffer_size(Queue& ctx,
     (void)ctx;
     (void)params;
     validate_gesvdj_dims(a, singular_values, u_out, vh_out, jobu, jobvh, "gesvdj_cta_buffer_size");
-    if (std::max(a.rows(), a.cols()) > 32) {
-        throw std::invalid_argument("gesvdj_cta_buffer_size: currently supports max(m, n) <= 32");
+    if (std::max(a.rows(), a.cols()) > gesvdj_cta_max_dim<T>(want_vectors_for_cap(jobu, jobvh))) {
+        throw std::invalid_argument(
+            "gesvdj_cta_buffer_size: max(m, n) exceeds the supported cap for this scalar type");
     }
     // Everything is LDS-resident for the lifetime of the kernel.
     return 0;

--- a/src/extensions/gesvdj_cta.cc
+++ b/src/extensions/gesvdj_cta.cc
@@ -265,9 +265,17 @@ inline void gesvdj_cta_impl(Queue& ctx,
                           ? params.sweep_counts.data()
                           : nullptr;
 
+        // The 32 here is load-bearing and was previously only checked on the
+        // host, which cannot constrain what the compiler picks. The exact-norm
+        // reduction and the Gram reduce-scatter below are hardcoded 5- and
+        // (4+1)-step butterflies, probs_per_warp is sg_size/P with sg_size
+        // fixed at 32, and part_id assumes the same -- every one of those is
+        // silently wrong at any other sub-group width. Sibling CTA kernels
+        // (steqr_cta, syev_cta_fused, sytrd_sb2st_cta) all carry the attribute;
+        // this one and syev_jacobi_cta did not.
         cgh.parallel_for<GesvdjCTAKernel<T, P, ComputeV>>(
             sycl::nd_range<1>(global_size, wg_size),
-            [=](sycl::nd_item<1> it) {
+            [=](sycl::nd_item<1> it) [[sycl::reqd_sub_group_size(32)]] {
                 const auto wg = it.get_group();
                 const int32_t wg_id = static_cast<int32_t>(wg.get_group_linear_id());
                 const int32_t local_id = static_cast<int32_t>(it.get_local_linear_id());

--- a/src/extensions/gesvdj_cta.cc
+++ b/src/extensions/gesvdj_cta.cc
@@ -20,7 +20,7 @@ namespace batchlas {
 
 // Kernel name tag. Must live outside the anonymous namespace so it does not
 // depend on internal-linkage entities.
-template <typename T, size_t P, bool ComputeV>
+template <typename T, size_t P, size_t C, bool ComputeV>
 class GesvdjCTAKernel;
 
 // ---------------------------------------------------------------------------
@@ -150,7 +150,7 @@ inline void round_robin_pair_g(int32_t mp, int32_t t, int32_t k, int32_t& p, int
     }
 }
 
-template <typename T, size_t P, bool ComputeV>
+template <typename T, size_t P, size_t C, bool ComputeV>
 inline void gesvdj_cta_impl(Queue& ctx,
                             const MatrixView<T, MatrixFormat::Dense>& a_in,
                             typename base_type<T>::type* s_ptr,
@@ -178,10 +178,23 @@ inline void gesvdj_cta_impl(Queue& ctx,
         // conflict-free: lane i reads [r + c_i*LD] with c_i a permutation, and
         // gcd(LD,32)=1 turns c -> c*LD mod 32 into a bijection. With LD == P the
         // same access serialises 32 ways.
-        constexpr int32_t LD = static_cast<int32_t>(P) + 1;
-        constexpr size_t kTileElems = static_cast<size_t>(LD) * P;
-        constexpr size_t kRotSlots = (P / 2 > 0) ? (P / 2) : 1;
-        constexpr size_t kPairSlots = (P - 1) * kRotSlots;
+        // P is the PARTITION WIDTH (lanes). C is the TILE CAPACITY (rows and
+        // columns of the resident matrix). They are equal on every rung that
+        // existed before n > 32 support, and C > P means each lane owns
+        // kRPL = C/P rows rather than one.
+        //
+        // Splitting them is what keeps the n <= 32 path byte-identical: at
+        // C == P every generalised expression below reduces syntactically to
+        // what it was.
+        static_assert(C % P == 0, "tile capacity must be a whole number of partition widths");
+        static_assert(C <= 64, "int16 pair packing p|(q<<8) overflows above C=127; 64 is the tested cap");
+        constexpr size_t kRPL = C / P;                       // rows per lane
+        static_assert(kRPL == 1 || P == 32,
+                      "multi-row lanes are only defined on a full 32-wide partition");
+        constexpr int32_t LD = static_cast<int32_t>(C) + 1;
+        constexpr size_t kTileElems = static_cast<size_t>(LD) * C;
+        constexpr size_t kRotSlots = (C / 2 > 0) ? (C / 2) : 1;
+        constexpr size_t kPairSlots = (C - 1) * kRotSlots;
         constexpr bool kNeedPhase = internal::is_complex<T>::value;
 
         // Local-memory budget. Note this clamps probs_per_wg DIRECTLY rather
@@ -194,10 +207,10 @@ inline void gesvdj_cta_impl(Queue& ctx,
         constexpr size_t kPairTabBytes = kPairSlots * sizeof(int16_t);
         const size_t bytes_per_prob =
             (1 + (ComputeV ? 1 : 0)) * kTileElems * sizeof(T)
-            + P * sizeof(Real)
+            + C * sizeof(Real)
             + 2 * kRotSlots * sizeof(Real)
             + (kNeedPhase ? kRotSlots * sizeof(T) : 0)
-            + P * sizeof(int16_t);
+            + C * sizeof(int16_t);
 
         const size_t local_mem_bytes = dev.get_info<sycl::info::device::local_mem_size>();
         const size_t avail = (local_mem_bytes > kPairTabBytes) ? (local_mem_bytes - kPairTabBytes) : 1;
@@ -228,13 +241,13 @@ inline void gesvdj_cta_impl(Queue& ctx,
         auto V_local = sycl::local_accessor<T, 1>(
             sycl::range<1>(ComputeV ? static_cast<size_t>(probs_per_wg) * kTileElems : 1), cgh);
         auto Nrm_local = sycl::local_accessor<Real, 1>(
-            sycl::range<1>(static_cast<size_t>(probs_per_wg) * P), cgh);
+            sycl::range<1>(static_cast<size_t>(probs_per_wg) * C), cgh);
         auto Rcs_local = sycl::local_accessor<sycl::vec<Real, 2>, 1>(
             sycl::range<1>(static_cast<size_t>(probs_per_wg) * kRotSlots), cgh);
         auto Rd_local = sycl::local_accessor<T, 1>(
             sycl::range<1>(kNeedPhase ? static_cast<size_t>(probs_per_wg) * kRotSlots : 1), cgh);
         auto Inv_local = sycl::local_accessor<int16_t, 1>(
-            sycl::range<1>(static_cast<size_t>(probs_per_wg) * P), cgh);
+            sycl::range<1>(static_cast<size_t>(probs_per_wg) * C), cgh);
         auto Pair_local = sycl::local_accessor<int16_t, 1>(sycl::range<1>(kPairSlots), cgh);
 
         const int32_t RR = rows;
@@ -273,7 +286,7 @@ inline void gesvdj_cta_impl(Queue& ctx,
         // silently wrong at any other sub-group width. Sibling CTA kernels
         // (steqr_cta, syev_cta_fused, sytrd_sb2st_cta) all carry the attribute;
         // this one and syev_jacobi_cta did not.
-        cgh.parallel_for<GesvdjCTAKernel<T, P, ComputeV>>(
+        cgh.parallel_for<GesvdjCTAKernel<T, P, C, ComputeV>>(
             sycl::nd_range<1>(global_size, wg_size),
             [=](sycl::nd_item<1> it) [[sycl::reqd_sub_group_size(32)]] {
                 const auto wg = it.get_group();
@@ -299,8 +312,8 @@ inline void gesvdj_cta_impl(Queue& ctx,
                     if (k < pairs_per_round) {
                         round_robin_pair_g(mp, t, k, p, q);
                     } else {
-                        p = static_cast<int32_t>(P);
-                        q = static_cast<int32_t>(P);
+                        p = static_cast<int32_t>(C);
+                        q = static_cast<int32_t>(C);
                     }
                     Pair_local[idx] = static_cast<int16_t>(p | (q << 8));
                 }
@@ -323,9 +336,9 @@ inline void gesvdj_cta_impl(Queue& ctx,
 
                 const int32_t base_a = part_id * static_cast<int32_t>(kTileElems);
                 const int32_t base_v = ComputeV ? (part_id * static_cast<int32_t>(kTileElems)) : 0;
-                const int32_t base_n = part_id * static_cast<int32_t>(P);
+                const int32_t base_n = part_id * static_cast<int32_t>(C);
                 const int32_t base_r = part_id * static_cast<int32_t>(kRotSlots);
-                const int32_t base_p = part_id * static_cast<int32_t>(P);
+                const int32_t base_p = part_id * static_cast<int32_t>(C);
 
                 // ---- Load. lane = ROW. ----
                 // Lane-as-row makes the global read A_prob(lane,c) (address
@@ -335,7 +348,7 @@ inline void gesvdj_cta_impl(Queue& ctx,
                 // gesvd_blocked's out-of-place transpose + recursion.
                 // The pad region is written as exact zero so a padded pair's
                 // Gram is identically 0 and falls below any threshold.
-                for (int32_t c = 0; c < static_cast<int32_t>(P); ++c) {
+                for (int32_t c = 0; c < static_cast<int32_t>(C); ++c) {
                     T v = T(0);
                     if (lane < RR && c < CC) {
                         // For m < n we solve A^H, not A^T. A^H = U' S V'^H gives
@@ -426,7 +439,7 @@ inline void gesvdj_cta_impl(Queue& ctx,
                 // pressure, so it is not worth keeping behind a runtime flag
                 // either. See GESVD_PLAN.md Tier 2.
                 if (beta != Real(1)) {
-                    for (int32_t c = 0; c < static_cast<int32_t>(P); ++c) {
+                    for (int32_t c = 0; c < static_cast<int32_t>(C); ++c) {
                         A_local[base_a + lane + c * LD] = A_local[base_a + lane + c * LD] * T(beta);
                     }
                     group_barrier(part);
@@ -727,7 +740,7 @@ inline void gesvdj_cta_impl(Queue& ctx,
                             // sqrt(n2_c) -- not by sigma, which is that times
                             // 1/beta.
                             const Real inv_s = Real(1) / sycl::sqrt(n2_c);
-                            for (int32_t r = 0; r < static_cast<int32_t>(P); ++r) {
+                            for (int32_t r = 0; r < static_cast<int32_t>(C); ++r) {
                                 A_local[base_a + r + lane * LD] = A_local[base_a + r + lane * LD] * T(inv_s);
                             }
                         }
@@ -972,24 +985,32 @@ Event gesvdj_cta(Queue& ctx,
 
     auto* s_ptr = singular_values.data();
 
-    auto launch = [&](auto P_tag) {
+    // (P, C): P lanes per partition, C the tile capacity. Every rung here has
+    // C == P, i.e. one row per lane -- the shape this kernel has always had.
+    auto launch = [&](auto P_tag, auto C_tag) {
         constexpr size_t Pv = decltype(P_tag)::value;
+        constexpr size_t Cv = decltype(C_tag)::value;
         if (want_right) {
-            gesvdj_cta_impl<T, Pv, true>(ctx, a_in, s_ptr, u_out, vh_out, want_left, transposed, RR, CC, left_cols, params);
+            gesvdj_cta_impl<T, Pv, Cv, true>(ctx, a_in, s_ptr, u_out, vh_out, want_left, transposed, RR, CC, left_cols, params);
         } else {
-            gesvdj_cta_impl<T, Pv, false>(ctx, a_in, s_ptr, u_out, vh_out, want_left, transposed, RR, CC, left_cols, params);
+            gesvdj_cta_impl<T, Pv, Cv, false>(ctx, a_in, s_ptr, u_out, vh_out, want_left, transposed, RR, CC, left_cols, params);
         }
     };
 
+    constexpr auto k4 = std::integral_constant<size_t, 4>{};
+    constexpr auto k8 = std::integral_constant<size_t, 8>{};
+    constexpr auto k16 = std::integral_constant<size_t, 16>{};
+    constexpr auto k32 = std::integral_constant<size_t, 32>{};
+
     const int32_t md = std::max(m, n);
     if (md <= 4) {
-        launch(std::integral_constant<size_t, 4>{});
+        launch(k4, k4);
     } else if (md <= 8) {
-        launch(std::integral_constant<size_t, 8>{});
+        launch(k8, k8);
     } else if (md <= 16) {
-        launch(std::integral_constant<size_t, 16>{});
+        launch(k16, k16);
     } else {
-        launch(std::integral_constant<size_t, 32>{});
+        launch(k32, k32);
     }
 
     return ctx.get_event();

--- a/src/matrix.cc
+++ b/src/matrix.cc
@@ -774,34 +774,57 @@ template <MatrixFormat M>
     requires DenseMatrixFormat<M>
 Event MatrixView<T, MType>::triangularize(const Queue& ctx, Uplo uplo, 
                                                     Diag diag) const {
+    // `uplo` names the triangle to KEEP: Uplo::Upper zeroes the strict lower
+    // triangle and leaves an upper-triangular matrix.
+    //
+    // This used to do the opposite. The decode named `i` the row and `j` the
+    // column, but addressed `b*stride + i*ld + j`, and this library is
+    // column-major (`data_[b*stride_ + j*ld_ + i]`, matrix.hh:80) -- so `i` was
+    // really the column and `j` the row, and `Upper && i > j` zeroed col>row,
+    // i.e. the strict UPPER triangle. The names were wrong, not the address
+    // arithmetic, so the fix is to name them correctly and compare the right
+    // way round. The inversion cost PR #66 a day: extracting R from a geqrf
+    // result silently yielded the Householder reflectors instead, which are
+    // easier to diagonalise, and fabricated an apparent 1.7x win for QR
+    // preconditioning that did not exist.
+    //
+    // Two further bugs went with it: the element count came from `data_.size()`
+    // (the span extent, which for a sliced or strided view is not
+    // batch*rows*cols) and `n` was taken from rows_ alone, so a non-square view
+    // decoded its own indices wrongly. Both are fixed here.
     T* data_ptr = data_.data();
-    size_t total_elements = data_.size();
-    auto n = rows_; // Assuming square matrix
+    const size_t rows = static_cast<size_t>(rows_);
+    const size_t cols = static_cast<size_t>(cols_);
     auto batch_size = batch_size_;
     auto stride = stride_; // Stride for batched matrices
     auto ld = ld_; // Leading dimension
 
+    const size_t elems_per_matrix = rows * cols;
+    const size_t total_elements = elems_per_matrix * static_cast<size_t>(batch_size);
+    if (total_elements == 0) return ctx.get_event();
+
     // Use batched matrix decomposition strategy
     auto [global_size, local_size, wg_per_matrix] = compute_batched_matrix_decomposition(
-        batch_size, n * n, ctx.device(), KernelType::ELEMENTWISE);
+        batch_size, static_cast<int>(elems_per_matrix), ctx.device(), KernelType::ELEMENTWISE);
 
     ctx->parallel_for(sycl::nd_range<1>(global_size, local_size), [=](sycl::nd_item<1> item) {
         size_t global_id = item.get_global_id(0);
         size_t total_work_items = item.get_global_range(0);
-        
+
         // Grid-stride loop to handle large matrices
         for (size_t flat_idx = global_id; flat_idx < total_elements; flat_idx += total_work_items) {
             // Calculate 3D coordinates from flat index
-            size_t b = flat_idx / (n * n);          // batch index
-            size_t remainder = flat_idx % (n * n);
-            size_t i = remainder / n;               // row index
-            size_t j = remainder % n;               // column index
-            
-            if (i == j && diag == Diag::Unit) {
-                data_ptr[b * stride + i * ld + j] = T(1);
-            } else if ((uplo == Uplo::Lower && i < j) || (uplo == Uplo::Upper && i > j)) {
-                // Zero out elements above or below the diagonal depending on Uplo
-                data_ptr[b * stride + i * ld + j] = T(0);
+            size_t b = flat_idx / elems_per_matrix;   // batch index
+            size_t remainder = flat_idx % elems_per_matrix;
+            // Column-major: consecutive flat indices walk DOWN a column.
+            size_t col = remainder / rows;
+            size_t row = remainder % rows;
+
+            if (row == col && diag == Diag::Unit) {
+                data_ptr[b * stride + col * ld + row] = T(1);
+            } else if ((uplo == Uplo::Lower && row < col) || (uplo == Uplo::Upper && row > col)) {
+                // Zero the triangle that `uplo` does not name.
+                data_ptr[b * stride + col * ld + row] = T(0);
             }
         }
     });

--- a/tests/bdsdc_tests.cc
+++ b/tests/bdsdc_tests.cc
@@ -120,7 +120,8 @@ protected:
     // reconstruction of B, and orthogonality of both vector sets.
     void run_and_check(const std::vector<double>& dh,
                        const std::vector<double>& eh,
-                       int n, int batch, bool vectors, const char* label) {
+                       int n, int batch, bool vectors, const char* label,
+                       double orth_override = 0.0) {
         auto& ctx = *this->ctx;
         UnifiedVector<Scalar> d(static_cast<size_t>(n) * batch);
         UnifiedVector<Scalar> e(static_cast<size_t>(std::max(1, n - 1)) * batch);
@@ -207,12 +208,14 @@ protected:
                     vorth += (dv2 - tgt) * (dv2 - tgt);
                 }
             }
-            EXPECT_LE(std::sqrt(uorth), orth_tol()) << label << " U orthogonality n=" << n << " b=" << b;
-            EXPECT_LE(std::sqrt(vorth), orth_tol()) << label << " V orthogonality n=" << n << " b=" << b;
+            const double otol = (orth_override > 0.0) ? orth_override : static_cast<double>(orth_tol());
+            EXPECT_LE(std::sqrt(uorth), otol) << label << " U orthogonality n=" << n << " b=" << b;
+            EXPECT_LE(std::sqrt(vorth), otol) << label << " V orthogonality n=" << n << " b=" << b;
         }
     }
 
-    void check(int n, int batch, unsigned seed, bool vectors, double dscale = 1.0) {
+    void check(int n, int batch, unsigned seed, bool vectors, double dscale = 1.0,
+               double orth_override = 0.0) {
         std::mt19937 rng(seed);
         std::uniform_real_distribution<double> dist(0.3, 1.7);
         std::vector<double> dh(static_cast<size_t>(n) * batch);
@@ -225,7 +228,7 @@ protected:
                 eh[static_cast<size_t>(b) * (n - 1) + i] = dist(rng) * 0.5 * std::pow(dscale, i);
             }
         }
-        run_and_check(dh, eh, n, batch, vectors, "random");
+        run_and_check(dh, eh, n, batch, vectors, "random", orth_override);
     }
 
     // Mixed signs, exact zeros, entries over six decades -- what gebrd actually
@@ -290,6 +293,30 @@ TYPED_TEST(BdsdcTest, WithVectors) {
 TYPED_TEST(BdsdcTest, Graded) {
     this->check(32, 2, 301u, /*vectors=*/true, /*dscale=*/0.8);
     this->check(64, 2, 302u, /*vectors=*/false, /*dscale=*/0.85);
+}
+
+// Graded WITH vectors at kappa ~ 1e6, which is where the +sigma/-sigma pair of
+// the 2n Golub-Kahan matrix stops being resolvable. Both members of an
+// unresolved pair then normalise to the same (v, u), so U and V come back with
+// parallel columns -- measured 1.6e-2 before the repair threshold was derived
+// from the resolution limit rather than set to detect exact zeros.
+//
+// The existing Graded case runs n=64 with vectors=FALSE, so nothing exercised
+// this; it is the whole reason the defect survived.
+TYPED_TEST(BdsdcTest, GradedWithVectorsHighCondition) {
+    // 5e-3 rather than the usual 1e-3, and that is a real residual, not slack:
+    // this graded bidiagonal is harsher than a random matrix of the same kappa
+    // (many clustered tiny sigma rather than a smooth spread), and the repair's
+    // own Gram-Schmidt accumulates error across the columns it rebuilds.
+    // Measured 1.6e-2 before the threshold fix and 4.8e-3 after, so the bound
+    // still fails on the old code -- which is the point of it.
+    //
+    // End-to-end through gesvd the same kappa lands at 1.1e-4 (gesvd_relacc,
+    // n=64, float), comfortably inside every tolerance the suite applies.
+    // Callers who need better than this above n=32 want the one-sided Jacobi
+    // route, which never forms the bidiagonal at all.
+    const double kGradedOrthTol = std::is_same_v<typename TestFixture::Scalar, float> ? 5e-3 : 1e-10;
+    this->check(64, 2, 303u, /*vectors=*/true, /*dscale=*/0.803, kGradedOrthTol);
 }
 
 TYPED_TEST(BdsdcTest, MixedSignsZerosAndWideRange) {

--- a/tests/cond_tests.cc
+++ b/tests/cond_tests.cc
@@ -364,3 +364,63 @@ TYPED_TEST(CondTest, RandomHermitianTridiagonalLogCondSpectral) {
     }
 }
 
+// The generator must never emit a non-finite matrix.
+//
+// It used to, intermittently: it orthonormalised two raw Matrix::Random factors
+// with OrthoAlgorithm::Chol2, and Chol-QR forms the Gram matrix, squaring the
+// condition number of its input. That input is UNconditioned -- the requested
+// kappa is imposed afterwards by the diagonal -- so in float the squared Gram
+// goes numerically indefinite whenever an ordinary random draw lands above
+// kappa ~ 1e4, which happens a few times in a batch of 32 at n=64. potrf then
+// fails, its info code is discarded, the following trsm back-substitutes
+// through a garbage diagonal, and two gemms smear the NaN over every entry of
+// that batch item.
+//
+// benchmarks/gesvd_relacc.cc works around it by re-drawing up to 8 times, so
+// this has to test the generator directly; going through the benchmark would
+// hide exactly the failure being guarded. The default is now Householder,
+// which is unconditionally backward stable.
+//
+// Seeds matter: at n=64/batch=32 the reported reproduction failed on seed 1 and
+// not on 123 or 2024, so a single seed proves nothing. Float only in practice
+// (double needs kappa > 6.7e7), but both are swept here since the fixture is
+// typed anyway.
+TYPED_TEST(CondTest, RandomMatrixGeneratorIsAlwaysFinite) {
+    using T = typename TestFixture::ScalarType;
+    using real_t = typename base_type<T>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    const int n = 64;
+    const int batch_size = 32;
+    const real_t log10_cond = real_t(4);
+
+    for (unsigned seed : {1u, 7u, 42u, 123u, 2024u}) {
+        auto mat = random_with_log10_cond_metric<B, T>(
+            *this->ctx, n, log10_cond, NormType::Spectral, batch_size, seed);
+        this->ctx->wait();
+
+        const auto view = mat.view();
+        const T* base = view.data_ptr();
+        const int64_t stride = view.stride();
+        const int64_t ld = view.ld();
+
+        int non_finite_items = 0;
+        for (int b = 0; b < batch_size; ++b) {
+            bool bad = false;
+            for (int c = 0; c < n && !bad; ++c) {
+                for (int r = 0; r < n; ++r) {
+                    const T v = base[b * stride + static_cast<int64_t>(c) * ld + r];
+                    if (!std::isfinite(static_cast<double>(std::abs(v)))) {
+                        bad = true;
+                        break;
+                    }
+                }
+            }
+            if (bad) ++non_finite_items;
+        }
+
+        EXPECT_EQ(non_finite_items, 0)
+            << "seed " << seed << ": " << non_finite_items << " of " << batch_size
+            << " batch items are non-finite";
+    }
+}

--- a/tests/gesvd_tests.cc
+++ b/tests/gesvd_tests.cc
@@ -1192,3 +1192,236 @@ TYPED_TEST(GesvdTest, DefaultProviderKeepsSingularValuesAtHighCondition) {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Thin (economy) singular vectors on the blocked path.
+//
+// Note there is deliberately no GTEST_SKIP on the CUDA backend in the first
+// test: dispatch pins NETLIB to Vendor, so running it on GesvdTest/0 and /1 is
+// what exercises the new LAPACKE jobu='S' mapping, which is in turn the
+// reference the GPU results are checked against.
+// ---------------------------------------------------------------------------
+
+TYPED_TEST(GesvdTest, ThinTallRectangular) {
+    using Scalar = typename TestFixture::Scalar;
+    using Real = typename TestFixture::Real;
+    constexpr Backend B = TestFixture::B;
+
+    const int m = 192;
+    const int n = 64;
+    const int k = std::min(m, n);
+    const int batch = 2;
+
+    auto A = Matrix<Scalar, MatrixFormat::Dense>::Random(m, n, false, batch, 8101);
+    Matrix<Scalar, MatrixFormat::Dense> A_ref(m, n, batch);
+    MatrixView<Scalar, MatrixFormat::Dense>::copy(*this->ctx, A_ref.view(), A.view()).wait();
+
+    UnifiedVector<Real> s(static_cast<size_t>(k) * static_cast<size_t>(batch));
+    Matrix<Scalar, MatrixFormat::Dense> U(m, k, batch);      // thin: m x k, not m x m
+    Matrix<Scalar, MatrixFormat::Dense> Vh(k, n, batch);     // k == n here, so this is full
+
+    const std::string err = run_gesvd_with_provider<Scalar, B>(*this->ctx, A, s, U, Vh,
+                                                               SvdVectors::Thin,
+                                                               SvdVectors::Thin,
+                                                               nullptr);
+    ASSERT_TRUE(err.empty()) << err;
+
+    expect_singular_values_match_lapacke(A_ref, s, gesvd_sv_tol<Real>());
+    expect_orthonormal_columns(U);
+    expect_orthonormal_rows(Vh);
+    expect_reconstruction(A_ref, s, U, Vh);
+}
+
+TYPED_TEST(GesvdTest, ThinWideRectangular) {
+    using Scalar = typename TestFixture::Scalar;
+    using Real = typename TestFixture::Real;
+    constexpr Backend B = TestFixture::B;
+
+    // m < n takes the transpose branch, where the thin factor is V^H and the
+    // workspace view it is produced through (ut_view) had to become rectangular.
+    const int m = 64;
+    const int n = 192;
+    const int k = std::min(m, n);
+    const int batch = 2;
+
+    auto A = Matrix<Scalar, MatrixFormat::Dense>::Random(m, n, false, batch, 8102);
+    Matrix<Scalar, MatrixFormat::Dense> A_ref(m, n, batch);
+    MatrixView<Scalar, MatrixFormat::Dense>::copy(*this->ctx, A_ref.view(), A.view()).wait();
+
+    UnifiedVector<Real> s(static_cast<size_t>(k) * static_cast<size_t>(batch));
+    Matrix<Scalar, MatrixFormat::Dense> U(m, k, batch);      // k == m here, so this is full
+    Matrix<Scalar, MatrixFormat::Dense> Vh(k, n, batch);     // thin: k x n, not n x n
+
+    const std::string err = run_gesvd_with_provider<Scalar, B>(*this->ctx, A, s, U, Vh,
+                                                               SvdVectors::Thin,
+                                                               SvdVectors::Thin,
+                                                               nullptr);
+    ASSERT_TRUE(err.empty()) << err;
+
+    expect_singular_values_match_lapacke(A_ref, s, gesvd_sv_tol<Real>());
+    expect_orthonormal_columns(U);
+    expect_orthonormal_rows(Vh);
+    expect_reconstruction(A_ref, s, U, Vh);
+}
+
+// The point of the whole item: a thin request must not pay the full U cost,
+// in U *or* in the workspace. Without the direct-bidiag forcing rule the
+// m x m allocation simply migrates into the scratch buffer and the caller
+// still cannot run the shape.
+TYPED_TEST(GesvdTest, ThinWorkspaceIsSmallerThanFull) {
+    using Scalar = typename TestFixture::Scalar;
+    using Real = typename TestFixture::Real;
+    constexpr Backend B = TestFixture::B;
+
+    if constexpr (B != Backend::CUDA && B != Backend::ROCM) {
+        GTEST_SKIP() << "Native blocked provider is only dispatched on GPU backends.";
+    } else {
+        const int m = 512;
+        const int n = 32;
+        const int k = std::min(m, n);
+        const int batch = 2;
+
+        Matrix<Scalar, MatrixFormat::Dense> A(m, n, batch);
+        UnifiedVector<Real> s(static_cast<size_t>(k) * static_cast<size_t>(batch));
+
+        Matrix<Scalar, MatrixFormat::Dense> U_full(m, m, batch);
+        Matrix<Scalar, MatrixFormat::Dense> Vh_full(n, n, batch);
+        const size_t ws_full = gesvd_buffer_size<B, Scalar>(
+            *this->ctx, A.view(), s.to_span(), U_full.view(), Vh_full.view(),
+            SvdVectors::All, SvdVectors::All);
+
+        Matrix<Scalar, MatrixFormat::Dense> U_thin(m, k, batch);
+        Matrix<Scalar, MatrixFormat::Dense> Vh_thin(k, n, batch);
+        const size_t ws_thin = gesvd_buffer_size<B, Scalar>(
+            *this->ctx, A.view(), s.to_span(), U_thin.view(), Vh_thin.view(),
+            SvdVectors::Thin, SvdVectors::Thin);
+
+        EXPECT_LT(ws_thin, ws_full)
+            << "thin workspace " << ws_thin << " is not smaller than full " << ws_full;
+    }
+}
+
+// Thin must be an economy mode, not a differently-computed answer.
+TYPED_TEST(GesvdTest, ThinMatchesFullLeadingColumns) {
+    using Scalar = typename TestFixture::Scalar;
+    using Real = typename TestFixture::Real;
+    constexpr Backend B = TestFixture::B;
+
+    const int m = 96;
+    const int n = 48;
+    const int k = std::min(m, n);
+    const int batch = 2;
+
+    auto A_full = Matrix<Scalar, MatrixFormat::Dense>::Random(m, n, false, batch, 8103);
+    Matrix<Scalar, MatrixFormat::Dense> A_thin(m, n, batch);
+    MatrixView<Scalar, MatrixFormat::Dense>::copy(*this->ctx, A_thin.view(), A_full.view()).wait();
+
+    UnifiedVector<Real> s_full(static_cast<size_t>(k) * static_cast<size_t>(batch));
+    Matrix<Scalar, MatrixFormat::Dense> U_full(m, m, batch), Vh_full(n, n, batch);
+    const std::string err_full = run_gesvd_with_provider<Scalar, B>(
+        *this->ctx, A_full, s_full, U_full, Vh_full, SvdVectors::All, SvdVectors::All, nullptr);
+    ASSERT_TRUE(err_full.empty()) << err_full;
+
+    UnifiedVector<Real> s_thin(static_cast<size_t>(k) * static_cast<size_t>(batch));
+    Matrix<Scalar, MatrixFormat::Dense> U_thin(m, k, batch), Vh_thin(k, n, batch);
+    const std::string err_thin = run_gesvd_with_provider<Scalar, B>(
+        *this->ctx, A_thin, s_thin, U_thin, Vh_thin, SvdVectors::Thin, SvdVectors::Thin, nullptr);
+    ASSERT_TRUE(err_thin.empty()) << err_thin;
+
+    const Real sv_tol = gesvd_sv_tol<Real>();
+    for (int b = 0; b < batch; ++b) {
+        for (int i = 0; i < k; ++i) {
+            EXPECT_NEAR(static_cast<double>(s_thin[static_cast<size_t>(b) * k + i]),
+                        static_cast<double>(s_full[static_cast<size_t>(b) * k + i]),
+                        static_cast<double>(sv_tol))
+                << "sigma mismatch b=" << b << " i=" << i;
+        }
+        auto Uf = U_full.view().batch_item(b);
+        auto Ut = U_thin.view().batch_item(b);
+        for (int c = 0; c < k; ++c) {
+            // |<u_thin, u_full>| == 1: a singular vector's sign/phase is not
+            // determined, so an entrywise comparison would be wrong.
+            Scalar acc = Scalar(0);
+            for (int i = 0; i < m; ++i) acc += conj_value(Ut(i, c, 0)) * Uf(i, c, 0);
+            EXPECT_NEAR(static_cast<double>(std::abs(acc)), 1.0, 1e-2)
+                << "U column " << c << " differs at b=" << b;
+        }
+    }
+}
+
+// gesvd_cta cannot produce a genuinely thin factor: mode CTA always takes the
+// normal-equations branch, whose patch_zero_left_vectors writes m columns of U
+// unconditionally. Two different things are asserted here, and they differ:
+//
+//  * A DIRECT gesvd_cta call must throw. Silently writing m columns into a U
+//    that has k is an overrun.
+//  * Going through gesvd() with BATCHLAS_GESVD_PROVIDER=cta must still return
+//    the right answer. Dispatch resets an unsupported forced provider to Auto
+//    (gesvd.hh), so the request lands on a route that can serve it. That
+//    degrade is pre-existing behaviour shared by every provider, not something
+//    specific to Thin -- which is exactly why "it ran" is never by itself
+//    evidence that a forced provider was used.
+TYPED_TEST(GesvdTest, CtaRejectsGenuinelyThinButDispatchStillSucceeds) {
+    using Scalar = typename TestFixture::Scalar;
+    using Real = typename TestFixture::Real;
+    constexpr Backend B = TestFixture::B;
+
+    if constexpr (B != Backend::CUDA && B != Backend::ROCM) {
+        GTEST_SKIP() << "Native CTA provider is only dispatched on GPU backends.";
+    } else {
+        const int m = 32, n = 8, k = 8, batch = 2;
+        auto A = Matrix<Scalar, MatrixFormat::Dense>::Random(m, n, false, batch, 8104);
+        Matrix<Scalar, MatrixFormat::Dense> A_ref(m, n, batch);
+        MatrixView<Scalar, MatrixFormat::Dense>::copy(*this->ctx, A_ref.view(), A.view()).wait();
+
+        UnifiedVector<Real> s(static_cast<size_t>(k) * static_cast<size_t>(batch));
+        Matrix<Scalar, MatrixFormat::Dense> U(m, k, batch), Vh(k, n, batch);
+
+        EXPECT_THROW(
+            (gesvd_cta_buffer_size<B, Scalar>(*this->ctx, A.view(), s.to_span(),
+                                              U.view(), Vh.view(),
+                                              SvdVectors::Thin, SvdVectors::Thin)),
+            std::invalid_argument);
+
+        const std::string err = run_gesvd_with_provider<Scalar, B>(
+            *this->ctx, A, s, U, Vh, SvdVectors::Thin, SvdVectors::Thin, "cta");
+        ASSERT_TRUE(err.empty()) << err;
+        expect_orthonormal_columns(U);
+        expect_reconstruction(A_ref, s, U, Vh);
+    }
+}
+
+// The only test of the direct-bidiag forcing rule. Without it, a thin tall U
+// under BATCHLAS_GESVD_BIDIAG=normal reaches patch_zero_left_vectors, which
+// writes m columns into a U that has only k.
+TYPED_TEST(GesvdTest, ThinTallUnderNormalEquationsBidiag) {
+    using Scalar = typename TestFixture::Scalar;
+    using Real = typename TestFixture::Real;
+    constexpr Backend B = TestFixture::B;
+
+    if constexpr (B != Backend::CUDA && B != Backend::ROCM) {
+        GTEST_SKIP() << "Native blocked provider is only dispatched on GPU backends.";
+    } else {
+        ScopedEnvVar bidiag("BATCHLAS_GESVD_BIDIAG", "normal");
+
+        const int m = 128, n = 48;
+        const int k = std::min(m, n);
+        const int batch = 2;
+
+        auto A = Matrix<Scalar, MatrixFormat::Dense>::Random(m, n, false, batch, 8105);
+        Matrix<Scalar, MatrixFormat::Dense> A_ref(m, n, batch);
+        MatrixView<Scalar, MatrixFormat::Dense>::copy(*this->ctx, A_ref.view(), A.view()).wait();
+
+        UnifiedVector<Real> s(static_cast<size_t>(k) * static_cast<size_t>(batch));
+        Matrix<Scalar, MatrixFormat::Dense> U(m, k, batch), Vh(k, n, batch);
+
+        const std::string err = run_gesvd_with_provider<Scalar, B>(*this->ctx, A, s, U, Vh,
+                                                                   SvdVectors::Thin,
+                                                                   SvdVectors::Thin,
+                                                                   nullptr);
+        ASSERT_TRUE(err.empty()) << err;
+
+        expect_orthonormal_columns(U);
+        expect_reconstruction(A_ref, s, U, Vh);
+    }
+}

--- a/tests/gesvd_tests.cc
+++ b/tests/gesvd_tests.cc
@@ -129,8 +129,27 @@ protected:
     }
 };
 
+// Complex GENERAL input, as distinct from the Hermitian-complex fixture above.
+// The suite had no such case at all: gesvd_supports_blocked declines complex,
+// so before gesvdj_cta covered the 33..64 band these shapes fell through to
+// Vendor and threw.
+template <typename Config>
+class GesvdGeneralComplexTest : public test_utils::BatchLASTest<Config> {
+protected:
+    using Scalar = typename Config::ScalarType;
+    using Real = typename base_type<Scalar>::type;
+    static constexpr Backend B = Config::BackendVal;
+
+    // Mirrors gesvd_jacobi_max_dim: complex<double> with vectors does not fit
+    // local memory at the C=64 rung on this device.
+    static constexpr int max_dim_with_vectors() {
+        return std::is_same_v<Scalar, std::complex<double>> ? 32 : 64;
+    }
+};
+
 TYPED_TEST_SUITE(GesvdTest, GesvdTestTypes);
 TYPED_TEST_SUITE(GesvdHermitianComplexTest, GesvdHermitianComplexTestTypes);
+TYPED_TEST_SUITE(GesvdGeneralComplexTest, GesvdHermitianComplexTestTypes);
 
 template <typename T>
 inline T conj_value(const T& value) {
@@ -1575,5 +1594,90 @@ TYPED_TEST(GesvdTest, BlockedGebrdMatchesUnblockedAtSmallN) {
         }
         expect_orthonormal_columns(U_blk);
         expect_reconstruction(A_ref, s_blk, U_blk, Vh_blk);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Complex GENERAL SVD above n = 32 (follow-up item 5).
+//
+// This used to throw. gesvd_supports_blocked returns false for complex and
+// gesvd_supports_cta does too outside the Hermitian branch, so complex general
+// input fell through to Vendor, whose only binding is gesvdjBatched at
+// max(m,n) <= 32. Widening gesvdj_cta to 64 is what closes the band.
+//
+// Note the follow-up list attributes "18 gesvd_tests cases skip for this" to
+// this gap. That is not so: all 18 skips are NETLIB-backend skips of GPU-only
+// provider tests, none of them would newly pass, and there was no complex
+// GENERAL case in the suite to un-skip. These are new.
+// ---------------------------------------------------------------------------
+
+TYPED_TEST(GesvdGeneralComplexTest, GeneralComplexAboveThirtyTwo) {
+    using Scalar = typename TestFixture::Scalar;
+    using Real = typename TestFixture::Real;
+    constexpr Backend B = TestFixture::B;
+
+    if constexpr (B != Backend::CUDA && B != Backend::ROCM) {
+        GTEST_SKIP() << "Native gesvd providers are only dispatched on GPU backends.";
+    } else {
+        if (TestFixture::max_dim_with_vectors() < 64) {
+            GTEST_SKIP() << "complex<double> with vectors is capped at 32 (local memory)";
+        }
+
+        struct Shape { int m; int n; };
+        const Shape shapes[] = {{48, 48}, {64, 40}, {40, 64}};
+
+        for (const auto& sh : shapes) {
+            SCOPED_TRACE("m=" + std::to_string(sh.m) + " n=" + std::to_string(sh.n));
+            const int k = std::min(sh.m, sh.n);
+            const int batch = 2;
+
+            // hermitian=false: this is the GENERAL path, not the Hermitian one.
+            auto A = Matrix<Scalar, MatrixFormat::Dense>::Random(sh.m, sh.n, false, batch, 6161);
+            Matrix<Scalar, MatrixFormat::Dense> A_ref(sh.m, sh.n, batch);
+            MatrixView<Scalar, MatrixFormat::Dense>::copy(*this->ctx, A_ref.view(), A.view()).wait();
+
+            UnifiedVector<Real> s(static_cast<size_t>(k) * batch);
+            Matrix<Scalar, MatrixFormat::Dense> U(sh.m, sh.m, batch);
+            Matrix<Scalar, MatrixFormat::Dense> Vh(sh.n, sh.n, batch);
+
+            // nullptr => the Auto order. Reaching a result at all is the point.
+            const std::string err = run_gesvd_with_provider<Scalar, B>(
+                *this->ctx, A, s, U, Vh, SvdVectors::All, SvdVectors::All, nullptr);
+            ASSERT_TRUE(err.empty()) << err;
+
+            for (int b = 0; b < batch; ++b) {
+                for (int i = 1; i < k; ++i) {
+                    const size_t idx = static_cast<size_t>(b) * k;
+                    EXPECT_LE(s[idx + i], s[idx + i - 1] * Real(1 + 1e-4))
+                        << "sigma not descending at b=" << b << " i=" << i;
+                }
+            }
+            expect_orthonormal_columns(U);
+            expect_orthonormal_rows(Vh);
+            expect_reconstruction(A_ref, s, U, Vh);
+        }
+    }
+}
+
+// Above the Jacobi cap there is still no complex general route, and it must
+// fail loudly rather than return something. This is also what proves the test
+// above is exercising the new band rather than some pre-existing path.
+TYPED_TEST(GesvdGeneralComplexTest, GeneralComplexAboveCapStillRefused) {
+    using Scalar = typename TestFixture::Scalar;
+    using Real = typename TestFixture::Real;
+    constexpr Backend B = TestFixture::B;
+
+    if constexpr (B != Backend::CUDA && B != Backend::ROCM) {
+        GTEST_SKIP() << "Native gesvd providers are only dispatched on GPU backends.";
+    } else {
+        const int n = 96, batch = 2;
+        auto A = Matrix<Scalar, MatrixFormat::Dense>::Random(n, n, false, batch, 6162);
+        UnifiedVector<Real> s(static_cast<size_t>(n) * batch);
+        Matrix<Scalar, MatrixFormat::Dense> U(n, n, batch), Vh(n, n, batch);
+
+        const std::string err = run_gesvd_with_provider<Scalar, B>(
+            *this->ctx, A, s, U, Vh, SvdVectors::All, SvdVectors::All, nullptr);
+        EXPECT_FALSE(err.empty())
+            << "complex general at n=96 silently produced a result; there is no route for it";
     }
 }

--- a/tests/gesvd_tests.cc
+++ b/tests/gesvd_tests.cc
@@ -1482,3 +1482,98 @@ TYPED_TEST(GesvdTest, ThinTallUnderNormalEquationsBidiag) {
         expect_reconstruction(A_ref, s, U, Vh);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Tall input with min(m, n) <= 32.
+//
+// This band had no coverage at all, which is why it stayed 64-179x slow. It
+// needs min(m,n) <= 32 to reach the blocked provider's small-n branch and
+// m > 32 for the level-2 bidiagonalisation to hurt, and until the gesvd
+// benchmarks took m and n separately, every one of them built a square
+// Random(n, n). The CTA and Jacobi predicates both require max(m,n) <= 32, so
+// these shapes reach neither -- they are blocked-provider-only by construction.
+// ---------------------------------------------------------------------------
+TYPED_TEST(GesvdTest, TallNarrowBelowCtaCap) {
+    using Scalar = typename TestFixture::Scalar;
+    using Real = typename TestFixture::Real;
+    constexpr Backend B = TestFixture::B;
+
+    if constexpr (B != Backend::CUDA && B != Backend::ROCM) {
+        GTEST_SKIP() << "Native blocked provider is only dispatched on GPU backends.";
+    } else {
+        struct Shape { int m; int n; };
+        const Shape shapes[] = {{256, 8}, {256, 16}, {512, 32}};
+
+        for (const auto& sh : shapes) {
+            SCOPED_TRACE("m=" + std::to_string(sh.m) + " n=" + std::to_string(sh.n));
+            const int k = std::min(sh.m, sh.n);
+            const int batch = 3;
+
+            auto A = Matrix<Scalar, MatrixFormat::Dense>::Random(sh.m, sh.n, false, batch, 9101);
+            Matrix<Scalar, MatrixFormat::Dense> A_ref(sh.m, sh.n, batch);
+            MatrixView<Scalar, MatrixFormat::Dense>::copy(*this->ctx, A_ref.view(), A.view()).wait();
+
+            UnifiedVector<Real> s(static_cast<size_t>(k) * batch);
+            Matrix<Scalar, MatrixFormat::Dense> U(sh.m, k, batch);
+            Matrix<Scalar, MatrixFormat::Dense> Vh(k, sh.n, batch);
+
+            // nullptr => the Auto order, which must land on Blocked here.
+            const std::string err = run_gesvd_with_provider<Scalar, B>(
+                *this->ctx, A, s, U, Vh, SvdVectors::Thin, SvdVectors::Thin, nullptr);
+            ASSERT_TRUE(err.empty()) << err;
+
+            expect_singular_values_match_lapacke(A_ref, s, gesvd_sv_tol<Real>());
+            expect_orthonormal_columns(U);
+            expect_orthonormal_rows(Vh);
+            expect_reconstruction(A_ref, s, U, Vh);
+        }
+    }
+}
+
+// The blocked bidiagonalisation must agree with the unblocked one it now
+// replaces at small n. BATCHLAS_GESVD_BLOCKED_GEBRD_MIN restores the old path,
+// so this is differential rather than absolute.
+TYPED_TEST(GesvdTest, BlockedGebrdMatchesUnblockedAtSmallN) {
+    using Scalar = typename TestFixture::Scalar;
+    using Real = typename TestFixture::Real;
+    constexpr Backend B = TestFixture::B;
+
+    if constexpr (B != Backend::CUDA && B != Backend::ROCM) {
+        GTEST_SKIP() << "Native blocked provider is only dispatched on GPU backends.";
+    } else {
+        const int m = 192, n = 16, k = 16, batch = 3;
+
+        auto A_ref = Matrix<Scalar, MatrixFormat::Dense>::Random(m, n, false, batch, 9102);
+        Matrix<Scalar, MatrixFormat::Dense> A_blk(m, n, batch), A_unb(m, n, batch);
+        MatrixView<Scalar, MatrixFormat::Dense>::copy(*this->ctx, A_blk.view(), A_ref.view()).wait();
+        MatrixView<Scalar, MatrixFormat::Dense>::copy(*this->ctx, A_unb.view(), A_ref.view()).wait();
+
+        UnifiedVector<Real> s_blk(static_cast<size_t>(k) * batch), s_unb(static_cast<size_t>(k) * batch);
+        Matrix<Scalar, MatrixFormat::Dense> U_blk(m, k, batch), Vh_blk(k, n, batch);
+        Matrix<Scalar, MatrixFormat::Dense> U_unb(m, k, batch), Vh_unb(k, n, batch);
+
+        {
+            const std::string err = run_gesvd_with_provider<Scalar, B>(
+                *this->ctx, A_blk, s_blk, U_blk, Vh_blk, SvdVectors::Thin, SvdVectors::Thin, "blocked");
+            ASSERT_TRUE(err.empty()) << "blocked gebrd: " << err;
+        }
+        {
+            ScopedEnvVar old_path("BATCHLAS_GESVD_BLOCKED_GEBRD_MIN", "9999");
+            const std::string err = run_gesvd_with_provider<Scalar, B>(
+                *this->ctx, A_unb, s_unb, U_unb, Vh_unb, SvdVectors::Thin, SvdVectors::Thin, "blocked");
+            ASSERT_TRUE(err.empty()) << "unblocked gebrd: " << err;
+        }
+
+        const Real sv_tol = gesvd_sv_tol<Real>();
+        for (int b = 0; b < batch; ++b) {
+            for (int i = 0; i < k; ++i) {
+                const size_t idx = static_cast<size_t>(b) * k + i;
+                EXPECT_NEAR(static_cast<double>(s_blk[idx]), static_cast<double>(s_unb[idx]),
+                            static_cast<double>(sv_tol))
+                    << "sigma b=" << b << " i=" << i;
+            }
+        }
+        expect_orthonormal_columns(U_blk);
+        expect_reconstruction(A_ref, s_blk, U_blk, Vh_blk);
+    }
+}

--- a/tests/gesvd_tests.cc
+++ b/tests/gesvd_tests.cc
@@ -108,8 +108,12 @@ protected:
     using Real = typename base_type<Scalar>::type;
     static constexpr Backend B = Config::BackendVal;
 
+    // Guards the values-only result against LAPACKE at n=8, absolute. Was
+    // 5e-2, which at sigma_max ~ 3 is a 1.6% relative check; tightening the
+    // three constants above without this one would just leave the loosest
+    // guard here.
     static constexpr Real tol() {
-        return std::is_same_v<Real, float> ? Real(5e-2f) : Real(1e-10);
+        return std::is_same_v<Real, float> ? Real(2e-3f) : Real(1e-10);
     }
 };
 
@@ -121,7 +125,7 @@ protected:
     static constexpr Backend B = Config::BackendVal;
 
     static constexpr Real tol() {
-        return std::is_same_v<Real, float> ? Real(8e-2f) : Real(1e-10);
+        return std::is_same_v<Real, float> ? Real(5e-3f) : Real(1e-10);
     }
 };
 
@@ -308,19 +312,72 @@ TYPED_TEST(GesvdTest, ValuesOnlyMatchesLapacke) {
 
 namespace {
 
+// The float constants used to be 5e-2 / 2e-1 / 3e-1. Those predate any path
+// accurate enough to justify tightening them, and they had stopped guarding
+// anything: 3e-1 permits a 30% relative reconstruction error against a measured
+// ~1.3e-6 on these shapes.
+//
+// Chosen with margin over BOTH error sources, not only ours. The reference is
+// LAPACKE_sgesvd in the SAME precision, whose own error is about
+// eps_f32 * sigma_max ~= 1.1e-6 absolute at n=64; the test matrices are
+// Random(-1,1), so sigma_max ~= 2*sqrt(n)/sqrt(3) ~= 9.2 there, and the
+// singular-value check is ABSOLUTE.
+//
+// These were fitted by measurement across every provider and all three
+// BATCHLAS_GESVD_BIDIAG settings, which is the sweep that matters: a value
+// tuned only against the bdsdc default will fail the =normal path, whose
+// relative error reaches 4e-1 at kappa=1e4.
+// BATCHLAS_GESVD_BIDIAG=normal selects the OLD normal-equations bidiagonal
+// path, which is retained purely so the three solvers can be A/B'd. It forms
+// the tridiagonal of B^T B, so it squares the condition number and reaches ~4e-1
+// relative error at kappa=1e4 -- it cannot meet the tolerances the default path
+// meets, and it is not supposed to.
+//
+// So the tolerances are solver-aware rather than pinned to the worst path. The
+// alternative was to keep 3e-1 forever, which is what made these guards
+// vacuous in the first place; the alternative after that was to let the =normal
+// A/B arm fail, which would quietly train people to ignore a red suite.
+inline bool gesvd_bidiag_is_normal_equations() {
+    const char* v = std::getenv("BATCHLAS_GESVD_BIDIAG");
+    return v != nullptr && std::string(v) == "normal";
+}
+
+// The float constants used to be 5e-2 / 2e-1 / 3e-1. Those predate any path
+// accurate enough to justify tightening them, and they had stopped guarding
+// anything: 3e-1 permits a 30% relative reconstruction error against a measured
+// ~1.3e-6 on these shapes.
+//
+// Chosen with margin over BOTH error sources, not only ours. The reference is
+// LAPACKE_sgesvd in the SAME precision, whose own error is about
+// eps_f32 * sigma_max ~= 1.1e-6 absolute at n=64; the test matrices are
+// Random(-1,1), so sigma_max ~= 2*sqrt(n)/sqrt(3) ~= 9.2 there, and the
+// singular-value check is ABSOLUTE. Verified against every provider and all
+// three BATCHLAS_GESVD_BIDIAG settings.
 template <typename Real>
-constexpr Real gesvd_sv_tol() {
-    return std::is_same_v<Real, float> ? Real(5e-2f) : Real(1e-10);
+inline Real gesvd_sv_tol() {
+    if constexpr (std::is_same_v<Real, float>) {
+        return gesvd_bidiag_is_normal_equations() ? Real(5e-2f) : Real(2e-3f);
+    } else {
+        return Real(1e-10);
+    }
 }
 
 template <typename Real>
-constexpr Real gesvd_ortho_tol() {
-    return std::is_same_v<Real, float> ? Real(2e-1f) : Real(5e-8);
+inline Real gesvd_ortho_tol() {
+    if constexpr (std::is_same_v<Real, float>) {
+        return gesvd_bidiag_is_normal_equations() ? Real(2e-1f) : Real(1e-3f);
+    } else {
+        return Real(5e-8);
+    }
 }
 
 template <typename Real>
-constexpr Real gesvd_recon_tol() {
-    return std::is_same_v<Real, float> ? Real(3e-1f) : Real(1e-8);
+inline Real gesvd_recon_tol() {
+    if constexpr (std::is_same_v<Real, float>) {
+        return gesvd_bidiag_is_normal_equations() ? Real(3e-1f) : Real(1e-4f);
+    } else {
+        return Real(1e-8);
+    }
 }
 
 #if BATCHLAS_HAS_HOST_BACKEND

--- a/tests/gesvd_tests.cc
+++ b/tests/gesvd_tests.cc
@@ -1013,3 +1013,182 @@ TYPED_TEST(GesvdTest, BlockedProviderLargeTallRectangularFullVectors) {
         expect_reconstruction(A_ref, s, U, Vh, recon_tol);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Default-provider routing for n <= 32.
+//
+// gesvdj_cta used to sit behind BatchLAS_CTA in the shared provider order, so
+// Auto never reached it for real input. The CTA path forms the normal
+// equations; measured at n=32/float/256 samples, its singular-value relative
+// error runs 1.4e-6 -> 3.1e-3 -> 0.235 -> 1.857 across log10(kappa) 1..6 while
+// gesvdj_cta holds 4.8e-6 -> 1.2e-5 -> 7.1e-5 -> 5.6e-3. The order is now
+// per-op (blas/dispatch/env.hh) and Jacobi leads for gesvd.
+//
+// These two tests guard that from opposite sides: the first pins the dispatch
+// decision itself, the second pins the numerical consequence on the default
+// path, so neither a reordering nor a predicate change can quietly undo it.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// A = H(u) * diag(sigma) * H(v), with H(x) = I - 2 x x^T the Householder
+// reflector of a unit vector x. Both factors are orthogonal, so the singular
+// values of A are exactly sigma -- no reference solve is needed.
+//
+// It has to be DENSE to discriminate here. make_repeated_tiny_spectrum_matrix
+// above builds a diagonal matrix, whose columns are already orthogonal: Jacobi
+// converges in zero sweeps and A^T A is diagonal, so the normal-equation path
+// is exact too and the two are indistinguishable however ill-conditioned the
+// spectrum is.
+template <typename Scalar>
+Matrix<Scalar, MatrixFormat::Dense> make_graded_dense_matrix(int n,
+                                                            int batch,
+                                                            double log10cond) {
+    using Real = typename base_type<Scalar>::type;
+
+    std::vector<double> sigma(static_cast<size_t>(n));
+    for (int i = 0; i < n; ++i) {
+        const double t = (n > 1) ? static_cast<double>(i) / static_cast<double>(n - 1) : 0.0;
+        sigma[static_cast<size_t>(i)] = std::pow(10.0, -log10cond * t);
+    }
+
+    Matrix<Scalar, MatrixFormat::Dense> A = Matrix<Scalar, MatrixFormat::Dense>::Zeros(n, n, batch);
+
+    for (int b = 0; b < batch; ++b) {
+        // Deterministic per-batch-item reflectors; a fixed LCG keeps this
+        // reproducible without pulling in a generator that is itself suspect.
+        std::vector<double> u(static_cast<size_t>(n)), v(static_cast<size_t>(n));
+        uint64_t state = 0x9E3779B97F4A7C15ull + static_cast<uint64_t>(b) * 0x1000193ull;
+        auto next = [&state]() {
+            state = state * 6364136223846793005ull + 1442695040888963407ull;
+            return static_cast<double>((state >> 11) & ((1ull << 53) - 1)) / static_cast<double>(1ull << 53) - 0.5;
+        };
+        double nu = 0.0, nv = 0.0;
+        for (int i = 0; i < n; ++i) {
+            u[static_cast<size_t>(i)] = next();
+            v[static_cast<size_t>(i)] = next();
+            nu += u[static_cast<size_t>(i)] * u[static_cast<size_t>(i)];
+            nv += v[static_cast<size_t>(i)] * v[static_cast<size_t>(i)];
+        }
+        nu = std::sqrt(nu);
+        nv = std::sqrt(nv);
+        for (int i = 0; i < n; ++i) {
+            u[static_cast<size_t>(i)] /= nu;
+            v[static_cast<size_t>(i)] /= nv;
+        }
+
+        auto Ab = A.view().batch_item(b);
+        for (int i = 0; i < n; ++i) {
+            for (int j = 0; j < n; ++j) {
+                double acc = 0.0;
+                for (int k = 0; k < n; ++k) {
+                    const double h1 = (i == k ? 1.0 : 0.0) - 2.0 * u[static_cast<size_t>(i)] * u[static_cast<size_t>(k)];
+                    const double h2 = (k == j ? 1.0 : 0.0) - 2.0 * v[static_cast<size_t>(k)] * v[static_cast<size_t>(j)];
+                    acc += h1 * sigma[static_cast<size_t>(k)] * h2;
+                }
+                Ab(i, j, 0) = static_cast<Scalar>(static_cast<Real>(acc));
+            }
+        }
+    }
+
+    return A;
+}
+
+}  // namespace
+
+TYPED_TEST(GesvdTest, DefaultProviderRoutesSmallGeneralToJacobi) {
+    using Scalar = typename TestFixture::Scalar;
+    constexpr Backend B = TestFixture::B;
+    namespace disp = batchlas::blas::dispatch;
+
+    if constexpr (B != Backend::CUDA && B != Backend::ROCM) {
+        GTEST_SKIP() << "Native gesvd providers are only dispatched on GPU backends.";
+    } else {
+        const disp::DeviceCaps caps = disp::query_caps(*this->ctx);
+        const disp::DispatchPolicy policy = disp::policy_from_env("GESVD");
+
+        // A stray BATCHLAS_GESVD_PROVIDER in the environment would make every
+        // expectation below pass or fail for the wrong reason.
+        ASSERT_EQ(policy.forced, disp::Provider::Auto)
+            << "BATCHLAS_GESVD_PROVIDER is set; this test asserts the Auto order";
+
+        Matrix<Scalar, MatrixFormat::Dense> A(32, 32, 2);
+
+        // Every job combination at n <= 32, including values-only: the CTA path
+        // is ~2.2x faster values-only at n=32 but has no correct digits past
+        // kappa = 1e3, so it is not the default for any of them.
+        for (SvdVectors jobu : {SvdVectors::None, SvdVectors::All}) {
+            for (SvdVectors jobvh : {SvdVectors::None, SvdVectors::All}) {
+                EXPECT_EQ(disp::detail::choose_gesvd_provider(policy, caps, A.view(), jobu, jobvh),
+                          disp::Provider::BatchLAS_Jacobi)
+                    << "jobu=" << static_cast<int>(jobu)
+                    << " jobvh=" << static_cast<int>(jobvh);
+            }
+        }
+
+        // Hermitian input is untouched: gesvd_supports_jacobi declines it, so
+        // these still land on the CTA path.
+        EXPECT_EQ(disp::detail::choose_gesvd_provider(policy, caps, A.view(),
+                                                      SvdVectors::All, SvdVectors::All, Uplo::Lower),
+                  disp::Provider::BatchLAS_CTA);
+
+        // And n > 32 still reaches the blocked path rather than being captured
+        // by the promoted Jacobi entry.
+        Matrix<Scalar, MatrixFormat::Dense> Big(64, 64, 2);
+        EXPECT_EQ(disp::detail::choose_gesvd_provider(policy, caps, Big.view(),
+                                                      SvdVectors::All, SvdVectors::All),
+                  disp::Provider::BatchLAS_Blocked);
+    }
+}
+
+TYPED_TEST(GesvdTest, DefaultProviderKeepsSingularValuesAtHighCondition) {
+    using Scalar = typename TestFixture::Scalar;
+    using Real = typename TestFixture::Real;
+    constexpr Backend B = TestFixture::B;
+
+    if constexpr (B != Backend::CUDA && B != Backend::ROCM) {
+        GTEST_SKIP() << "Native gesvd providers are only dispatched on GPU backends.";
+    } else {
+        const int n = 32;
+        const int batch = 4;
+        const double log10cond = 5.0;
+
+        auto A = make_graded_dense_matrix<Scalar>(n, batch, log10cond);
+
+        UnifiedVector<Real> s(static_cast<size_t>(n) * static_cast<size_t>(batch));
+        Matrix<Scalar, MatrixFormat::Dense> U(n, n, batch);
+        Matrix<Scalar, MatrixFormat::Dense> Vh(n, n, batch);
+
+        // nullptr => no BATCHLAS_GESVD_PROVIDER override, i.e. the Auto order.
+        const std::string err = run_gesvd_with_provider<Scalar, B>(*this->ctx,
+                                                                   A,
+                                                                   s,
+                                                                   U,
+                                                                   Vh,
+                                                                   SvdVectors::All,
+                                                                   SvdVectors::All,
+                                                                   nullptr);
+        ASSERT_TRUE(err.empty()) << err;
+
+        std::vector<Real> expected(static_cast<size_t>(n));
+        for (int i = 0; i < n; ++i) {
+            const double t = static_cast<double>(i) / static_cast<double>(n - 1);
+            expected[static_cast<size_t>(i)] = static_cast<Real>(std::pow(10.0, -log10cond * t));
+        }
+
+        // RELATIVE error, per singular value -- the quantity the normal-equation
+        // path destroys and an absolute check cannot see. At kappa = 1e5 the CTA
+        // path measures ~1.0 here and gesvdj_cta ~6e-4, so this threshold
+        // separates them by two orders of magnitude in each direction.
+        const Real sv_rel_tol = std::is_same_v<Real, float> ? Real(1e-2f) : Real(1e-8);
+
+        for (int b = 0; b < batch; ++b) {
+            for (int i = 0; i < n; ++i) {
+                const Real got = s[static_cast<size_t>(b) * static_cast<size_t>(n) + static_cast<size_t>(i)];
+                const Real want = expected[static_cast<size_t>(i)];
+                EXPECT_LE(std::abs(got - want) / want, sv_rel_tol)
+                    << "batch " << b << " sigma[" << i << "] = " << got << ", expected " << want;
+            }
+        }
+    }
+}

--- a/tests/gesvdj_cta_tests.cc
+++ b/tests/gesvdj_cta_tests.cc
@@ -84,6 +84,13 @@ protected:
     static Real recon_tol() { return std::is_same_v<Real, float> ? Real(2e-4f) : Real(1e-11); }
     static Real ortho_tol() { return std::is_same_v<Real, float> ? Real(2e-4f) : Real(1e-11); }
 
+    // Mirrors gesvdj_cta_max_dim. complex<double> with vectors needs 138,816 B
+    // of local memory at the C=64 rung against this device's 101,376 B, so it
+    // is capped at 32 and these cases skip rather than fail.
+    static constexpr int max_dim_with_vectors() {
+        return std::is_same_v<Scalar, std::complex<double>> ? 32 : 64;
+    }
+
     // ||A - U diag(s) Vh||_F / ||A||_F, computed on the host in double.
     // u_ld / vh_ld are passed explicitly rather than assumed to be m and n:
     // a thin V^H is k x n, so its leading dimension is k, and hardcoding n
@@ -297,6 +304,77 @@ TYPED_TEST(GesvdjCtaTest, SquareRandom) {
     for (int n : {2, 5, 8, 16, 32}) {
         this->check(n, n, 3, this->random_matrix(n, n, 3, 1234u + n));
     }
+}
+
+// ---------------------------------------------------------------------------
+// The 33..64 band.
+//
+// Above 32 the kernel keeps P = 32 lanes and grows the tile capacity C to 64,
+// so each lane owns kRPL = C/P = 2 rows instead of one. Everything that
+// indexes a ROW (load, rotation apply, U completion, the non-transposed
+// writeback) gains an rr loop; everything that indexes a COLUMN or a RANK (the
+// epilogue sort, sigma writeback, the transposed writeback) gains a cc loop;
+// and the Gram reduce-scatter is chunked so its 4+1-step butterfly and the
+// lane>>1 pair mapping stay exactly as they were.
+//
+// Sizes that are not multiples of 32 matter most here: they exercise the
+// padding in the second row-slot, where an off-by-one in `row < RR` silently
+// mixes a pad row into a dot product.
+// ---------------------------------------------------------------------------
+
+TYPED_TEST(GesvdjCtaTest, SquareAboveThirtyTwo) {
+    if (TestFixture::max_dim_with_vectors() < 64) {
+        GTEST_SKIP() << "scalar type is capped below 64 with vectors (local memory)";
+    }
+    for (int n : {33, 40, 48, 63, 64}) {
+        this->check(n, n, 2, this->random_matrix(n, n, 2, 4321u + n));
+    }
+}
+
+TYPED_TEST(GesvdjCtaTest, TallRectangularAboveThirtyTwo) {
+    if (TestFixture::max_dim_with_vectors() < 64) {
+        GTEST_SKIP() << "scalar type is capped below 64 with vectors (local memory)";
+    }
+    this->check(64, 24, 2, this->random_matrix(64, 24, 2, 981u));
+    this->check(48, 33, 2, this->random_matrix(48, 33, 2, 982u));
+}
+
+TYPED_TEST(GesvdjCtaTest, WideRectangularAboveThirtyTwo) {
+    if (TestFixture::max_dim_with_vectors() < 64) {
+        GTEST_SKIP() << "scalar type is capped below 64 with vectors (local memory)";
+    }
+    // m < n takes the transposed load (A^H) and the transposed writeback, where
+    // the thin/rank bound lands on the lane index rather than the inner loop.
+    this->check(24, 64, 2, this->random_matrix(24, 64, 2, 983u));
+    this->check(33, 48, 2, this->random_matrix(33, 48, 2, 984u));
+}
+
+TYPED_TEST(GesvdjCtaTest, ThinAboveThirtyTwo) {
+    if (TestFixture::max_dim_with_vectors() < 64) {
+        GTEST_SKIP() << "scalar type is capped below 64 with vectors (local memory)";
+    }
+    this->check_thin(64, 24, 2, this->random_matrix(64, 24, 2, 985u));
+    this->check_thin(24, 64, 2, this->random_matrix(24, 64, 2, 986u));
+}
+
+TYPED_TEST(GesvdjCtaTest, RankDeficientAboveThirtyTwo) {
+    if (TestFixture::max_dim_with_vectors() < 64) {
+        GTEST_SKIP() << "scalar type is capped below 64 with vectors (local memory)";
+    }
+    // Forces the in-kernel Gram-Schmidt completion at C=64, where the trial
+    // vector is distributed over two row-slots per lane and each lane must sum
+    // its own rows before the 32-wide butterfly.
+    const int n = 48, batch = 2;
+    auto host = this->random_matrix(n, n, batch, 987u);
+    for (int b = 0; b < batch; ++b) {
+        for (int dup : {40, 41, 42}) {
+            for (int i = 0; i < n; ++i) {
+                host[static_cast<size_t>(b) * n * n + static_cast<size_t>(dup) * n + i] =
+                    host[static_cast<size_t>(b) * n * n + static_cast<size_t>(3) * n + i];
+            }
+        }
+    }
+    this->check(n, n, batch, std::move(host));
 }
 
 TYPED_TEST(GesvdjCtaTest, TallRectangular) {

--- a/tests/gesvdj_cta_tests.cc
+++ b/tests/gesvdj_cta_tests.cc
@@ -85,10 +85,13 @@ protected:
     static Real ortho_tol() { return std::is_same_v<Real, float> ? Real(2e-4f) : Real(1e-11); }
 
     // ||A - U diag(s) Vh||_F / ||A||_F, computed on the host in double.
+    // u_ld / vh_ld are passed explicitly rather than assumed to be m and n:
+    // a thin V^H is k x n, so its leading dimension is k, and hardcoding n
+    // would silently read the wrong elements.
     static double reconstruction(int m, int n, int batch,
                                  const std::vector<Scalar>& A,
-                                 const Scalar* U, int64_t u_stride,
-                                 const Scalar* Vh, int64_t vh_stride,
+                                 const Scalar* U, int64_t u_stride, int u_ld,
+                                 const Scalar* Vh, int64_t vh_stride, int vh_ld,
                                  const Real* s) {
         const int k = std::min(m, n);
         double worst = 0.0;
@@ -98,8 +101,8 @@ protected:
                 for (int i = 0; i < m; ++i) {
                     std::complex<double> acc(0.0, 0.0);
                     for (int t = 0; t < k; ++t) {
-                        const std::complex<double> u = to_cd(U[b * u_stride + static_cast<size_t>(t) * m + i]);
-                        const std::complex<double> v = to_cd(Vh[b * vh_stride + static_cast<size_t>(j) * n + t]);
+                        const std::complex<double> u = to_cd(U[b * u_stride + static_cast<size_t>(t) * u_ld + i]);
+                        const std::complex<double> v = to_cd(Vh[b * vh_stride + static_cast<size_t>(j) * vh_ld + t]);
                         acc += u * static_cast<double>(s[b * k + t]) * v;
                     }
                     const std::complex<double> a = to_cd(A[static_cast<size_t>(b) * m * n + static_cast<size_t>(j) * m + i]);
@@ -175,8 +178,8 @@ protected:
         }
 
         EXPECT_LE(reconstruction(m, n, batch, host_A,
-                                 U.view().data_ptr(), U.view().stride(),
-                                 Vh.view().data_ptr(), Vh.view().stride(),
+                                 U.view().data_ptr(), U.view().stride(), static_cast<int>(U.view().ld()),
+                                 Vh.view().data_ptr(), Vh.view().stride(), static_cast<int>(Vh.view().ld()),
                                  s.data()),
                   static_cast<double>(recon_tol()))
             << "reconstruction m=" << m << " n=" << n;
@@ -200,6 +203,77 @@ protected:
         EXPECT_LE(col_orthogonality(n, n, batch, vht.data(), static_cast<int64_t>(n) * n, n),
                   static_cast<double>(ortho_tol()))
             << "V orthogonality m=" << m << " n=" << n;
+    }
+
+    // Same validation as check(), but with U as m x k and Vh as k x n.
+    //
+    // Worth stating what this can and cannot catch on its own: for m >= n a
+    // thin V^H IS a full V^H, and for m <= n a thin U IS a full U, so exactly
+    // one side is genuinely narrower in each shape. The tall and wide cases
+    // below therefore exercise DIFFERENT code -- the tall one skips the
+    // in-kernel Gram-Schmidt completion, the wide one takes the transposed
+    // writeback where the thin bound lands on `lane` rather than on the inner
+    // loop. Both are needed.
+    void check_thin(int m, int n, int batch, std::vector<Scalar> host_A) {
+        auto& ctx = *this->ctx;
+        const int k = std::min(m, n);
+
+        Matrix<Scalar> A(m, n, batch);
+        for (int b = 0; b < batch; ++b) {
+            for (int j = 0; j < n; ++j) {
+                for (int i = 0; i < m; ++i) {
+                    A.view().data_ptr()[b * A.view().stride() + static_cast<size_t>(j) * A.view().ld() + i] =
+                        host_A[static_cast<size_t>(b) * m * n + static_cast<size_t>(j) * m + i];
+                }
+            }
+        }
+
+        Matrix<Scalar> U(m, k, batch);
+        Matrix<Scalar> Vh(k, n, batch);
+        UnifiedVector<Real> s(static_cast<size_t>(k) * batch);
+
+        gesvdj_cta<B, Scalar>(ctx, A.view(), s.to_span(), U.view(), Vh.view(),
+                              SvdVectors::Thin, SvdVectors::Thin);
+        ctx.wait_and_throw();
+
+        for (int b = 0; b < batch; ++b) {
+            for (int i = 0; i < k; ++i) {
+                EXPECT_GE(s[b * k + i], Real(0)) << "negative sigma at b=" << b << " i=" << i;
+                if (i > 0) {
+                    EXPECT_LE(s[b * k + i], s[b * k + i - 1] * (Real(1) + Real(1e-5)))
+                        << "not descending at b=" << b << " i=" << i;
+                }
+            }
+        }
+
+        // A = U S V^H must still hold exactly: the discarded columns of a full U
+        // multiply zero singular values, so thin loses nothing here.
+        EXPECT_LE(reconstruction(m, n, batch, host_A,
+                                 U.view().data_ptr(), U.view().stride(), static_cast<int>(U.view().ld()),
+                                 Vh.view().data_ptr(), Vh.view().stride(), static_cast<int>(Vh.view().ld()),
+                                 s.data()),
+                  static_cast<double>(recon_tol()))
+            << "thin reconstruction m=" << m << " n=" << n;
+
+        EXPECT_LE(col_orthogonality(m, k, batch, U.view().data_ptr(), U.view().stride(),
+                                    static_cast<int>(U.view().ld())),
+                  static_cast<double>(ortho_tol()))
+            << "thin U orthogonality m=" << m << " n=" << n;
+
+        // Vh is k x n; its k ROWS must be orthonormal, so build Vh^H (n x k)
+        // and check its columns.
+        std::vector<Scalar> vht(static_cast<size_t>(n) * k * batch);
+        for (int b = 0; b < batch; ++b) {
+            for (int j = 0; j < k; ++j) {
+                for (int i = 0; i < n; ++i) {
+                    vht[static_cast<size_t>(b) * n * k + static_cast<size_t>(j) * n + i] =
+                        conj_h(Vh.view().data_ptr()[b * Vh.view().stride() + static_cast<size_t>(i) * Vh.view().ld() + j]);
+                }
+            }
+        }
+        EXPECT_LE(col_orthogonality(n, k, batch, vht.data(), static_cast<int64_t>(n) * k, n),
+                  static_cast<double>(ortho_tol()))
+            << "thin V orthogonality m=" << m << " n=" << n;
     }
 
     std::vector<Scalar> random_matrix(int m, int n, int batch, unsigned seed) {
@@ -363,12 +437,117 @@ TYPED_TEST(GesvdjCtaTest, PublicApiDispatch) {
     ctx.wait_and_throw();
 
     EXPECT_LE(TestFixture::reconstruction(n, n, batch, host,
-                                          U.view().data_ptr(), U.view().stride(),
-                                          Vh.view().data_ptr(), Vh.view().stride(),
+                                          U.view().data_ptr(), U.view().stride(), static_cast<int>(U.view().ld()),
+                                          Vh.view().data_ptr(), Vh.view().stride(), static_cast<int>(Vh.view().ld()),
                                           s.data()),
-              // Loose: for real T this is still the normal-equations CTA path by
-              // default. The point is that it dispatches and reconstructs at all.
+              // Loose because the point of this test is that it dispatches and
+              // reconstructs at all, not how well. (It used to reach the
+              // normal-equations CTA path for real T; Auto now routes n <= 32
+              // to gesvdj_cta, so the achieved value is far below this.)
               0.3);
+}
+
+// ---------------------------------------------------------------------------
+// Thin (economy) vectors.
+// ---------------------------------------------------------------------------
+
+TYPED_TEST(GesvdjCtaTest, ThinTallRectangular) {
+    // m > n: U is the genuinely thin factor (32 x 8 instead of 32 x 32), and
+    // the in-kernel Gram-Schmidt that manufactures the other 24 columns is
+    // skipped entirely.
+    this->check_thin(32, 8, 3, this->random_matrix(32, 8, 3, 20241u));
+}
+
+TYPED_TEST(GesvdjCtaTest, ThinWideRectangular) {
+    // m < n: the kernel solves A^H, so the thin factor is written through the
+    // TRANSPOSED writeback, where the bound applies to `lane` (the rank index)
+    // rather than to the inner loop. Truncating the wrong one still produces
+    // plausible-looking output, so this shape is not redundant with the tall one.
+    this->check_thin(8, 32, 3, this->random_matrix(8, 32, 3, 20242u));
+}
+
+TYPED_TEST(GesvdjCtaTest, ThinSquareEqualsAll) {
+    // Square input: Thin and All request the same shapes, so this must behave
+    // identically to check() -- it is the canonicalisation path.
+    this->check_thin(16, 16, 3, this->random_matrix(16, 16, 3, 20243u));
+}
+
+TYPED_TEST(GesvdjCtaTest, ThinRankDeficientStillRepairsColumns) {
+    // A numerically deficient column must still be rebuilt even when no
+    // completion columns are wanted: the gate is `any_def > 0 || LC > CC`, and
+    // dropping the first disjunct would leave a zero column in a thin U that
+    // still has to be orthonormal.
+    const int m = 32, n = 8, batch = 2;
+    auto host = this->random_matrix(m, n, batch, 20244u);
+    // Force rank 6 of 8: make columns 6 and 7 copies of column 0.
+    for (int b = 0; b < batch; ++b) {
+        for (int dup : {6, 7}) {
+            for (int i = 0; i < m; ++i) {
+                host[static_cast<size_t>(b) * m * n + static_cast<size_t>(dup) * m + i] =
+                    host[static_cast<size_t>(b) * m * n + static_cast<size_t>(0) * m + i];
+            }
+        }
+    }
+    this->check_thin(m, n, batch, std::move(host));
+}
+
+TYPED_TEST(GesvdjCtaTest, ThinMatchesFullLeadingColumns) {
+    // The thin U must be the first k columns of the full U, up to a per-column
+    // sign (real) or unit phase (complex). This is what makes Thin a genuine
+    // economy mode rather than a differently-computed answer.
+    using Scalar = typename TestFixture::Scalar;
+    using Real = typename TestFixture::Real;
+    constexpr Backend B = TestFixture::B;
+    auto& ctx = *this->ctx;
+
+    const int m = 32, n = 8, batch = 2;
+    const int k = std::min(m, n);
+    auto host = this->random_matrix(m, n, batch, 20245u);
+
+    auto load = [&](Matrix<Scalar>& A) {
+        for (int b = 0; b < batch; ++b)
+            for (int j = 0; j < n; ++j)
+                for (int i = 0; i < m; ++i)
+                    A.view().data_ptr()[b * A.view().stride() + static_cast<size_t>(j) * A.view().ld() + i] =
+                        host[static_cast<size_t>(b) * m * n + static_cast<size_t>(j) * m + i];
+    };
+
+    Matrix<Scalar> A_all(m, n, batch);
+    load(A_all);
+    Matrix<Scalar> U_all(m, m, batch), Vh_all(n, n, batch);
+    UnifiedVector<Real> s_all(static_cast<size_t>(k) * batch);
+    gesvdj_cta<B, Scalar>(ctx, A_all.view(), s_all.to_span(), U_all.view(), Vh_all.view(),
+                          SvdVectors::All, SvdVectors::All);
+    ctx.wait_and_throw();
+
+    Matrix<Scalar> A_thin(m, n, batch);
+    load(A_thin);
+    Matrix<Scalar> U_thin(m, k, batch), Vh_thin(k, n, batch);
+    UnifiedVector<Real> s_thin(static_cast<size_t>(k) * batch);
+    gesvdj_cta<B, Scalar>(ctx, A_thin.view(), s_thin.to_span(), U_thin.view(), Vh_thin.view(),
+                          SvdVectors::Thin, SvdVectors::Thin);
+    ctx.wait_and_throw();
+
+    const double tol = static_cast<double>(TestFixture::ortho_tol());
+    for (int b = 0; b < batch; ++b) {
+        for (int i = 0; i < k; ++i) {
+            EXPECT_NEAR(static_cast<double>(s_thin[b * k + i]),
+                        static_cast<double>(s_all[b * k + i]), tol)
+                << "sigma mismatch b=" << b << " i=" << i;
+        }
+        for (int c = 0; c < k; ++c) {
+            // Compare |<u_thin, u_all>| == 1 rather than entrywise: the sign or
+            // phase of a singular vector is not determined.
+            std::complex<double> acc(0.0, 0.0);
+            for (int i = 0; i < m; ++i) {
+                acc += std::conj(TestFixture::to_cd(
+                           U_thin.view().data_ptr()[b * U_thin.view().stride() + static_cast<size_t>(c) * U_thin.view().ld() + i]))
+                     * TestFixture::to_cd(
+                           U_all.view().data_ptr()[b * U_all.view().stride() + static_cast<size_t>(c) * U_all.view().ld() + i]);
+            }
+            EXPECT_NEAR(std::abs(acc), 1.0, 1e-3) << "U column " << c << " differs at b=" << b;
+        }
+    }
 }
 
 } // namespace

--- a/tests/matrix_tests.cc
+++ b/tests/matrix_tests.cc
@@ -262,3 +262,140 @@ TEST(MatrixCSRTest, ExceptionOnCopyFromMismatchedShape) {
     Matrix<float, MatrixFormat::CSR> b(3, 2, 2, 1);
     EXPECT_THROW(a.copy_from(b.view()), std::runtime_error);
 }
+
+// ---------------------------------------------------------------------------
+// triangularize
+//
+// `uplo` names the triangle to KEEP. These tests exist because the function
+// shipped with that inverted: it named the flat-index quotient the row while
+// addressing it as the column, so under column-major storage
+// triangularize(Uplo::Upper) left a LOWER triangular matrix. It had no test
+// and, in-tree, no caller, so nothing caught it -- PR #66 found it only
+// because extracting R from a geqrf result silently handed back the
+// Householder reflectors instead, which fabricated a 1.7x speedup that was
+// not real.
+//
+// Each entry is seeded with a value encoding its own (row, col), so a
+// transposed or mis-strided write shows up as a wrong *position*, not merely a
+// wrong number.
+// ---------------------------------------------------------------------------
+namespace {
+
+inline float tri_marker(int row, int col) {
+    return 100.0f * static_cast<float>(row + 1) + static_cast<float>(col + 1);
+}
+
+}  // namespace
+
+TEST(MatrixTriangularize, UpperKeepsUpperTriangle) {
+    constexpr int n = 5;
+    constexpr int batch = 2;
+    constexpr int ld = 7;      // deliberately > rows
+    constexpr int stride = 40; // deliberately > ld * cols
+
+    Queue ctx;
+    Matrix<float, MatrixFormat::Dense> mat(n, n, batch, ld, stride);
+    for (int b = 0; b < batch; ++b)
+        for (int j = 0; j < n; ++j)
+            for (int i = 0; i < n; ++i)
+                mat.data()[b * stride + j * ld + i] = tri_marker(i, j);
+
+    mat.view().triangularize(ctx, Uplo::Upper, Diag::NonUnit).wait();
+
+    for (int b = 0; b < batch; ++b) {
+        for (int j = 0; j < n; ++j) {
+            for (int i = 0; i < n; ++i) {
+                const float v = mat.data()[b * stride + j * ld + i];
+                if (i <= j) {
+                    EXPECT_FLOAT_EQ(v, tri_marker(i, j)) << "kept (" << i << "," << j << ")";
+                } else {
+                    EXPECT_FLOAT_EQ(v, 0.0f) << "strict lower (" << i << "," << j << ")";
+                }
+            }
+        }
+    }
+}
+
+TEST(MatrixTriangularize, LowerKeepsLowerTriangle) {
+    constexpr int n = 5;
+    constexpr int batch = 2;
+
+    Queue ctx;
+    Matrix<float, MatrixFormat::Dense> mat(n, n, batch);
+    const int ld = mat.view().ld();
+    const int stride = mat.view().stride();
+    for (int b = 0; b < batch; ++b)
+        for (int j = 0; j < n; ++j)
+            for (int i = 0; i < n; ++i)
+                mat.data()[b * stride + j * ld + i] = tri_marker(i, j);
+
+    mat.view().triangularize(ctx, Uplo::Lower, Diag::NonUnit).wait();
+
+    for (int b = 0; b < batch; ++b) {
+        for (int j = 0; j < n; ++j) {
+            for (int i = 0; i < n; ++i) {
+                const float v = mat.data()[b * stride + j * ld + i];
+                if (i >= j) {
+                    EXPECT_FLOAT_EQ(v, tri_marker(i, j)) << "kept (" << i << "," << j << ")";
+                } else {
+                    EXPECT_FLOAT_EQ(v, 0.0f) << "strict upper (" << i << "," << j << ")";
+                }
+            }
+        }
+    }
+}
+
+TEST(MatrixTriangularize, UnitDiagonalOverwritesDiagonal) {
+    constexpr int n = 4;
+
+    Queue ctx;
+    Matrix<float, MatrixFormat::Dense> mat(n, n, 1);
+    const int ld = mat.view().ld();
+    for (int j = 0; j < n; ++j)
+        for (int i = 0; i < n; ++i)
+            mat.data()[j * ld + i] = tri_marker(i, j);
+
+    mat.view().triangularize(ctx, Uplo::Upper, Diag::Unit).wait();
+
+    for (int j = 0; j < n; ++j) {
+        for (int i = 0; i < n; ++i) {
+            const float v = mat.data()[j * ld + i];
+            if (i == j)     EXPECT_FLOAT_EQ(v, 1.0f);
+            else if (i < j) EXPECT_FLOAT_EQ(v, tri_marker(i, j));
+            else            EXPECT_FLOAT_EQ(v, 0.0f);
+        }
+    }
+}
+
+// The element count used to come from data_.size() and the index decode from
+// rows_ alone, so a non-square view decoded its own coordinates wrongly.
+TEST(MatrixTriangularize, NonSquareTallAndWide) {
+    Queue ctx;
+
+    const std::pair<int, int> shapes[] = {{6, 3}, {3, 6}};
+    for (const auto& shape : shapes) {
+        const int rows = shape.first;
+        const int cols = shape.second;
+
+        Matrix<float, MatrixFormat::Dense> mat(rows, cols, 1);
+        const int ld = mat.view().ld();
+        for (int j = 0; j < cols; ++j)
+            for (int i = 0; i < rows; ++i)
+                mat.data()[j * ld + i] = tri_marker(i, j);
+
+        mat.view().triangularize(ctx, Uplo::Upper, Diag::NonUnit).wait();
+
+        for (int j = 0; j < cols; ++j) {
+            for (int i = 0; i < rows; ++i) {
+                const float v = mat.data()[j * ld + i];
+                if (i <= j) {
+                    EXPECT_FLOAT_EQ(v, tri_marker(i, j))
+                        << rows << "x" << cols << " kept (" << i << "," << j << ")";
+                } else {
+                    EXPECT_FLOAT_EQ(v, 0.0f)
+                        << rows << "x" << cols << " zeroed (" << i << "," << j << ")";
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Works through the "what's still missing for a truly performant batched SVD" list from #66. All six items plus the low-priority cleanups are addressed.

Two resolve as **measured negative results**, and in both cases the measurement redirected the work somewhere more valuable: item 3's QR route never wins but exposed a 179× bug, and item 4's widened kernel does not close the cliff but does deliver items 5 and 6.

Everything measured on this box (2x RTX 4090, CUDA 13.2, uncontended, `CUDA_VISIBLE_DEVICES=1`).

## 1. `gesvdj_cta` is now the default at n ≤ 32

The item proposed gating the promotion on `jobu`/`jobvh`, since the old CTA path is faster values-only. It is faster values-only — and that turns out not to be the deciding axis.

Measured head-to-head, float, n=32, 256 samples. Singular-value relative error against the known spectrum (`max_relerr`, `benchmarks/gesvd_relacc`):

| log10 κ | 1 | 2 | 3 | 4 | 5 | 6 |
|---|---|---|---|---|---|---|
| CTA | **1.4e-6** | 4.7e-5 | 3.1e-3 | 0.235 | 1.046 | 1.857 |
| `gesvdj_cta` | 4.8e-6 | **5.9e-6** | **1.2e-5** | **7.1e-5** | **6.3e-4** | **5.6e-3** |
| cuSOLVER | 4.1e-6 | 4.1e-6 | 1.1e-5 | 8.3e-5 | 7.7e-4 | 8.7e-3 |

The CTA path forms the normal equations, so it squares the condition number and loses the singular **values**, not merely the vectors — its orthogonality over the same sweep runs 2.8e-6 → 0.879 → 4.371 while Jacobi stays flat near 1.3e-5. It leads only at κ=1e1, where both are ~1e-6 and it cannot matter. Jacobi also beats cuSOLVER from κ=1e4 up.

Speed agrees wherever U is wanted, because the CTA path builds U through an assembly + back-transform chain while Jacobi gets it free (U *is* the rotated, normalised A). Per matrix, float, saturated batch, `jobu=All`: n=8 **23×**, n=16 **4.1×**, n=32 parity. Adding U costs CTA 17× at n=8 (0.065 → 1.126 µs) and costs Jacobi nothing (0.0448 → 0.0452 µs).

So there is no predicate. The one regime where CTA genuinely wins is values-only at n ≥ 16 (2.2× at n=32), and that is exactly where it has no correct digits past κ=1e3. A 2.2× that returns 1.857 relative error is not a default; it stays reachable via `BATCHLAS_GESVD_PROVIDER=cta`.

The provider order is now per-op (`default_order_for_op` already carried an "extend per-op later" note). Safe because no other op's chooser matches `BatchLAS_Jacobi` at all. Hermitian is unaffected — `gesvd_supports_jacobi` declines it, so those calls still take the CTA path.

Two tests guard it from opposite sides: one pins the dispatch decision for all four job combinations plus the Hermitian and n>32 cases that must **not** move; the other pins the numerical consequence at κ=1e5 and **was checked to fail on the old routing** (σ[27] off by 38%). That needed a dense test matrix — the existing tiny-spectrum generator builds a *diagonal* matrix, whose columns are already orthogonal and which every path, including the normal-equation one, solves exactly.

## 2. Thin/economy vectors (`SvdVectors::Thin`)

LAPACK `'S'`: U is m×k, V^H is k×n, k = min(m,n). A 10000×32 job now allocates a 10000×32 U (1.3 MB in float) instead of 10000×10000 (400 MB, 1.6 GB at batch=4).

The identity the implementation rests on is that **Thin and All differ on at most one side**. For m ≤ n, k == m, so a thin U *is* a full U; for m ≥ n a thin V^H is a full V^H; square input has Thin == All on both. Entry points canonicalise Thin→All whenever the shapes coincide, so only the genuinely narrower side has to be served or refused, and every existing square and Hermitian caller stays on exactly the code it used before. The helpers are pure functions of `(job, m, n)`, so `buffer_size` and the run path cannot disagree about what was requested.

* **`gesvdj_cta`** — strictly cheaper than All. The thin U is what the solve already produces; the completion columns are manufactured afterwards by an in-kernel two-pass Gram-Schmidt that a Thin request skips, removing ~2·Σ_{d=CC}^{RR-1} d partition all-reduces per problem.
* **`gesvd_blocked`** — the default direct-bidiagonal path needed almost nothing (`u_sub` was already m×k, ormbr constrains only the reflector-order dimension, so this is a genuinely *smaller* ormbr). What needed work: a thin tall U now forces the direct bidiagonal solve even under `BATCHLAS_GESVD_BIDIAG=normal`, because that branch allocates an m×m `left_vecs` and `patch_zero_left_vectors` writes m columns unconditionally — honouring "normal" would pay the whole m×m cost in the workspace instead of in U (so it would look like it worked) and then overrun.
* **NETLIB** implements `'S'` rather than refusing: dispatch pins that backend to Vendor, so refusing would leave the entire CPU backend unable to serve Thin — and it is the reference the GPU results are checked against.
* **cuSOLVER** refuses. Verified against `cusolverDn.h`: `gesvdjBatched` has no `econ` flag (that is on the non-batched `gesvdj`), and `gesvdaStridedBatched` is a different, rank-truncated algorithm. Mandatory rather than cosmetic — `want_u` there is `== All`, so Thin would have quietly meant "no vectors" while the shape checks passed and U was never written.

Two subtleties worth flagging for review. In `gesvdj_cta` the two writebacks are **not** symmetric: for m < n the kernel solves A^H, `lane` is the rank index and the inner loop runs over the output's columns, so the thin bound belongs on `lane` — truncating the inner loop instead emits a wrongly-shaped factor while still writing plausible numbers. And the completion gate keeps its `any_def > 0` disjunct, because a numerically deficient column still has to be repaired when no completion columns are wanted, or a thin U comes back with a zero column.

Tests cover both rectangular orientations separately (different code), the square canonicalisation path, a rank-deficient thin case, that thin U equals the leading columns of full U up to sign/phase, and that the thin workspace is strictly smaller. All pass for float, double, complex&lt;float&gt; and complex&lt;double&gt;.

`gesvd_cta` refuses Thin, and the test asserts two *different* things: a direct call must throw, but going through `gesvd()` with `BATCHLAS_GESVD_PROVIDER=cta` must still return the right answer, because dispatch resets an unsupported forced provider to Auto. The first version asserted an error from the dispatch path and failed, which is how the distinction got pinned down. Worth stating plainly: **"it ran" is never on its own evidence that a forced provider was used.**

## 3. Tall-skinny — a negative result, and the 179× bug it exposed

The route (A = QR, SVD of the n×n R, U = Q·U_R) was implemented and measured. **It never wins.** Against a correct baseline, float, n=32, batch=128, values+V, µs/matrix:

| m | 512 | 2048 | 8192 | 32768 |
|---|---|---|---|---|
| direct | **9.20** | **28.98** | **215.3** | **1015.7** |
| A = QR | 17.02 | 59.57 | 262.3 | 1044.3 |

It approaches parity as m grows but does not cross. The reason is physical: at n=32 the cost is bandwidth in m, and the QR route touches the m×n data more times — geqrf reads A, then ormqr reads it again — against a single blocked gebrd pass. At n=128 it is 3–4× behind (m=1024: 84.2 → 349.5), because the direct path there was already blocked.

It is worth saying how close this came to shipping as a win. The **first** measurement showed 9388 → 115 µs at m=4096, an 81×, and it was reproducible. It was measured against the unblocked baseline, i.e. against a bug rather than against the alternative. The same class of error had already cost #66 a day (the `triangularize` inversion fabricating a 1.7× QR-preconditioning win), which is the only reason I went looking for a second baseline.

### What actually shipped: the blocked bidiagonalization at every n

`gesvd_use_blocked_gebrd` returned `n >= 33`. That threshold came from #66 on the reasoning that the CTA path takes over below it — true only for **square** input. `gesvd_supports_cta` and `gesvd_supports_jacobi` both require `max(m, n) <= 32`, so a **tall** matrix with n ≤ 32 satisfies neither, lands on the blocked provider, and ran the unblocked level-2 gebrd over all m rows.

float, m=1024, batch=128, jobu=None jobvh=All, µs/matrix:

| n | 8 | 16 | 24 | 32 |
|---|---|---|---|---|
| unblocked | 138.73 | 604.48 | 1535.2 | 2537.2 |
| blocked | **2.15** | **5.69** | **9.42** | **14.15** |
| speedup | **64×** | **106×** | **163×** | **179×** |

And not only tall: square through this provider is faster blocked too — 8×8 0.935 → 0.370 µs, 32×32 48.67 → **1.84 µs (26×)**. There is no n where unblocked is right, so the threshold is now a floor of 1 rather than a tuned constant.

**How it hid.** Reaching the band needs `min(m,n) <= 32` *and* `m > 32`, and every gesvd benchmark built a square `Random(n, n)` from a single size argument — no tall shape was expressible in any of them. There was no test either. `gesvd_blocked_benchmark` now takes m and n separately (and understands Thin); that is the instrument that found it. It also no longer sizes U as m×m when `jobu=None`, which is 137 GB at m=16384/batch=128 and killed the process before the first timing.

Two tests cover the band: one through the Auto path against LAPACKE plus orthogonality and reconstruction, and one differential against `BATCHLAS_GESVD_BLOCKED_GEBRD_MIN=9999`, which restores the old path so the two bidiagonalizations are compared on identical input.

## 4, 5, 6. The 33–64 band: one kernel, three different answers

`gesvdj_cta` now runs to n=64. P stays at 32 lanes (it is the sub-group width) and the tile capacity C grows, so each lane owns two rows.

**The item's premise is wrong in a way that matters.** It says "multiple columns per lane" — but during the sweep `lane` is the **row**, and a rotation on column pair (p,q) is a column operation executed by all 32 lanes on their own rows. Two columns are never owned by one lane, so the special case the item anticipates does not exist. The axis is rows per lane.

Two things are deliberately *not* widened: `exact_norms` keeps `Real x[P]` and its 5-step butterfly (covering C columns in C/P passes), and the Gram phase is chunked at P/2 pairs so the 4+1-step reduce-scatter, the `lane>>1` mapping and the `lane % 2 == 0` guards stay byte-identical. Chunking is safe because a round's pairs are a perfect matching. n≤32 is verified unchanged: 0.450 vs 0.470 µs/matrix.

### Item 4 — the cliff is not closed

batch=4096, float, full vectors, µs/matrix:

| n | 32 | 33 | 40 | 48 | 64 |
|---|---|---|---|---|---|
| jacobi | 0.502 | 3.177 | 3.746 | 4.856 | 7.253 |
| blocked | — | **1.846** | — | **2.930** | **4.855** |

Jacobi is **1.5–1.7× slower** across 33–64, so the n=32→33 cliff stands. The cause is rung granularity: n=33 pays the full C=64 tile (64×65, 63 rounds) exactly as n=64 does. A C=48 rung would help 33–48, but 48 is not a multiple of P=32, so it needs P=16 (kRPL=3) — a different partition width and a separate measured change.

### Item 5 — complex general SVD, 33–64

This used to **throw**: `gesvd_supports_blocked` declines complex, `gesvd_supports_cta` does too outside the Hermitian branch, so complex general fell through to Vendor, whose only binding caps at 32. complex\<float\> now works at 48×48, 64×40 and 40×64 through the Auto path; complex\<double\> is values-only above 32 (its C=64 tile with V needs 138,816 B against this device's measured 101,376 B). n>64 is still refused, and a test asserts that rather than leaving it to chance.

The item states "18 `gesvd_tests` cases skip for this." They don't — all 18 are NETLIB-backend skips of GPU-only provider tests, **none** would newly pass, and the suite contained no complex-general case at all. These tests are new.

### Item 6 — relative accuracy above n=32

The same kernel is the plan's recommended fix, and it meets the target. n=64, float, 256 samples:

| log10 κ | 1 | 3 | 5 | 6 |
|---|---|---|---|---|
| blocked relerr | **1.1e-6** | **1.7e-5** | 4.6e-3 | 0.526 |
| jacobi relerr | 1.2e-5 | 2.3e-5 | **7.3e-4** | **6.2e-3** |
| blocked ortho | **7.4e-7** | **3.0e-6** | 4.9e-4 | 0.144 |
| jacobi ortho | 2.4e-5 | 3.0e-5 | **3.5e-5** | **3.7e-5** |

At κ=1e6 the blocked path returns **no correct digits and a U that is not a basis**. Jacobi is 84× better on values and 3900× on orthogonality, for 1.5× the time — clearing the item's stated target of <1e-2 (bdsdc 0.497, bdsqr 0.198 before).

### Routing, and why it differs from item 1

Real input in 33–64 **keeps the blocked default**. Unlike the n≤32 case, where the old CTA path was worse from κ=1e2 up and the choice was free, here blocked is both faster *and* more accurate below κ≈1e4 — and which regime a caller is in is not knowable from the shape. So the accurate route is opt-in via `BATCHLAS_GESVD_PROVIDER=jacobi` (checked ahead of the Auto loop, so unaffected by the rule). Complex general in that band routes to Jacobi automatically, because the alternative is a throw.

Tests cover 33/40/48/63/64 square, both rectangular orientations, thin, and a rank-deficient case forcing the in-kernel Gram-Schmidt completion with the trial vector spread across two row-slots. Non-multiples of 32 are the ones that matter — an off-by-one in `row < RR` silently mixes a pad row into a dot product.

## Accuracy above n=32: a non-orthogonal U was a bug, not a floor

The blocked path returned a U that **was not a basis** at high conditioning — orthogonality 0.143 at κ=1e6, n=64, and **1.41** on an individual batch item of a graded bidiagonal. That is not a precision floor: U comes from ormbr applying Householder reflectors, so ‖UᴴU − I‖ should be ~n·eps whatever κ is.

**Root cause.** bdsdc solves the 2n Golub-Kahan matrix, whose eigenvalues are ±σᵢ, and splits each eigenvector into halves that normalise to v and u. stedc's eigenvectors for a cluster of gap g carry error ~eps·‖T‖/g, and the ±σᵢ pair has gap 2σᵢ — so once that pair stops being resolvable, the two eigenvectors are an *arbitrary* basis of the pair's 2-D eigenspace and **both normalise to the same (v, u)**. U and V come back with parallel columns.

The repair kernel already existed to rebuild such columns. Its threshold was the problem: `16·eps·σ_max`, chosen to "sit an order of magnitude above where an exact zero lands." That is the right criterion for detecting an exact zero and the wrong one for keeping U orthogonal, because the collapse degrades smoothly as the pair closes rather than only at σ=0.

**The fix is derived, not tuned.** Column i contributes ≈ eps·σ_max/(2σᵢ) of orthogonality error, so holding that under τ needs σᵢ ≥ eps·σ_max/(2τ) — a multiplier of 1/(2τ). τ=1e-3 gives **500**, replacing 16.

float, 128 samples, by log10 κ:

| n=64 | 1e1 | 1e3 | 1e4 | 1e5 | 1e6 |
|---|---|---|---|---|---|
| ortho | unchanged | unchanged | unchanged | 5.2e-4 → **4.6e-5** | 0.143 → **1.1e-4** |
| recon | unchanged | unchanged | unchanged | 1.3e-6 → 7.2e-5 | 3.1e-6 → 7.3e-5 |

n=128 at κ=1e6: ortho 0.200 → **2.5e-4**.

It is a real trade and 500 is the knee. κ≤1e4 is untouched entirely; above it ~1300× of orthogonality costs ~20× of reconstruction (1e-6 → 1e-5), both far inside every tolerance the suite applies. Pushing to 3000 keeps helping orthogonality but starts discarding vectors that carry information at κ=1e4 too (recon 1.3e-6 → 4.2e-4) — the exact failure the original comment warns about. **Double is unchanged at every κ measured**, and 500·eps in double is still three orders above where an exact zero lands, so the property the old constant was chosen for survives. No performance change.

**This does not fix the singular values** — still 0.52 relative error at κ=1e6. That is gebrd's own backward-stability floor (it perturbs A by eps·‖A‖, so B's tiny σ are only determined to eps·σ_max regardless of what solves B), and it is unreachable from inside bdsdc. The Jacobi route is the answer there, because it never forms the bidiagonal.

The test that should have caught this **did not exist**: the existing `Graded` case runs n=64 with `vectors=false`, so no ill-conditioned input was ever checked for vector orthogonality. The new case was verified to *fail* on the old threshold rather than merely pass on the new one.

## Low-priority items

**`MatrixView::triangularize` uplo was inverted.** The decode named the flat-index quotient the row but addressed `b*stride + i*ld + j`, and the library is column-major, so `i` was really the column and `Upper && i > j` zeroed the strict *upper* triangle. Two further defects went with it: the element count came from `data_.size()` (the span extent, not batch·rows·cols) and `n` came from `rows_` alone, so a non-square view decoded its own coordinates wrongly. It had no test and no in-tree caller, which is why nothing caught any of it — it has four tests now, seeded so each entry encodes its own (row, col).

**`random_with_log10_cond_metric` no longer emits non-finite matrices.** It orthonormalised two raw `Matrix::Random` factors with Chol2; Chol-QR forms the Gram, squaring an *unconditioned* input's condition number, so in float `potrf` fails once an ordinary draw passes κ ≈ 1e4 — and its `info` is allocated and never read, so `trsm` back-substitutes through a garbage diagonal and two gemms smear the NaN over the batch item.

Householder is the obvious fix and is the **wrong** one:

| algo | ortho err | achieved log10 κ (want 5.0) | non-finite |
|---|---|---|---|
| Chol2 (old) | 3.9e-7 | [5.000, 5.000] | 2/32 |
| Householder | 4.3e-7 | **[5.000, 17.390]** | 0/32 |
| CGS2 | **2.3e-7** | [5.000, 5.000] | **0/32** |

It removes the NaNs but leaves some batch items numerically singular, so the generator silently stops honouring the requested κ — a worse failure than the one being fixed, because it is invisible. It broke a pre-existing conditioning test immediately. That is a latent defect in `ortho`'s geqrf+orgqr path, left for a separate change. The default is now CGS2: best orthogonality of the six, exact κ, and no `potrf` at all.

The new test pins the generator directly rather than through `gesvd_relacc`, which re-draws up to 8 times and would hide exactly this, and it sweeps seeds because a single one proves nothing (seed 1 fails, seeds 7/42/123 pass even when broken).

**Tolerances.** 5e-2 / 2e-1 / 3e-1 → 2e-3 / 1e-3 / 1e-4, with margin over both error sources (the reference is LAPACKE in the *same* precision, error ~1.1e-6 absolute at n=64). The old absolute 5e-2 made the tiny-singular-value assertions vacuous — they expect σ = 1e-4 and 1e-7, so anything in [-0.05, 0.05] passed. Tolerances are now solver-aware: `BIDIAG=normal` cannot meet them and is not meant to, and pinning the whole suite to the worst path is what made the guards vacuous in the first place.

## Still open

* **The n=32→33 cliff.** A C=48 rung at P=16 (kRPL=3) is the next thing to try; see item 4 above.
* **Complex general above n=64.** Needs complex `gebrd` — a `larfg_rbeta` variant per LAPACK ZLARFG to make the bidiagonal real, plus the ZLACGV conjugation convention on the P-side reflector — and thin complex wrappers over `bdsdc`/`bdsqr`, which are single-`T` today.
* **Relative accuracy above n=64.** Unsolved. dqds and a faster `bdsqr` both rank low-value: `gebrd` itself perturbs A by eps·‖A‖, so B's tiny singular values are only determined to eps·σ_max no matter what solves B.
* **`bdsdc`'s repair kernel** is still one work-group per batch item with a serial `j` loop (pure perf, fires only on rank-deficient input).
* **`ortho`'s Householder path** returns a factor that leaves some batch items numerically singular — found while fixing the generator, left as a separate defect.

## Verification

54 `gesvd_tests` cases on each of the three `BATCHLAS_GESVD_BIDIAG` settings and the blocked/cta forced-provider arms; 67 `gesvdj_cta_tests`; plus `bdsdc_tests`, `bdsqr_tests`, `cond_tests`, `matrix_tests`, `matrix_view_tests`, `ortho_tests` and `syev_tests` — nine suites, all green. Jacobi throughput unchanged by the refactors (float n=32, batch=16384, All/All: 0.47014 vs 0.46963 µs/matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6XUtzwA7cHeiH7CvF4H1J
