### PR TITLE
Blocked Jacobi eigensolver for n = 64-256 (WP8 / Tier B+C)

### DIFF
--- a/SYEV_JACOBI_BLOCKED_RESULTS.md
+++ b/SYEV_JACOBI_BLOCKED_RESULTS.md
@@ -1,0 +1,198 @@
+# Blocked Jacobi at n = 64–256: implementation and measured results
+
+Executes **WP8 / C1** of `SYEV_PERF_IMPLEMENTATION_PLAN.md` ("block Jacobi at n = 64–256"),
+which defers to Tiers B and C of `JACOBI_EIGENSOLVER_PLAN.md` §8.5. Tier A (`syev_jacobi_cta`,
+n ≤ 32) was already in tree; Tiers B and C were design-only. Both now exist as one kernel.
+
+Ships as `syev_jacobi_blocked` / `syev_jacobi_blocked_buffer_size`
+(`src/extensions/syev_jacobi_blocked.cc`), **not routed from `Auto`**. Why not is §4.
+
+---
+
+## 1. What was built
+
+One work-group per matrix, block-cyclic two-sided Jacobi over block-column pairs. Only the
+current pivot block is resident; `A` and the eigenvector accumulator `Z` stay in global memory,
+so `n` is bounded by global memory rather than by local memory as in Tier A.
+
+```
+for each sweep
+  for each block pair (p, q), cyclically            l(l-1)/2 pairs, l = ceil(n/nb)
+    S <- A[idx, idx]                                idx = cols(p) ++ cols(q), |idx| = m <= 2nb
+    skip the pair unless some |S_ij| > tol*sqrt(|S_ii S_jj|)
+    U <- inner two-sided Jacobi on S                local memory, rotation-based
+    A[:, idx] <- A[:, idx] * U                      panel update, coalesced
+    A[idx, idx] <- S                                already U^H A U
+    A[idx, r]   <- conj(A[r, idx])                  mirror, r outside idx
+    Z[:, idx] <- Z[:, idx] * U
+```
+
+Three things in that loop are not in the plan's sketch and are worth keeping:
+
+**The row update is a transpose, not a second GEMM.** §8.5 has
+`A[(p,q), :] <- U^T A[(p,q), :]` as an m × n product. It never has to be computed. With
+`V` block-diagonal and `B = A V`, the rows outside the pivot block satisfy
+`A'[idx, r] = conj(A'[r, idx])` because `A'` is Hermitian and `A'[r, idx]` is exactly what the
+*column* update already produced. The second product therefore collapses to the m × m pivot
+block — which the inner solve has already computed, as `S` — plus a transposing copy. That
+removes `n*m^2` flops per pivot pair and, more importantly, removes the strided-read panel the
+row update would have needed.
+
+**The mirror is staged through local memory.** Its destination is transposed, so writing it
+directly turns one coalesced store into m scattered ones. It reuses the `S` buffer, which is
+dead by that point, so the staging costs no extra local memory.
+
+**l == 2 degenerates into the fully resident solve.** With two block columns the pivot block is
+the whole matrix, the panel update and the mirror are both empty, and the kernel never touches
+global memory between the initial load and the final store. That is the plan's Tier B
+(`32 < n <~ 128`) and it falls out of the Tier C structure rather than needing its own kernel.
+It is also, by a wide margin, where the kernel is fastest — see §3.
+
+Supported: real symmetric and complex Hermitian, `Uplo::Lower` and `Uplo::Upper`, `2 <= n <= 1024`,
+both job modes. 25 tests in `tests/syev_jacobi_blocked_tests.cc`, all passing on all four scalar
+types. `A` is destroyed in both job modes.
+
+---
+
+## 2. Accuracy — the payoff holds at n = 64 and n = 128
+
+This is the result the solver exists for, and it survives blocking.
+
+Graded SPD input `A = D M D`, `D_ii = 2^-e_i` with the exponents spread linearly over
+`[0, 58]`, so `kappa(A) ~ 1e35` while the column-equilibrated condition number stays `O(1)`.
+Entries are dyadic, so float and double see bit-identical input. Reference is an independent
+double-precision CPU Jacobi. Solver and reference both in **float**:
+
+| n | spectrum | `syev_jacobi_blocked` | routed `syev` |
+|---|----------|-----------------------|---------------|
+| 64  | 1.1e-35 … 1.06 | **3.0e-06** | 1.6e+27 |
+| 128 | 9.0e-36 … 1.11 | **1.2e-05** | 4.8e+26 |
+
+Thirty-three orders of magnitude, on the same input in the same precision. The blocked kernel
+resolves every eigenvalue to a small multiple of float eps (25x and 104x eps respectively);
+the tridiagonalizing path returns garbage for the small end, exactly as the theory predicts.
+
+Note the test-construction trap that cost a debugging cycle: the fixed per-index grading used
+at n ≤ 32 (`D_ii = 2^{-2i}`) does not survive to n = 128 — it puts the smallest entry at
+`2^{-4*127}`, which in float is not inaccurate but *zero*. The first version of this test was
+measuring underflow, not the solver. Spreading a fixed total exponent span keeps the smallest
+eigenvalue three orders above `FLT_MIN` at every n.
+
+Backward error on random symmetric input is pinned by the residual and orthogonality tests at
+n ∈ {33, 47, 64, 65, 97, 128, 129}.
+
+---
+
+## 3. Performance — it loses, and the cost model says it had to
+
+RTX 4090 (device 1, idle), float, saturating batch, shipped defaults, µs per matrix.
+Ratio > 1 means blocked Jacobi is slower.
+
+| n | batch | job | `syev_jacobi_blocked` | routed `syev` | ratio |
+|---|-------|-----|----------------------|---------------|-------|
+| 64  | 4096 | vectors | 2.92 | 1.44 | **2.03x** |
+| 64  | 4096 | values  | 2.95 | 0.50 | 5.88x |
+| 128 | 2048 | vectors | 44.7 | 6.54 | 6.83x |
+| 128 | 2048 | values  | 36.4 | 2.88 | 12.7x |
+| 256 | 1024 | vectors | 370  | 32.1 | 11.5x |
+| 256 | 1024 | values  | 276  | 15.6 | 17.7x |
+
+`complex<float>` is roughly 2x worse again at every shape, because the register budget of the
+panel update caps the pivot block at m = 32 instead of 64, which doubles the global traffic
+(§3.2).
+
+### 3.1 The plan's cost model was 3x optimistic, and this is why
+
+WP8 estimated "~8–10 sweeps × ~4n³ ≈ 30–40n³ against our ~4n³ — a 10x flop premium — so it
+breaks even at 17–21 TFLOP/s".
+
+The `4n³` per sweep counts **one** of the three block updates a round performs. Right-multiplying
+`A` by the block-diagonal `V` costs `4n²·nb` per round and there are `l-1 ≈ n/nb` rounds, so
+`A·V` is `4n³` per sweep — but `V^H·A` is another `4n³` and `Z·V` a third. The real figure is
+**12n³ per sweep with eigenvectors, 8n³ without**, hence ~100n³ over 8–10 sweeps, a **~25x**
+premium over syev's ~4n³, not 10x.
+
+Break-even at n = 256 therefore needs ~51 TFLOP/s, which is *above* the ~47 TFLOP/s this card
+sustains on cuBLAS SGEMM (see `sycl-matches-cuda-gemm`). **WP8 could not have won at n = 256 at
+any implementation quality.** The transpose trick in §1 removes one of the three terms, taking
+the premium to ~17x; that is a real saving and it is not enough.
+
+### 3.2 What actually binds is memory traffic, and it explains the shape of the table
+
+Global traffic per sweep is `6n³/nb` elements with vectors (`4n³/nb` without), because every
+pivot-pair update reads and writes the whole n × m panel three times over — panel, mirror,
+eigenvectors. `nb` is the only term that moves it, and `nb` is capped by local memory: the
+pivot block needs two m × (m+1) arrays with m = 2nb, which at 48 KB and float allows m ≤ 64.
+
+That predicts a **cliff, not a slope**, at the point where the matrix stops fitting in local
+memory — and that is what the table shows. n = 64 gives l = 2, the fully resident case with
+*zero* global traffic between load and store, and costs 2.03x. n = 128 gives l = 4 and costs
+6.83x. The degradation is not gradual; it is the loss of residency.
+
+Two independent confirmations that the implementation sits on its own cost model rather than
+leaving easy factors on the table:
+- Dropping eigenvectors at n = 256 saves 34% (370 → 276 µs). Z is 1/3 of the traffic terms.
+  A compute-bound kernel would not have shown that.
+- Widening the pivot block is worth exactly what the `1/nb` term says: forcing nb = 8 instead of
+  the auto-selected 32 costs 1.9x at n = 64 and 1.4x at n = 128.
+
+### 3.3 Two defaults that are measured, not guessed
+
+**Inner sweeps.** 0 (the default) selects: diagonalize the pivot block exactly when it is the
+whole matrix, one inexact sweep otherwise. Measured spread is ~1.3x either way, and the
+crossover has a cause — when `l == 2` an exact inner solve finishes the problem in one outer
+sweep and there is no outer cost left to amortize, whereas when `l > 2` the inner solve costs
+`O(m³)` per block against the outer update's `O(n m²)`, so extra inner sweeps buy convergence
+at a worse rate than another outer sweep does. The latter is why MAGMA's batched SVD and
+Novaković's block-oriented variant both use a single inexact sweep; the former is why the plan's
+blanket `M_s = 1` recommendation is wrong for the resident case.
+
+**Work-group size** (µs per matrix, eigenvectors):
+
+| | wg=256 | wg=512 | wg=768 | wg=1024 |
+|---|---|---|---|---|
+| n=64  | 3.36 | 3.00 | **2.94** | 3.96 |
+| n=128 | 55.4 | 51.5 | 52.0 | **44.8** |
+| n=256 | 398 | 398 | 421 | **372** |
+
+Same `l == 2` split. A resident solve is bound by local-memory traffic and barriers and wants
+two work-groups per SM to hide them, which under Ada's 1536-thread-per-SM ceiling caps the
+work-group at 768 — going to 1024 halves residency and costs 35%, the cliff in the n = 64 row.
+A blocked solve is bound by global-memory latency on the panel update instead, where one wide
+work-group issuing more concurrent loads beats two narrow ones. Shipped default follows that
+rule; `BATCHLAS_JACOBI_BLOCKED_WG` overrides it.
+
+---
+
+## 4. Routing decision: opt-in, not `Auto`
+
+`syev_jacobi_blocked` is **not** wired into `detail::choose_syev_provider`. It is slower than
+the routed path at every measured shape, so routing it on speed would be a pure regression, and
+routing it on accuracy would require an input property the API does not carry (the
+relative-accuracy theorem is SPD-only, and nothing in the signature asserts SPD).
+
+This is the framing `JACOBI_EIGENSOLVER_PLAN.md` already recommends and WP8 repeats: Jacobi is a
+*second* backend for accuracy-critical and graded input, not a replacement. What changed is that
+the accuracy backend now covers n = 64–256 instead of stopping at n = 32.
+
+---
+
+## 5. If someone wants to close the gap
+
+Recorded so it is not re-derived. The binding constraint is `6n³/nb` and `nb` is capped by local
+memory, so the only structural lever is **Novaković's hierarchical blocking**: run the outer loop
+at nb = 64 (l = 4 at n = 256 instead of 8) and solve the 128 × 128 pivot block with a nested
+blocked Jacobi over a global scratch rather than in local memory. That cuts traffic ~2.3x.
+
+Against ratios of 6.8x and 11.5x, 2.3x does not change the conclusion — which is why it was not
+built. It is worth revisiting only on hardware with a materially larger local memory per SM, or
+if a future caller needs relative accuracy badly enough to pay a 3-5x time premium instead of a
+7-12x one.
+
+Two smaller items measured or identified and deliberately not taken:
+- When `l == 2` and the solve converges in one outer sweep, `Z` is exactly `U`, so the `Z = I`
+  seed and the first `Z <- Z·U` product are both waste. Worth ~11% at n = 64 (2.95 → ~2.6 µs
+  measured as the values-only/vectors gap), and nothing anywhere else.
+- Raising the panel-update register cap from 64 to 76 floats would let nb reach 37 at n = 256.
+  Worth ~14% of the traffic there, nothing at n = 64 or 128 where the block partition does not
+  change.

--- a/SYEV_PERF_IMPLEMENTATION_PLAN.md
+++ b/SYEV_PERF_IMPLEMENTATION_PLAN.md
@@ -39,7 +39,7 @@ The research document's §7 order is kept, with two deviations, both stated:
 | **WP5** | Single-read panel symv | B1 | new kernel | **1.22–1.82×** end to end, both types |
 | **WP6** | Complex stage-2 occupancy | B2 | kernel rework | 1.49× cfloat two-stage; opens n ≥ 512 |
 | **WP7** | Measurement debt | A4, A5, B4 | investigation | routing corrections |
-| **WP8** | Block Jacobi | C1 | large | 1.5–2.5× at n = 128–256 (speculative) |
+| **WP8** | Block Jacobi | C1 | large | ~~1.5–2.5× at n = 128–256~~ — **done, measured 2.0–11.5× *slower*; ships unrouted as an accuracy backend** |
 
 **Deviation 1 — WP0 goes first.** Two of the packages below cannot be measured with the
 harness as it stands (§WP0). Fixing that is ~40 lines and removes the need to tune A3 and
@@ -570,6 +570,28 @@ eigenvector mode only.
 ---
 
 ## WP8 — C1: block Jacobi at n = 64–256
+
+> **Status: implemented and measured. It loses.** Shipped as `syev_jacobi_blocked`
+> (`src/extensions/syev_jacobi_blocked.cc`), covering n = 64–256 for all four scalar types,
+> **not routed from `Auto`**. Full write-up in `SYEV_JACOBI_BLOCKED_RESULTS.md`.
+>
+> Measured, RTX 4090 / float / saturating batch, eigenvectors: **2.03x slower** than the routed
+> path at n = 64, **6.83x** at n = 128, **11.5x** at n = 256. Eigenvalues-only is worse again
+> (5.9x / 12.7x / 17.7x). The accuracy payoff is confirmed and large: max relative eigenvalue
+> error on graded SPD input with kappa ~ 1e35 is 3.0e-06 at n = 64 against the routed `syev`'s
+> 1.6e+27, on identical float input.
+>
+> **The cost estimate below is wrong by 3x, and the error is arithmetic, not luck.** "~8–10
+> sweeps × ~4n³" counts one of the *three* block updates each round performs: right-multiplying
+> A by the block-diagonal V is 4n³ per sweep, but V^H·A is another 4n³ and Z·V a third. The real
+> figure is 12n³ per sweep with vectors, so ~100n³ — a ~25x premium over syev's ~4n³, not 10x.
+> Break-even at n = 256 needs ~51 TFLOP/s, which is above the ~47 TFLOP/s this card sustains on
+> cuBLAS SGEMM. **No implementation of this item could have won at n = 256.**
+>
+> What binds in practice is not flops but global traffic, `6n³/nb` per sweep, with nb capped by
+> the local memory the pivot block needs. That produces a cliff rather than a slope: n = 64 is
+> fully resident (l = 2, zero global traffic between load and store) and costs 2.03x; n = 128
+> is not, and costs 6.83x.
 
 Kept last deliberately: highest ceiling among the conventional-alternative items, entirely
 unmeasured, and it should only start once WP1–WP6 have bounded what the current path can

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -38,6 +38,7 @@ set(BENCHMARK_TARGETS
     syev_benchmark
     syev_cta_benchmark
     syev_jacobi_cta_benchmark
+    syev_jacobi_blocked_benchmark
     syev_cta_fused_benchmark
     syev_blocked_benchmark
     gesvd_cta_benchmark

--- a/benchmarks/syev_jacobi_blocked_benchmark.cc
+++ b/benchmarks/syev_jacobi_blocked_benchmark.cc
@@ -1,0 +1,137 @@
+#include <util/minibench.hh>
+
+#include <blas/enums.hh>
+#include <blas/extensions.hh>
+#include <blas/functions.hh>
+
+#include "bench_utils.hh"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+using namespace batchlas;
+
+namespace {
+
+// Head-to-head grid for the blocked Jacobi eigensolver against the routed syev
+// path on identical inputs, at the batch sizes where each n saturates the
+// device (the same ones syev_benchmark registers). Ratios taken below
+// saturation measure launch overhead, not algorithms.
+//
+// arg0 n, arg1 batch, arg2 jobz, arg3 nb (0 = auto), arg4 inner sweeps.
+template <typename Benchmark>
+inline void SyevJacobiBlockedBenchSizes(Benchmark* b) {
+    auto add = [&](int n, int batch) {
+        for (int jobz : {0, 1}) {
+            // inner: 0 = the shipped adaptive rule, 30 = exact block solves.
+            for (int nb : {0, 8, 16, 24, 32}) {
+                for (int inner : {0, 1, 2, 30}) {
+                    b->Args({n, batch, jobz, nb, inner});
+                }
+            }
+        }
+    };
+    add(64, 4096);
+    add(128, 2048);
+    add(256, 1024);
+}
+
+// The reference path does not care about nb or the inner sweep count, so it
+// gets the same grid with those two collapsed.
+template <typename Benchmark>
+inline void SyevRefBenchSizes(Benchmark* b) {
+    auto add = [&](int n, int batch) {
+        for (int jobz : {0, 1}) {
+            b->Args({n, batch, jobz, 0, 0});
+        }
+    };
+    add(64, 4096);
+    add(128, 2048);
+    add(256, 1024);
+}
+
+inline JobType parse_jobz(int v) {
+    return (v == 0) ? JobType::NoEigenVectors : JobType::EigenVectors;
+}
+
+// Operation count of the *reference* algorithm, so GFLOPS is comparable across
+// the two rows. Jacobi does roughly an order of magnitude more arithmetic than
+// this; the honest way to read the table is the per-matrix time column.
+inline double ref_flops(std::size_t n) {
+    return 4.0 / 3.0 * static_cast<double>(n) * static_cast<double>(n) * static_cast<double>(n);
+}
+
+} // namespace
+
+template <typename T, Backend B>
+static void BM_SYEV_JACOBI_BLOCKED(minibench::State& state) {
+    const size_t n = state.range(0);
+    const size_t batch = state.range(1);
+    const JobType jobz = parse_jobz(static_cast<int>(state.range(2)));
+
+    auto q = std::make_shared<Queue>(Device(B == Backend::NETLIB ? "cpu" : "gpu"), B);
+    auto A = Matrix<T>::Random(n, n, /*hermitian=*/true, batch);
+    UnifiedVector<typename base_type<T>::type> W(n * batch);
+
+    JacobiParams<T> params;
+    params.block_size = static_cast<size_t>(state.range(3));
+    params.inner_sweeps = static_cast<size_t>(state.range(4));
+
+    const size_t ws_size = syev_jacobi_blocked_buffer_size<B, T>(*q, A.view(), jobz, params);
+    UnifiedVector<std::byte> workspace(ws_size);
+
+    state.SetKernel(q,
+                    bench::pristine(A),
+                    std::move(W),
+                    jobz,
+                    Uplo::Lower,
+                    std::move(workspace),
+                    params,
+                    [](Queue& q, auto&&... xs) {
+                        syev_jacobi_blocked(q, std::forward<decltype(xs)>(xs)...);
+                    });
+
+    state.SetMetric("GFLOPS", static_cast<double>(batch) * (1e-9 * ref_flops(n)), minibench::Rate);
+    state.SetMetric("Time (µs) / matrix", (1.0 / batch) * 1e6, minibench::Reciprocal);
+}
+
+// The routed syev, which at these shapes is the vendor path on CUDA.
+template <typename T, Backend B>
+static void BM_SYEV_ROUTED_REF(minibench::State& state) {
+    const size_t n = state.range(0);
+    const size_t batch = state.range(1);
+    const JobType jobz = parse_jobz(static_cast<int>(state.range(2)));
+
+    auto q = std::make_shared<Queue>(Device(B == Backend::NETLIB ? "cpu" : "gpu"), B);
+    auto A = Matrix<T>::Random(n, n, /*hermitian=*/true, batch);
+    UnifiedVector<typename base_type<T>::type> W(n * batch);
+
+    const size_t ws_size = syev_buffer_size(*q, A.view(), W.to_span(), jobz, Uplo::Lower);
+    UnifiedVector<std::byte> workspace(ws_size);
+
+    state.SetKernel(q,
+                    bench::pristine(A),
+                    std::move(W),
+                    jobz,
+                    Uplo::Lower,
+                    std::move(workspace),
+                    [](Queue& q, auto&&... xs) {
+                        syev(q, std::forward<decltype(xs)>(xs)...);
+                    });
+
+    state.SetMetric("GFLOPS", static_cast<double>(batch) * (1e-9 * ref_flops(n)), minibench::Rate);
+    state.SetMetric("Time (µs) / matrix", (1.0 / batch) * 1e6, minibench::Reciprocal);
+}
+
+#if BATCHLAS_HAS_CUDA_BACKEND
+BATCHLAS_BENCH_CUDA_ALL_TYPES(BM_SYEV_JACOBI_BLOCKED, SyevJacobiBlockedBenchSizes);
+BATCHLAS_BENCH_CUDA_ALL_TYPES(BM_SYEV_ROUTED_REF, SyevRefBenchSizes);
+#endif
+
+#if BATCHLAS_HAS_ROCM_BACKEND
+BATCHLAS_BENCH_ROCM_ALL_TYPES(BM_SYEV_JACOBI_BLOCKED, SyevJacobiBlockedBenchSizes);
+BATCHLAS_BENCH_ROCM_ALL_TYPES(BM_SYEV_ROUTED_REF, SyevRefBenchSizes);
+#endif
+
+MINI_BENCHMARK_MAIN();

--- a/include/blas/extensions.hh
+++ b/include/blas/extensions.hh
@@ -1723,6 +1723,28 @@ namespace batchlas {
         // chosen from n; the result is clamped by the device's maximum
         // work-group size and by available local memory.
         size_t cta_wg_size_multiplier = 1;
+
+        // --- syev_jacobi_blocked only; ignored by syev_jacobi_cta. ---
+
+        // Block-column width nb. 0 selects the widest block that fits local
+        // memory and the panel update's register budget, which is what the
+        // outer loop wants: global traffic per sweep is ~6 n^3 / nb, so nb is
+        // the only knob that moves it. A smaller value is clamped up to at
+        // least ceil(n/2) blocks worth, never above the device limit.
+        size_t block_size = 0;
+
+        // Sweeps of the inner solve on each 2nb x 2nb pivot block. 1 is the
+        // "inexact"/block-oriented variant (MAGMA's batched SVD, Novakovic);
+        // any value at or above max_sweeps diagonalizes each pivot block
+        // exactly, giving classical block Jacobi.
+        //
+        // 0 chooses by measurement: exact when the pivot block is the whole
+        // matrix (there is then no outer cost to amortize and one inner solve
+        // finishes the problem), a single inexact sweep otherwise (the inner
+        // solve costs O(m^3) per block against the outer update's O(n m^2), so
+        // extra inner sweeps buy convergence at a worse rate than another outer
+        // sweep). Measured spread between the two is 1.3x either way.
+        size_t inner_sweeps = 0;
     };
 
     /**
@@ -1768,6 +1790,46 @@ namespace batchlas {
                                        const MatrixView<T, MatrixFormat::Dense>& a,
                                        JobType jobz,
                                        JacobiParams<T> params = JacobiParams<T>());
+
+    /**
+     * @brief Blocked two-sided Jacobi symmetric/Hermitian eigen-solver.
+     *
+     * The n > 32 continuation of syev_jacobi_cta, and the same trade: high
+     * *relative* accuracy on graded or badly scaled input, at a substantially
+     * higher operation count than a tridiagonalizing solver. syev_jacobi_cta is
+     * capped at n <= 32 because it holds A and Z in local memory per sub-group
+     * partition; this kernel gives each matrix a whole work-group and keeps only
+     * the current 2*nb x 2*nb pivot block resident, so n is limited by global
+     * memory rather than by local.
+     *
+     * Notes:
+     * - Intended for 64 <= n <= 256; accepted for 2 <= n <= 1024.
+     * - Real symmetric and complex Hermitian, Uplo::Lower and Uplo::Upper.
+     * - A is DESTROYED in both job modes. With jobz == EigenVectors it is
+     *   overwritten by the eigenvectors; with NoEigenVectors its contents are
+     *   unspecified on return.
+     * - Eigenvalues are returned in ascending order when JacobiParams::sort is
+     *   enabled (default).
+     * - Needs a workspace of n*n*batch elements of T for the eigenvector
+     *   accumulator, and none at all for eigenvalues only.
+     *
+     * See JACOBI_EIGENSOLVER_PLAN.md (Tier B/C) for the design rationale and
+     * SYEV_PERF_IMPLEMENTATION_PLAN.md WP8 for how it is expected to perform.
+     */
+    template <Backend B, typename T>
+    Event syev_jacobi_blocked(Queue& ctx,
+                              const MatrixView<T, MatrixFormat::Dense>& a_in,
+                              Span<typename base_type<T>::type> eigenvalues,
+                              JobType jobz,
+                              Uplo uplo,
+                              const Span<std::byte>& ws = Span<std::byte>(),
+                              JacobiParams<T> params = JacobiParams<T>());
+
+    template <Backend B, typename T>
+    size_t syev_jacobi_blocked_buffer_size(Queue& ctx,
+                                           const MatrixView<T, MatrixFormat::Dense>& a,
+                                           JobType jobz,
+                                           JacobiParams<T> params = JacobiParams<T>());
 
     /**
      * @brief Blocked symmetric/Hermitian eigen-solver (SYEV-like) for medium/large matrices.
@@ -2470,6 +2532,8 @@ BATCHLAS_DISPATCH_ON_QUEUE(syev_cta_fused)
 BATCHLAS_DISPATCH_ON_QUEUE(syev_cta_fused_buffer_size)
 BATCHLAS_DISPATCH_ON_QUEUE(syev_jacobi_cta)
 BATCHLAS_DISPATCH_ON_QUEUE(syev_jacobi_cta_buffer_size)
+BATCHLAS_DISPATCH_ON_QUEUE(syev_jacobi_blocked)
+BATCHLAS_DISPATCH_ON_QUEUE(syev_jacobi_blocked_buffer_size)
 BATCHLAS_DISPATCH_ON_QUEUE(syev_blocked)
 BATCHLAS_DISPATCH_ON_QUEUE(syev_blocked_buffer_size)
 BATCHLAS_DISPATCH_ON_QUEUE(syev_two_stage)

--- a/src/extensions/CMakeLists.txt
+++ b/src/extensions/CMakeLists.txt
@@ -6,6 +6,7 @@ set(EXTENSIONS_CTA_SOURCES
     sytrd_cta.cc
     sytrd_sb2st_cta.cc
     syev_jacobi_cta.cc
+    syev_jacobi_blocked.cc
     gesvdj_cta.cc
     syev_cta_fused.cc
 )

--- a/src/extensions/syev_jacobi_blocked.cc
+++ b/src/extensions/syev_jacobi_blocked.cc
@@ -1,0 +1,858 @@
+#include <blas/matrix.hh>
+#include <blas/functions.hh>
+#include <blas/extensions.hh>
+#include <blas/extra.hh>
+#include <util/mempool.hh>
+#include <util/env.hh>
+#include <batchlas/backend_config.h>
+#include "../math-helpers.hh"
+#include "../queue.hh"
+#include "../util/template-instantiations.hh"
+#include <algorithm>
+#include <complex>
+#include <limits>
+#include <stdexcept>
+
+namespace batchlas {
+
+// Kernel name tag. Must live outside the anonymous namespace below so it does
+// not depend on internal-linkage entities.
+template <typename T, bool ComputeVectors>
+class SyevJacobiBlockedKernel;
+
+// ---------------------------------------------------------------------------
+// Blocked two-sided Jacobi eigensolver (JACOBI_EIGENSOLVER_PLAN.md Tier B/C,
+// SYEV_PERF_IMPLEMENTATION_PLAN.md WP8).
+//
+// syev_jacobi_cta solves one problem inside one sub-group partition, which caps
+// it at n <= 32: A and Z have to fit in local memory *per partition*. This
+// kernel lifts the same algorithm to n in the hundreds by giving each matrix a
+// whole work-group and keeping only the current 2nb x 2nb pivot block resident:
+//
+//   for each sweep
+//     for each block pair (p, q), cyclically
+//       S  <- A[idx, idx]                    idx = cols(p) ++ cols(q)
+//       U  <- inner two-sided Jacobi on S    (local memory, rotation-based)
+//       A[:, idx] <- A[:, idx] * U           (panel update, coalesced)
+//       A[idx, idx] <- S                     (already U^H A U)
+//       A[idx, r]   <- conj(A[r, idx])       (mirror, r outside idx)
+//       Z[:, idx] <- Z[:, idx] * U
+//
+// Two structural points that are not obvious from the plan sketch:
+//
+// * **The row update is a transpose, not a GEMM.** The sketch has
+//   `A[(p,q), :] <- U^T A[(p,q), :]` as a second m x n product. It does not
+//   have to be computed. Writing A' = V^H A V with V block-diagonal and
+//   B = A V, the rows outside the pivot block satisfy
+//   A'[idx, r] = conj(A'[r, idx]) because A' is Hermitian and A'[r, idx] is
+//   exactly what the *column* update already produced. So the second product
+//   collapses to the m x m pivot block -- which the inner solve has computed
+//   anyway, as S -- plus a transposing copy. That removes n*m^2 flops per pair
+//   and, more importantly, removes the strided-read panel the row update would
+//   otherwise need.
+//
+// * **The pivot block covers everything when l == 2.** With two block columns
+//   the pivot block is the whole matrix, the panel update and the mirror are
+//   empty, and the kernel degenerates into a fully local-memory-resident
+//   work-group Jacobi. That is the Tier B regime of the plan (32 < n <~ 128)
+//   and it is where this kernel is fastest, because it never touches global
+//   memory between the initial load and the final store.
+//
+// Accuracy is the reason the solver exists: with the *relative* off-diagonal
+// threshold below, the eigenvalue error is governed by the condition number of
+// the column-equilibrated matrix rather than of A itself (Demmel & Veselic,
+// SIMAX 13(4), 1992), so graded input keeps its small eigenvalues where a
+// tridiagonalizing path loses them entirely. The blocking does not change the
+// criterion: a rotation is applied for exactly the same pivot pairs a scalar
+// Jacobi would rotate, they are just applied via the accumulated block
+// transform. See JACOBI_EIGENSOLVER_PLAN.md sections 4 and 5 for what the
+// theory does and does not cover for the blocked variant.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+template <typename U>
+inline U conj_jb(const U& x) {
+    if constexpr (internal::is_complex<U>::value) {
+        return U(x.real(), -x.imag());
+    } else {
+        return x;
+    }
+}
+
+template <typename U>
+inline typename base_type<U>::type abs_jb(const U& x) {
+    using Real = typename base_type<U>::type;
+    if constexpr (internal::is_complex<U>::value) {
+        return sycl::hypot(x.real(), x.imag());
+    } else {
+        return sycl::fabs(x);
+    }
+}
+
+template <typename U>
+inline U force_real_jb(const U& x) {
+    if constexpr (internal::is_complex<U>::value) {
+        return U(x.real(), typename base_type<U>::type(0));
+    } else {
+        return x;
+    }
+}
+
+template <typename U>
+inline typename base_type<U>::type real_jb(const U& x) {
+    if constexpr (internal::is_complex<U>::value) {
+        return x.real();
+    } else {
+        return x;
+    }
+}
+
+// Textbook complex multiply. std::complex<T>::operator* implements C99 Annex G,
+// which clang lowers to a per-operand isnan branch plus a __mulsc3 / __muldc3
+// call -- see the same fix in latrd_lower_panel.cc:121 and syev.hh:650. The
+// panel update below is one long chain of these, so the libcall form is not
+// affordable there.
+template <typename U>
+inline U mul_jb(const U& a, const U& b) {
+    if constexpr (internal::is_complex<U>::value) {
+        using Real = typename base_type<U>::type;
+        const Real ar = a.real();
+        const Real ai = a.imag();
+        const Real br = b.real();
+        const Real bi = b.imag();
+        return U(ar * br - ai * bi, ar * bi + ai * br);
+    } else {
+        return a * b;
+    }
+}
+
+// Longest pivot-block order the panel update can hold in registers.
+//
+// The update keeps one full row of the m-column panel live (`T arow[MaxM]`) so
+// that the whole row can be read once, coalesced, and rewritten in place. That
+// is the single biggest lever on the update's cost and it is worth spending
+// registers on -- but only 64 of them: see register-residency notes in
+// gemm_128x128 work, where an over-wide thread tile spilled the accumulator and
+// cost 43%. Each entry is sized so MaxM * sizeof(T) == 256 bytes.
+template <typename T>
+constexpr int jacobi_blocked_max_m() {
+    if constexpr (sizeof(T) <= 4) {
+        return 64;   // float
+    } else if constexpr (sizeof(T) <= 8) {
+        return 32;   // double, complex<float>
+    } else {
+        return 16;   // complex<double>
+    }
+}
+
+// Round-robin ("chess tournament") pairing, identical to syev_jacobi_cta's.
+// Round t of an even order m produces m/2 disjoint pairs and the m-1 rounds
+// together cover every index pair exactly once.
+inline void round_robin_pair_jb(int32_t m, int32_t t, int32_t k, int32_t& p, int32_t& q) {
+    const int32_t ring = m - 1;
+    if (k == 0) {
+        p = 0;
+        q = (t % ring) + 1;
+    } else {
+        p = ((t + k) % ring) + 1;
+        q = (((t - k) % ring + ring) % ring) + 1;
+    }
+    if (p > q) {
+        const int32_t tmp = p;
+        p = q;
+        q = tmp;
+    }
+}
+
+// Block partition: l block columns of width nb, the last possibly short.
+struct BlockPlan {
+    int32_t nb = 0;      // block width
+    int32_t l = 0;       // number of block columns
+    int32_t m_max = 0;   // largest pivot-block order that can occur
+};
+
+// Pick the widest pivot block that fits both local memory and the register
+// budget of the panel update. Wider is strictly better for the outer loop:
+// global traffic per sweep is ~6 n^3 / nb, so nb is the only knob that moves
+// it. Local memory is the binding constraint at every scalar type.
+template <typename T>
+BlockPlan plan_blocks(int32_t n, std::size_t local_mem_bytes, int32_t forced_nb) {
+    using Real = typename base_type<T>::type;
+    constexpr int32_t kMaxM = jacobi_blocked_max_m<T>();
+    constexpr bool kNeedPhase = internal::is_complex<T>::value;
+
+    // Fixed overhead that does not scale with m: the rank scratch used by the
+    // final sort, plus the two rotation counters.
+    const std::size_t fixed = static_cast<std::size_t>(n) * sizeof(int32_t) + 4 * sizeof(int32_t);
+
+    int32_t m_max = 0;
+    for (int32_t m = kMaxM; m >= 4; m -= 2) {
+        const std::size_t ld = static_cast<std::size_t>(m) + 1;
+        std::size_t bytes = 2 * static_cast<std::size_t>(m) * ld * sizeof(T);          // S and U
+        bytes += static_cast<std::size_t>(m) * static_cast<std::size_t>(m / 2) * sizeof(int16_t);  // pair table
+        bytes += static_cast<std::size_t>(m / 2) * 2 * sizeof(Real);                   // (c, s)
+        if constexpr (kNeedPhase) {
+            bytes += static_cast<std::size_t>(m / 2) * sizeof(T);                      // diagonal phase
+        }
+        bytes += fixed;
+        if (bytes <= local_mem_bytes) {
+            m_max = m;
+            break;
+        }
+    }
+    if (m_max == 0) {
+        throw std::runtime_error("syev_jacobi_blocked: device local memory is too small for any pivot block.");
+    }
+
+    BlockPlan plan;
+    plan.m_max = m_max;
+
+    // l >= 2 always: with a single block column there are no pivot pairs. The
+    // l == 2 case is the fully resident one and is deliberately reachable.
+    int32_t nb = std::min<int32_t>(m_max / 2, (n + 1) / 2);
+    if (forced_nb > 0) {
+        nb = std::min<int32_t>(std::min<int32_t>(forced_nb, m_max / 2), (n + 1) / 2);
+    }
+    nb = std::max<int32_t>(nb, 1);
+
+    int32_t l = (n + nb - 1) / nb;
+    l = std::max<int32_t>(l, 2);
+    // Rebalance so the blocks are as even as the partition allows, then make
+    // sure the rebalanced width still fits.
+    nb = (n + l - 1) / l;
+    while (2 * nb > m_max) {
+        ++l;
+        nb = (n + l - 1) / l;
+    }
+    l = (n + nb - 1) / nb;
+
+    plan.nb = nb;
+    plan.l = l;
+    return plan;
+}
+
+template <typename T, bool ComputeVectors>
+void syev_jacobi_blocked_impl(Queue& ctx,
+                              MatrixView<T, MatrixFormat::Dense>& a,
+                              typename base_type<T>::type* w_ptr,
+                              T* z_ptr,
+                              int32_t n,
+                              bool upper,
+                              const BlockPlan& plan,
+                              JacobiParams<T> params,
+                              int32_t wg_size) {
+    using Real = typename base_type<T>::type;
+    constexpr int32_t kMaxM = jacobi_blocked_max_m<T>();
+    constexpr bool kNeedPhase = internal::is_complex<T>::value;
+
+    const int32_t batch_size = static_cast<int32_t>(a.batch_size());
+
+    ctx->submit([&](sycl::handler& cgh) {
+        auto A_view = a.kernel_view();
+
+        const int32_t m_max = plan.m_max;
+        const int32_t nb = plan.nb;
+        const int32_t l = plan.l;
+        const int32_t LDS = m_max + 1;
+        const int32_t W = wg_size;
+
+        // Rows of the panel staged through local memory when the mirror runs.
+        // The staging tile reuses the S buffer, which is dead by then, so it
+        // costs nothing extra.
+        const int32_t RB = std::min<int32_t>(m_max, n);
+
+        auto S_local = sycl::local_accessor<T, 1>(sycl::range<1>(static_cast<std::size_t>(m_max) * LDS), cgh);
+        auto U_local = sycl::local_accessor<T, 1>(sycl::range<1>(static_cast<std::size_t>(m_max) * LDS), cgh);
+        auto Pair_local = sycl::local_accessor<int16_t, 1>(
+            sycl::range<1>(static_cast<std::size_t>(m_max) * static_cast<std::size_t>(m_max / 2)), cgh);
+        auto Rcs_local = sycl::local_accessor<sycl::vec<Real, 2>, 1>(
+            sycl::range<1>(static_cast<std::size_t>(m_max / 2)), cgh);
+        auto Rd_local = sycl::local_accessor<T, 1>(
+            sycl::range<1>(kNeedPhase ? static_cast<std::size_t>(m_max / 2) : 1), cgh);
+        auto Rank_local = sycl::local_accessor<int32_t, 1>(sycl::range<1>(static_cast<std::size_t>(n)), cgh);
+        // [0] rotations applied to the current pivot block, [1] rotations in the
+        // current inner sweep, [2] "this block is above threshold at all".
+        auto Cnt_local = sycl::local_accessor<int32_t, 1>(sycl::range<1>(4), cgh);
+
+        const int32_t nn = n;
+        const int32_t max_sweeps = std::max<int32_t>(int32_t(1), static_cast<int32_t>(params.max_sweeps));
+        // 0 selects by the measured rule below; anything else is a literal cap,
+        // itself clamped by max_sweeps, so a large value means "to convergence".
+        //
+        // Measured, RTX 4090 / float / saturating batch, us per matrix:
+        //
+        //             l == 2 (resident)      l > 2 (blocked)
+        //   exact          3.64 (n=64)        76.2 (n=128)  383 (n=256, vals)
+        //   1 sweep        4.81 (n=64)        55.1 (n=128)  238 (n=256, vals)
+        //
+        // The crossover has a cause, not just a number. When l == 2 the pivot
+        // block *is* the matrix, so an exact inner solve finishes the whole
+        // problem in one outer sweep and there is no outer cost left to
+        // amortize. When l > 2 the inner solve costs O(m^3) per pivot block
+        // against the outer update's O(n m^2), so extra inner sweeps buy
+        // convergence at a worse rate than another outer sweep does -- which is
+        // exactly why MAGMA's batched SVD and Novakovic's block-oriented variant
+        // both use the single inexact sweep.
+        const bool resident_solve = (l == 2);
+        const int32_t inner_cap =
+            (params.inner_sweeps == 0)
+                ? (resident_solve ? max_sweeps : 1)
+                : std::min<int32_t>(max_sweeps, static_cast<int32_t>(params.inner_sweeps));
+        const bool do_sort = params.sort;
+        const bool ascending = (params.sort_order == SortOrder::Ascending);
+        const bool is_upper = upper;
+
+        // Relative off-diagonal threshold, |a_pq| > tol * sqrt(|a_pp| * |a_qq|).
+        // The classical absolute test would forfeit the relative-accuracy result
+        // this solver exists for.
+        const Real tol = params.tol_multiplier * static_cast<Real>(nn) * std::numeric_limits<Real>::epsilon();
+        const Real tiny = std::numeric_limits<Real>::min();
+        const Real tau_big = Real(1) / sycl::sqrt(std::numeric_limits<Real>::epsilon());
+
+        Real* Wout = w_ptr;
+        T* Zbase = z_ptr;
+
+        cgh.parallel_for<SyevJacobiBlockedKernel<T, ComputeVectors>>(
+            sycl::nd_range<1>(static_cast<std::size_t>(batch_size) * W, W),
+            [=](sycl::nd_item<1> it) {
+                const auto wg = it.get_group();
+                const int32_t prob = static_cast<int32_t>(wg.get_group_linear_id());
+                const int32_t tid = static_cast<int32_t>(it.get_local_linear_id());
+
+                auto A_prob = A_view.batch_item(prob);
+                T* Ad = A_prob.data();
+                const int32_t lda = static_cast<int32_t>(A_prob.ld());
+                T* Zd = ComputeVectors ? (Zbase + static_cast<int64_t>(prob) * nn * nn) : nullptr;
+
+                // ---- Symmetrize into full storage, and seed Z = I. ----
+                // Only one triangle of A is meaningful on input; the blocked
+                // update reads whole columns, so the mirror has to exist.
+                for (int32_t idx = tid; idx < nn * nn; idx += W) {
+                    const int32_t j = idx / nn;
+                    const int32_t i = idx - j * nn;
+                    if (i == j) {
+                        Ad[i + j * lda] = force_real_jb(Ad[i + j * lda]);
+                    } else if (is_upper ? (i > j) : (i < j)) {
+                        Ad[i + j * lda] = conj_jb(Ad[j + i * lda]);
+                    }
+                    if constexpr (ComputeVectors) {
+                        Zd[i + j * nn] = (i == j) ? T(1) : T(0);
+                    }
+                }
+                sycl::group_barrier(wg);
+
+                // ---- Sweeps over block pivot pairs, cyclic ordering. ----
+                for (int32_t sweep = 0; sweep < max_sweeps; ++sweep) {
+                    int32_t sweep_rot = 0;
+
+                    for (int32_t bp = 0; bp < l - 1; ++bp) {
+                        for (int32_t bq = bp + 1; bq < l; ++bq) {
+                            const int32_t p0 = bp * nb;
+                            const int32_t q0 = bq * nb;
+                            const int32_t mp = std::min<int32_t>(nb, nn - p0);
+                            const int32_t mq = std::min<int32_t>(nb, nn - q0);
+                            const int32_t m = mp + mq;
+                            if (mp <= 0 || mq <= 0) continue;
+
+                            // Global column (and row) index of pivot slot k.
+                            const auto gidx = [=](int32_t k) {
+                                return (k < mp) ? (p0 + k) : (q0 + k - mp);
+                            };
+
+                            const int32_t me = m + (m & 1);
+                            const int32_t rounds = me - 1;
+                            const int32_t ppr = me / 2;
+
+                            // Thread decomposition used by every m-wide phase:
+                            // consecutive threads take consecutive row/column
+                            // indices so both local and global accesses stay
+                            // stride-1, and each group of m threads owns one
+                            // pivot pair.
+                            const int32_t slot = tid / m;
+                            const int32_t lane = tid - slot * m;
+                            const int32_t slots = W / m;
+                            const bool slot_active = (slot < slots);
+
+                            // Closes the previous pivot pair: everything below
+                            // reuses S, U, the pair table and the counters.
+                            sycl::group_barrier(wg);
+
+                            // ---- Gather the pivot block; seed U = I. ----
+                            if (slot_active) {
+                                for (int32_t j = slot; j < m; j += slots) {
+                                    const int32_t gj = gidx(j);
+                                    S_local[lane + j * LDS] = Ad[gidx(lane) + gj * lda];
+                                    U_local[lane + j * LDS] = (lane == j) ? T(1) : T(0);
+                                }
+                            }
+
+                            // ---- Pivot pair table for this block order. ----
+                            for (int32_t idx = tid; idx < rounds * ppr; idx += W) {
+                                const int32_t t = idx / ppr;
+                                const int32_t k = idx - t * ppr;
+                                int32_t p = 0;
+                                int32_t q = 0;
+                                round_robin_pair_jb(me, t, k, p, q);
+                                Pair_local[idx] = static_cast<int16_t>(p | (q << 8));
+                            }
+                            if (tid == 0) {
+                                Cnt_local[0] = 0;
+                                Cnt_local[2] = 0;
+                            }
+                            sycl::group_barrier(wg);
+
+                            // ---- Is this block already diagonal to threshold? ----
+                            // Without this, a converged block still costs a full
+                            // inner sweep -- m-1 rounds and three work-group
+                            // barriers each -- just to discover that it rotates
+                            // nothing. The final verification sweep is the whole
+                            // matrix in that state, so the test pays for itself
+                            // there alone. It is exactly the criterion the inner
+                            // solve applies, so it can never skip a pair the
+                            // inner solve would have rotated.
+                            if (slot_active) {
+                                int32_t dirty = 0;
+                                for (int32_t j = slot; j < m; j += slots) {
+                                    if (lane == j) continue;
+                                    const Real ajj = real_jb(S_local[j + j * LDS]);
+                                    const Real aii = real_jb(S_local[lane + lane * LDS]);
+                                    const Real g_abs = abs_jb(S_local[lane + j * LDS]);
+                                    const Real thresh = tol * sycl::sqrt(sycl::fabs(aii) * sycl::fabs(ajj));
+                                    if (g_abs > thresh && g_abs > tiny) dirty = 1;
+                                }
+                                if (dirty) {
+                                    sycl::atomic_ref<int32_t, sycl::memory_order::relaxed,
+                                                     sycl::memory_scope::work_group,
+                                                     sycl::access::address_space::local_space>
+                                        cnt(Cnt_local[2]);
+                                    cnt.fetch_add(1);
+                                }
+                            }
+                            sycl::group_barrier(wg);
+                            if (Cnt_local[2] == 0) continue;
+
+                            // ---- Inner two-sided Jacobi on S, accumulating U. ----
+                            for (int32_t isweep = 0; isweep < inner_cap; ++isweep) {
+                                if (tid == 0) Cnt_local[1] = 0;
+                                sycl::group_barrier(wg);
+
+                                for (int32_t t = 0; t < rounds; ++t) {
+                                    const int32_t tab = t * ppr;
+
+                                    if (tid < ppr) {
+                                        const int32_t pq = static_cast<int32_t>(Pair_local[tab + tid]);
+                                        const int32_t p = pq & 0xFF;
+                                        const int32_t q = (pq >> 8) & 0xFF;
+
+                                        Real c_rot = Real(1);
+                                        Real s_rot = Real(0);
+                                        T d_rot = T(1);
+                                        bool active = (q < m);
+
+                                        if (active) {
+                                            const T apq = S_local[p + q * LDS];
+                                            const Real app = real_jb(S_local[p + p * LDS]);
+                                            const Real aqq = real_jb(S_local[q + q * LDS]);
+                                            const Real g_abs = abs_jb(apq);
+                                            const Real thresh = tol * sycl::sqrt(sycl::fabs(app) * sycl::fabs(aqq));
+
+                                            if (g_abs > thresh && g_abs > tiny) {
+                                                Real g;
+                                                if constexpr (internal::is_complex<T>::value) {
+                                                    g = g_abs;
+                                                    d_rot = T(apq.real() / g_abs, -apq.imag() / g_abs);
+                                                } else {
+                                                    g = apq;
+                                                    d_rot = T(1);
+                                                }
+                                                const Real tau = (aqq - app) / (Real(2) * g);
+                                                Real tt;
+                                                if (sycl::fabs(tau) > tau_big) {
+                                                    tt = Real(1) / (Real(2) * tau);
+                                                } else {
+                                                    tt = sycl::copysign(Real(1), tau)
+                                                       / (sycl::fabs(tau) + sycl::sqrt(Real(1) + tau * tau));
+                                                }
+                                                c_rot = Real(1) / sycl::sqrt(Real(1) + tt * tt);
+                                                s_rot = tt * c_rot;
+                                                // A rotation that rounds to the
+                                                // identity never annihilates
+                                                // a_pq, so counting it would keep
+                                                // the sweep loop alive forever.
+                                                if (s_rot == Real(0)) active = false;
+                                            } else {
+                                                active = false;
+                                            }
+                                        }
+
+                                        if (!active) {
+                                            c_rot = Real(1);
+                                            s_rot = Real(0);
+                                            d_rot = T(1);
+                                        }
+                                        Rcs_local[tid] = sycl::vec<Real, 2>(c_rot, s_rot);
+                                        if constexpr (kNeedPhase) {
+                                            Rd_local[tid] = d_rot;
+                                        }
+                                        if (active) {
+                                            sycl::atomic_ref<int32_t, sycl::memory_order::relaxed,
+                                                             sycl::memory_scope::work_group,
+                                                             sycl::access::address_space::local_space>
+                                                cnt(Cnt_local[1]);
+                                            cnt.fetch_add(1);
+                                        }
+                                    }
+                                    sycl::group_barrier(wg);
+
+                                    // Phase 1: S <- S * J and U <- U * J.
+                                    // lane == row, so both arrays are touched
+                                    // with stride 1.
+                                    if (slot_active) {
+                                        for (int32_t k = slot; k < ppr; k += slots) {
+                                            const sycl::vec<Real, 2> cs = Rcs_local[k];
+                                            const Real ck = cs[0];
+                                            const Real sk = cs[1];
+                                            if (sk == Real(0)) continue;
+
+                                            const int32_t pq = static_cast<int32_t>(Pair_local[tab + k]);
+                                            const int32_t pk = pq & 0xFF;
+                                            const int32_t qk = (pq >> 8) & 0xFF;
+
+                                            T u11 = T(ck);
+                                            T u12 = T(sk);
+                                            T u21 = T(-sk);
+                                            T u22 = T(ck);
+                                            if constexpr (kNeedPhase) {
+                                                const T dk = Rd_local[k];
+                                                u21 = -mul_jb(dk, T(sk));
+                                                u22 = mul_jb(dk, T(ck));
+                                            }
+
+                                            const int32_t ip = lane + pk * LDS;
+                                            const int32_t iq = lane + qk * LDS;
+                                            const T sp = S_local[ip];
+                                            const T sq = S_local[iq];
+                                            S_local[ip] = mul_jb(sp, u11) + mul_jb(sq, u21);
+                                            S_local[iq] = mul_jb(sp, u12) + mul_jb(sq, u22);
+
+                                            const T up = U_local[ip];
+                                            const T uq = U_local[iq];
+                                            U_local[ip] = mul_jb(up, u11) + mul_jb(uq, u21);
+                                            U_local[iq] = mul_jb(up, u12) + mul_jb(uq, u22);
+                                        }
+                                    }
+                                    sycl::group_barrier(wg);
+
+                                    // Phase 2: S <- J^H * S. lane == column, so
+                                    // the stride is LDS == m_max + 1, which is
+                                    // odd and therefore conflict-free. The
+                                    // annihilated entries are stored as exact
+                                    // zeros here rather than in a separate pass.
+                                    if (slot_active) {
+                                        for (int32_t k = slot; k < ppr; k += slots) {
+                                            const sycl::vec<Real, 2> cs = Rcs_local[k];
+                                            const Real ck = cs[0];
+                                            const Real sk = cs[1];
+                                            if (sk == Real(0)) continue;
+
+                                            const int32_t pq = static_cast<int32_t>(Pair_local[tab + k]);
+                                            const int32_t pk = pq & 0xFF;
+                                            const int32_t qk = (pq >> 8) & 0xFF;
+
+                                            const T cu11 = T(ck);
+                                            const T cu12 = T(sk);
+                                            T cu21 = T(-sk);
+                                            T cu22 = T(ck);
+                                            if constexpr (kNeedPhase) {
+                                                const T dk = Rd_local[k];
+                                                cu21 = -mul_jb(conj_jb(dk), T(sk));
+                                                cu22 = mul_jb(conj_jb(dk), T(ck));
+                                            }
+
+                                            const int32_t ip = pk + lane * LDS;
+                                            const int32_t iq = qk + lane * LDS;
+                                            const T sp = S_local[ip];
+                                            const T sq = S_local[iq];
+                                            T new_p = mul_jb(cu11, sp) + mul_jb(cu21, sq);
+                                            T new_q = mul_jb(cu12, sp) + mul_jb(cu22, sq);
+                                            if (lane == qk) {
+                                                new_p = T(0);
+                                                new_q = force_real_jb(new_q);
+                                            } else if (lane == pk) {
+                                                new_q = T(0);
+                                                new_p = force_real_jb(new_p);
+                                            }
+                                            S_local[ip] = new_p;
+                                            S_local[iq] = new_q;
+                                        }
+                                    }
+                                    sycl::group_barrier(wg);
+                                }
+
+                                const int32_t inner_rot = Cnt_local[1];
+                                if (tid == 0) Cnt_local[0] += inner_rot;
+                                sycl::group_barrier(wg);
+                                if (inner_rot == 0) break;
+                            }
+
+                            const int32_t pair_rot = Cnt_local[0];
+                            sweep_rot += pair_rot;
+                            if (pair_rot == 0) continue;
+
+                            const bool full_block = (m == nn);
+
+                            // ---- Apply U. ----
+                            // When the pivot block is the whole matrix there is
+                            // no panel outside it and no rows to mirror: the
+                            // inner solve has already produced the answer.
+                            if (!full_block) {
+                                // A[:, idx] <- A[:, idx] * U over all n rows.
+                                // The whole panel row is held in registers, so
+                                // each global element is read once and written
+                                // once, both coalesced, and U is read from local
+                                // memory as a work-group-wide broadcast.
+                                for (int32_t r = tid; r < nn; r += W) {
+                                    T arow[kMaxM];
+                                    for (int32_t k = 0; k < mp; ++k) {
+                                        arow[k] = Ad[r + (p0 + k) * lda];
+                                    }
+                                    for (int32_t k = 0; k < mq; ++k) {
+                                        arow[mp + k] = Ad[r + (q0 + k) * lda];
+                                    }
+                                    for (int32_t j = 0; j < m; ++j) {
+                                        T acc = T(0);
+                                        for (int32_t k = 0; k < m; ++k) {
+                                            acc += mul_jb(arow[k], U_local[k + j * LDS]);
+                                        }
+                                        Ad[r + gidx(j) * lda] = acc;
+                                    }
+                                }
+                                sycl::group_barrier(wg);
+                            }
+
+                            // A[idx, idx] <- S, which the inner solve left equal
+                            // to U^H A[idx, idx] U.
+                            if (slot_active) {
+                                for (int32_t j = slot; j < m; j += slots) {
+                                    Ad[gidx(lane) + gidx(j) * lda] = S_local[lane + j * LDS];
+                                }
+                            }
+                            sycl::group_barrier(wg);
+
+                            if (!full_block) {
+                                // Mirror: A[idx, r] <- conj(A[r, idx]) for rows
+                                // r outside the pivot block. Staged through the
+                                // (now dead) S buffer because the destination is
+                                // transposed -- writing it directly would turn
+                                // one coalesced store into m scattered ones.
+                                const int32_t LDT = m + 1;
+                                for (int32_t r0 = 0; r0 < nn; r0 += RB) {
+                                    const int32_t rows = std::min<int32_t>(RB, nn - r0);
+                                    sycl::group_barrier(wg);
+                                    // Load: lane == row, so the global read is
+                                    // stride 1 and the local write has stride
+                                    // LDT (odd).
+                                    for (int32_t idx = tid; idx < rows * m; idx += W) {
+                                        const int32_t k = idx / rows;
+                                        const int32_t i = idx - k * rows;
+                                        S_local[k + i * LDT] = Ad[(r0 + i) + gidx(k) * lda];
+                                    }
+                                    sycl::group_barrier(wg);
+                                    // Store: lane == pivot slot, so the global
+                                    // write is stride 1 within each of the two
+                                    // block ranges and the local read has stride 1.
+                                    for (int32_t idx = tid; idx < rows * m; idx += W) {
+                                        const int32_t i = idx / m;
+                                        const int32_t k = idx - i * m;
+                                        const int32_t r = r0 + i;
+                                        const bool inside = (r >= p0 && r < p0 + mp) || (r >= q0 && r < q0 + mq);
+                                        if (inside) continue;
+                                        Ad[gidx(k) + r * lda] = conj_jb(S_local[k + i * LDT]);
+                                    }
+                                }
+                                sycl::group_barrier(wg);
+                            }
+
+                            if constexpr (ComputeVectors) {
+                                for (int32_t r = tid; r < nn; r += W) {
+                                    T zrow[kMaxM];
+                                    for (int32_t k = 0; k < mp; ++k) {
+                                        zrow[k] = Zd[r + (p0 + k) * nn];
+                                    }
+                                    for (int32_t k = 0; k < mq; ++k) {
+                                        zrow[mp + k] = Zd[r + (q0 + k) * nn];
+                                    }
+                                    for (int32_t j = 0; j < m; ++j) {
+                                        T acc = T(0);
+                                        for (int32_t k = 0; k < m; ++k) {
+                                            acc += mul_jb(zrow[k], U_local[k + j * LDS]);
+                                        }
+                                        Zd[r + gidx(j) * nn] = acc;
+                                    }
+                                }
+                            }
+                            sycl::group_barrier(wg);
+                        }
+                    }
+
+                    // Converged when a whole sweep found no pivot pair above the
+                    // relative threshold.
+                    if (sweep_rot == 0) break;
+                }
+
+                // ---- Rank-based sort, then write back. ----
+                // Ranks are computed in parallel and ties broken on index, so
+                // the permutation is a bijection and needs no scratch sort.
+                for (int32_t i = tid; i < nn; i += W) {
+                    const Real wi = real_jb(Ad[i + i * lda]);
+                    int32_t rank = i;
+                    if (do_sort) {
+                        rank = 0;
+                        for (int32_t k = 0; k < nn; ++k) {
+                            const Real wk = real_jb(Ad[k + k * lda]);
+                            const bool before = ascending ? (wk < wi || (wk == wi && k < i))
+                                                          : (wk > wi || (wk == wi && k < i));
+                            if (before) ++rank;
+                        }
+                    }
+                    Rank_local[i] = rank;
+                    Wout[static_cast<int64_t>(prob) * nn + rank] = wi;
+                }
+                sycl::group_barrier(wg);
+
+                if constexpr (ComputeVectors) {
+                    for (int32_t c = 0; c < nn; ++c) {
+                        const int32_t dst = Rank_local[c];
+                        for (int32_t r = tid; r < nn; r += W) {
+                            Ad[r + dst * lda] = Zd[r + c * nn];
+                        }
+                    }
+                }
+            });
+    });
+}
+
+template <typename T>
+void validate_jacobi_blocked(const MatrixView<T, MatrixFormat::Dense>& a, JobType jobz, const char* who) {
+    if (a.rows() != a.cols()) {
+        throw std::invalid_argument(std::string(who) + ": A must be square.");
+    }
+    if (jobz != JobType::NoEigenVectors && jobz != JobType::EigenVectors) {
+        throw std::invalid_argument(std::string(who) + ": invalid JobType.");
+    }
+    if (a.rows() < 2 || a.rows() > 1024) {
+        throw std::invalid_argument(std::string(who) + " supports 2 <= n <= 1024.");
+    }
+}
+
+// Default work-group size, measured on RTX 4090 / float / saturating batch
+// (us per matrix, eigenvectors):
+//
+//            wg=256   wg=512   wg=768   wg=1024
+//   n=64      3.36     3.00     2.94      3.96
+//   n=128    55.4     51.5     52.0      44.8
+//   n=256   398      398      421       372
+//
+// Two regimes, and the split is the same l == 2 boundary as the inner-sweep
+// rule. A resident solve (l == 2) never leaves local memory, so it is bound by
+// local-memory traffic and barriers and wants *two* work-groups per SM to hide
+// them -- and with Ada's 1536-thread-per-SM ceiling that caps the work-group at
+// 768. Going to 1024 halves residency and costs 35%, which is the cliff in the
+// n=64 row. A blocked solve (l > 2) is bound by global-memory latency on the
+// panel update instead, where one wide work-group issuing more concurrent loads
+// beats two narrow ones.
+int32_t jacobi_blocked_wg_size(Queue& ctx, const BlockPlan& plan) {
+    const auto dev = ctx->get_device();
+    const int32_t max_wg = static_cast<int32_t>(dev.get_info<sycl::info::device::max_work_group_size>());
+    const int32_t fallback = (plan.l == 2) ? 768 : 1024;
+    int32_t wg = env_positive_int_or("BATCHLAS_JACOBI_BLOCKED_WG", fallback);
+    wg = std::min(wg, max_wg);
+    // Every m-wide phase decomposes the work-group into groups of m threads, so
+    // the work-group has to be at least one pivot-block order wide.
+    wg = std::max(wg, plan.m_max);
+    wg = (wg / 32) * 32;
+    return std::max<int32_t>(wg, 32);
+}
+
+} // namespace
+
+template <Backend B, typename T>
+Event syev_jacobi_blocked(Queue& ctx,
+                          const MatrixView<T, MatrixFormat::Dense>& a_in,
+                          Span<typename base_type<T>::type> eigenvalues,
+                          JobType jobz,
+                          Uplo uplo,
+                          const Span<std::byte>& ws,
+                          JacobiParams<T> params) {
+    validate_jacobi_blocked(a_in, jobz, "syev_jacobi_blocked");
+
+    const int32_t n = static_cast<int32_t>(a_in.rows());
+    const int64_t batch = a_in.batch_size();
+
+    if (eigenvalues.size() < static_cast<std::size_t>(n) * static_cast<std::size_t>(batch)) {
+        throw std::invalid_argument("syev_jacobi_blocked: eigenvalues span too small for n*batch.");
+    }
+
+    const std::size_t local_mem = ctx->get_device().get_info<sycl::info::device::local_mem_size>();
+    const int32_t forced_nb = env_positive_int_or("BATCHLAS_JACOBI_BLOCKED_NB",
+                                                  static_cast<int32_t>(params.block_size));
+    const BlockPlan plan = plan_blocks<T>(n, local_mem, forced_nb);
+    const int32_t wg = jacobi_blocked_wg_size(ctx, plan);
+
+    auto& a = const_cast<MatrixView<T, MatrixFormat::Dense>&>(a_in);
+    const bool upper = (uplo == Uplo::Upper);
+    const bool vectors = (jobz == JobType::EigenVectors);
+
+    if (vectors) {
+        auto ws_mut = const_cast<Span<std::byte>&>(ws);
+        BumpAllocator pool(ws_mut);
+        auto z = pool.allocate<T>(ctx, static_cast<std::size_t>(n) * n * static_cast<std::size_t>(batch));
+        syev_jacobi_blocked_impl<T, true>(ctx, a, eigenvalues.data(), z.data(), n, upper, plan, params, wg);
+    } else {
+        syev_jacobi_blocked_impl<T, false>(ctx, a, eigenvalues.data(), nullptr, n, upper, plan, params, wg);
+    }
+
+    return ctx.get_event();
+}
+
+template <Backend B, typename T>
+size_t syev_jacobi_blocked_buffer_size(Queue& ctx,
+                                       const MatrixView<T, MatrixFormat::Dense>& a,
+                                       JobType jobz,
+                                       JacobiParams<T> params) {
+    (void)params;
+    validate_jacobi_blocked(a, jobz, "syev_jacobi_blocked_buffer_size");
+    if (jobz != JobType::EigenVectors) return 0;
+
+    const std::size_t n = static_cast<std::size_t>(a.rows());
+    const std::size_t batch = static_cast<std::size_t>(a.batch_size());
+    return BumpAllocator::allocation_size<T>(ctx, n * n * batch);
+}
+
+#define SYEV_JACOBI_BLOCKED_INSTANTIATE(back, fp) \
+    template Event syev_jacobi_blocked<back, BATCHLAS_UNPAREN fp>(Queue&, const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>&, \
+                                                                  Span<typename base_type<BATCHLAS_UNPAREN fp>::type>, JobType, Uplo, \
+                                                                  const Span<std::byte>&, JacobiParams<BATCHLAS_UNPAREN fp>); \
+    template size_t syev_jacobi_blocked_buffer_size<back, BATCHLAS_UNPAREN fp>(Queue&, const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>&, \
+                                                                               JobType, JacobiParams<BATCHLAS_UNPAREN fp>);
+
+#define SYEV_JACOBI_BLOCKED_INSTANTIATE_FOR_BACKEND(back) \
+    BATCHLAS_FOR_EACH_SCALAR_TYPE_1(SYEV_JACOBI_BLOCKED_INSTANTIATE, back)
+
+#if BATCHLAS_HAS_CUDA_BACKEND
+    SYEV_JACOBI_BLOCKED_INSTANTIATE_FOR_BACKEND(Backend::CUDA)
+#endif
+
+#if BATCHLAS_HAS_ROCM_BACKEND
+    SYEV_JACOBI_BLOCKED_INSTANTIATE_FOR_BACKEND(Backend::ROCM)
+#endif
+
+#if BATCHLAS_HAS_HOST_BACKEND
+    SYEV_JACOBI_BLOCKED_INSTANTIATE_FOR_BACKEND(Backend::NETLIB)
+#endif
+
+#undef SYEV_JACOBI_BLOCKED_INSTANTIATE_FOR_BACKEND
+#undef SYEV_JACOBI_BLOCKED_INSTANTIATE
+
+} // namespace batchlas

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ set(TEST_TARGETS
     sytrd_blocked_tests
     syev_cta_tests
     syev_jacobi_cta_tests
+    syev_jacobi_blocked_tests
     syev_cta_fused_tests
     syev_blocked_tests
     syev_two_stage_tests
@@ -138,6 +139,7 @@ set(BATCHLAS_TEST_LABELS_tridiag
     sytrd_cta_tests sytrd_blocked_tests)
 set(BATCHLAS_TEST_LABELS_eig
     syev_tests syevx_tests syevx_range_tests syev_cta_tests syev_jacobi_cta_tests
+    syev_jacobi_blocked_tests
     syev_cta_fused_tests syev_blocked_tests syev_two_stage_tests
     lanczos_tests ritz_values_tests gesvd_tests gesvdj_cta_tests bdsqr_tests bdsdc_tests)
 set(BATCHLAS_TEST_LABELS_sparse

--- a/tests/syev_jacobi_blocked_tests.cc
+++ b/tests/syev_jacobi_blocked_tests.cc
@@ -1,0 +1,588 @@
+#include <gtest/gtest.h>
+
+#include <blas/enums.hh>
+#include <blas/extensions.hh>
+#include <blas/functions.hh>
+#include <blas/matrix.hh>
+#include <util/sycl-device-queue.hh>
+#include <util/sycl-span.hh>
+#include <util/sycl-vector.hh>
+
+#include "test_utils.hh"
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <type_traits>
+#include <vector>
+
+using namespace batchlas;
+
+namespace {
+
+template <typename Scalar>
+using RealOf = typename base_type<Scalar>::type;
+
+template <typename Scalar>
+static RealOf<Scalar> abs_val(const Scalar& x) {
+    return static_cast<RealOf<Scalar>>(std::abs(x));
+}
+
+template <typename Scalar>
+static RealOf<Scalar> norm2_val(const Scalar& x) {
+    using Real = RealOf<Scalar>;
+    if constexpr (std::is_same_v<Scalar, Real>) {
+        return x * x;
+    } else {
+        return static_cast<Real>(std::norm(x));
+    }
+}
+
+template <typename Scalar>
+static Scalar conj_val(const Scalar& x) {
+    if constexpr (std::is_same_v<Scalar, RealOf<Scalar>>) {
+        return x;
+    } else {
+        return std::conj(x);
+    }
+}
+
+template <typename Scalar>
+static void check_orthonormal_columns(const MatrixView<Scalar, MatrixFormat::Dense>& V,
+                                      int n, int b, RealOf<Scalar> tol) {
+    using Real = RealOf<Scalar>;
+    Real max_err = Real(0);
+    for (int j = 0; j < n; ++j) {
+        for (int i = 0; i < n; ++i) {
+            Scalar dot = Scalar(0);
+            for (int r = 0; r < n; ++r) {
+                dot += conj_val(V(r, i, b)) * V(r, j, b);
+            }
+            const Real target = (i == j) ? Real(1) : Real(0);
+            max_err = std::max(max_err, abs_val(dot - Scalar(target)));
+        }
+    }
+    EXPECT_LE(max_err, tol) << "max |V^H V - I| = " << max_err << " (batch " << b << ")";
+}
+
+template <typename Scalar>
+static void check_eigen_residual(const MatrixView<Scalar, MatrixFormat::Dense>& A0,
+                                 const MatrixView<Scalar, MatrixFormat::Dense>& V,
+                                 const UnifiedVector<RealOf<Scalar>>& W,
+                                 int n, int b, RealOf<Scalar> tol) {
+    using Real = RealOf<Scalar>;
+
+    Real a_norm2 = Real(0);
+    for (int j = 0; j < n; ++j) {
+        for (int i = 0; i < n; ++i) {
+            a_norm2 += norm2_val(A0(i, j, b));
+        }
+    }
+    const Real a_norm = std::sqrt(a_norm2);
+
+    Real r_norm2 = Real(0);
+    for (int j = 0; j < n; ++j) {
+        const Real wj = W[static_cast<std::size_t>(b) * static_cast<std::size_t>(n) + static_cast<std::size_t>(j)];
+        for (int i = 0; i < n; ++i) {
+            Scalar sum = Scalar(0);
+            for (int k = 0; k < n; ++k) {
+                sum += A0(i, k, b) * V(k, j, b);
+            }
+            sum -= Scalar(wj) * V(i, j, b);
+            r_norm2 += norm2_val(sum);
+        }
+    }
+
+    const Real r_norm = std::sqrt(r_norm2);
+    const Real denom = (a_norm > Real(0)) ? (a_norm * Real(n)) : Real(1);
+    const Real rel = r_norm / denom;
+    EXPECT_LE(rel, tol) << "relative residual ||AV - VW||/(||A||*n) = " << rel << " (batch " << b << ")";
+}
+
+// Accumulated rounding grows with the number of rotations, which is O(n^2) per
+// sweep, so the fixed absolute tolerance from test_utils is scaled by sqrt(n).
+// Identical rationale (and constants) to syev_jacobi_cta_tests.
+template <typename Scalar>
+static RealOf<Scalar> vec_tol(int n, RealOf<Scalar> extra = RealOf<Scalar>(1)) {
+    using Real = RealOf<Scalar>;
+    return test_utils::tolerance<Scalar>() * std::sqrt(Real(n)) * extra;
+}
+
+template <typename Scalar>
+static RealOf<Scalar> eig_compare_tol(const UnifiedVector<RealOf<Scalar>>& w_ref, int n, int batch) {
+    using Real = RealOf<Scalar>;
+    Real lambda_max = Real(1);
+    for (int i = 0; i < n * batch; ++i) {
+        lambda_max = std::max(lambda_max, std::abs(w_ref[static_cast<std::size_t>(i)]));
+    }
+    return test_utils::tolerance<Scalar>() * lambda_max * std::sqrt(Real(n));
+}
+
+// Runs the solver and returns the eigenvalues, taking care of the workspace.
+template <Backend B, typename Scalar>
+static void run_blocked(Queue& ctx,
+                        MatrixView<Scalar, MatrixFormat::Dense> a,
+                        Span<RealOf<Scalar>> w,
+                        JobType jobz,
+                        Uplo uplo,
+                        JacobiParams<Scalar> params = JacobiParams<Scalar>()) {
+    const std::size_t ws_bytes = syev_jacobi_blocked_buffer_size<B, Scalar>(ctx, a, jobz, params);
+    auto ws = UnifiedVector<std::byte>(ws_bytes);
+    syev_jacobi_blocked<B, Scalar>(ctx, a, w, jobz, uplo, ws.to_span(), params).wait();
+}
+
+// ---------------------------------------------------------------------------
+// Independent CPU reference: cyclic-by-rows two-sided Jacobi in double.
+//
+// A double LAPACK syev cannot serve as the truth for the graded test: it
+// tridiagonalizes, so its own error on the smallest eigenvalue of a strongly
+// graded matrix is ~eps_double*||A||, far larger than the eigenvalue itself.
+// ---------------------------------------------------------------------------
+static std::vector<double> reference_jacobi_eigenvalues(const std::vector<double>& A_in, int n) {
+    std::vector<double> A = A_in; // column-major n x n
+    const double tol = double(n) * std::numeric_limits<double>::epsilon();
+
+    for (int sweep = 0; sweep < 100; ++sweep) {
+        int rotations = 0;
+        for (int p = 0; p < n - 1; ++p) {
+            for (int q = p + 1; q < n; ++q) {
+                const double apq = A[p + q * n];
+                const double app = A[p + p * n];
+                const double aqq = A[q + q * n];
+                if (std::abs(apq) <= tol * std::sqrt(std::abs(app) * std::abs(aqq))) continue;
+                if (apq == 0.0) continue;
+
+                const double tau = (aqq - app) / (2.0 * apq);
+                const double t = std::copysign(1.0, tau) / (std::abs(tau) + std::sqrt(1.0 + tau * tau));
+                const double c = 1.0 / std::sqrt(1.0 + t * t);
+                const double s = t * c;
+
+                for (int r = 0; r < n; ++r) {
+                    const double arp = A[r + p * n];
+                    const double arq = A[r + q * n];
+                    A[r + p * n] = c * arp - s * arq;
+                    A[r + q * n] = s * arp + c * arq;
+                }
+                for (int cc = 0; cc < n; ++cc) {
+                    const double apc = A[p + cc * n];
+                    const double aqc = A[q + cc * n];
+                    A[p + cc * n] = c * apc - s * aqc;
+                    A[q + cc * n] = s * apc + c * aqc;
+                }
+                A[p + q * n] = 0.0;
+                A[q + p * n] = 0.0;
+                ++rotations;
+            }
+        }
+        if (rotations == 0) break;
+    }
+
+    std::vector<double> w(static_cast<std::size_t>(n));
+    for (int i = 0; i < n; ++i) w[static_cast<std::size_t>(i)] = A[i + i * n];
+    std::sort(w.begin(), w.end());
+    return w;
+}
+
+// Graded SPD matrix A = D * M * D, D_ii = 2^{-e_i}, with the exponents spread
+// linearly over [0, span] rather than stepped by a fixed amount per index.
+//
+// The fixed-step form used at n <= 32 does not survive to n = 128: a step of 2
+// puts the smallest entry at 2^{-4*127}, which is not merely inaccurate in
+// float, it is *zero*, so the test would be measuring underflow rather than the
+// solver. Spreading a fixed total span keeps the smallest eigenvalue a decade
+// or two above FLT_MIN at every n while kappa(A) stays ~2^(2*span).
+//
+// Every entry is a dyadic rational, so float and double see exactly the same
+// matrix and any difference in the answer is precision, not input rounding. The
+// column-equilibrated condition number stays O(kappa(M)) -- the regime where
+// the relative-accuracy bound bites.
+static void make_graded_spd(int n, int span, unsigned seed,
+                            std::vector<double>& out_double,
+                            std::vector<float>& out_float) {
+    std::minstd_rand rng(seed);
+    std::uniform_int_distribution<int> dist(-16, 16);
+
+    std::vector<double> M(static_cast<std::size_t>(n) * static_cast<std::size_t>(n), 0.0);
+    for (int j = 0; j < n; ++j) {
+        for (int i = j; i < n; ++i) {
+            if (i == j) {
+                M[i + j * n] = 1.0;
+            } else {
+                const double v = double(dist(rng)) / 256.0; // dyadic, |v| <= 1/16
+                M[i + j * n] = v;
+                M[j + i * n] = v;
+            }
+        }
+    }
+
+    std::vector<double> D(static_cast<std::size_t>(n));
+    for (int i = 0; i < n; ++i) {
+        const int e = (n > 1) ? (span * i) / (n - 1) : 0;
+        D[static_cast<std::size_t>(i)] = std::ldexp(1.0, -e);
+    }
+
+    out_double.assign(static_cast<std::size_t>(n) * static_cast<std::size_t>(n), 0.0);
+    out_float.assign(static_cast<std::size_t>(n) * static_cast<std::size_t>(n), 0.0f);
+    for (int j = 0; j < n; ++j) {
+        for (int i = 0; i < n; ++i) {
+            const double v = D[static_cast<std::size_t>(i)] * M[i + j * n] * D[static_cast<std::size_t>(j)];
+            out_double[static_cast<std::size_t>(i + j * n)] = v;
+            out_float[static_cast<std::size_t>(i + j * n)] = static_cast<float>(v);
+        }
+    }
+}
+
+template <typename T, Backend B>
+struct SyevJacobiBlockedConfig {
+    using ScalarType = T;
+    static constexpr Backend BackendVal = B;
+};
+
+} // namespace
+
+#if BATCHLAS_HAS_CUDA_BACKEND
+using SyevJacobiBlockedTestTypes = ::testing::Types<
+    SyevJacobiBlockedConfig<float, Backend::CUDA>,
+    SyevJacobiBlockedConfig<double, Backend::CUDA>,
+    SyevJacobiBlockedConfig<std::complex<float>, Backend::CUDA>,
+    SyevJacobiBlockedConfig<std::complex<double>, Backend::CUDA>>;
+#elif BATCHLAS_HAS_ROCM_BACKEND
+using SyevJacobiBlockedTestTypes = ::testing::Types<
+    SyevJacobiBlockedConfig<float, Backend::ROCM>,
+    SyevJacobiBlockedConfig<double, Backend::ROCM>,
+    SyevJacobiBlockedConfig<std::complex<float>, Backend::ROCM>,
+    SyevJacobiBlockedConfig<std::complex<double>, Backend::ROCM>>;
+#else
+using SyevJacobiBlockedTestTypes = ::testing::Types<SyevJacobiBlockedConfig<float, Backend::NETLIB>>;
+#endif
+
+template <typename Config>
+class SyevJacobiBlockedTest : public test_utils::BatchLASTest<Config> {};
+
+TYPED_TEST_SUITE(SyevJacobiBlockedTest, SyevJacobiBlockedTestTypes);
+
+#if BATCHLAS_HAS_CUDA_BACKEND || BATCHLAS_HAS_ROCM_BACKEND
+
+// n = 64 is the l == 2 case: the pivot block is the whole matrix, so the panel
+// update and the mirror never run. n = 128 exercises the general path with four
+// block columns and six pivot pairs per sweep.
+TYPED_TEST(SyevJacobiBlockedTest, EigenvaluesMatchNetlib) {
+    using Scalar = typename TestFixture::ScalarType;
+    using Real = typename base_type<Scalar>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    const int batch = 3;
+
+    for (int n : {64, 128}) {
+        for (auto uplo : {Uplo::Lower, Uplo::Upper}) {
+            SCOPED_TRACE(::testing::Message() << "n=" << n
+                            << " uplo=" << (uplo == Uplo::Lower ? "Lower" : "Upper"));
+
+            Matrix<Scalar, MatrixFormat::Dense> A0 =
+                Matrix<Scalar, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/321);
+            Matrix<Scalar, MatrixFormat::Dense> A_jac = A0;
+            Matrix<Scalar, MatrixFormat::Dense> A_ref = A0;
+
+            auto W_jac = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+            auto W_ref = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+
+#if BATCHLAS_HAS_HOST_BACKEND
+            {
+                auto ws_ref = UnifiedVector<std::byte>(syev_buffer_size(
+                    *this->ctx, A_ref.view(), W_ref.to_span(), JobType::NoEigenVectors, uplo));
+                syev(*this->ctx,
+                     A_ref.view(),
+                     W_ref.to_span(),
+                     {.jobz = JobType::NoEigenVectors, .uplo = uplo},
+                     ws_ref.to_span()).wait();
+            }
+#endif
+
+            run_blocked<B, Scalar>(*this->ctx, A_jac.view(), W_jac.to_span(),
+                                   JobType::NoEigenVectors, uplo);
+
+#if BATCHLAS_HAS_HOST_BACKEND
+            const Real tol = eig_compare_tol<Scalar>(W_ref, n, batch);
+            for (int b = 0; b < batch; ++b) {
+                for (int i = 0; i < n; ++i) {
+                    const std::size_t idx = static_cast<std::size_t>(b) * static_cast<std::size_t>(n)
+                                          + static_cast<std::size_t>(i);
+                    ASSERT_NEAR(W_jac[idx], W_ref[idx], tol)
+                        << "eigenvalue mismatch i=" << i << " batch=" << b << " n=" << n;
+                }
+            }
+#endif
+        }
+    }
+}
+
+TYPED_TEST(SyevJacobiBlockedTest, EigenvectorsResidualAndOrtho) {
+    using Scalar = typename TestFixture::ScalarType;
+    using Real = typename base_type<Scalar>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    const int batch = 2;
+
+    for (int n : {64, 128}) {
+        for (auto uplo : {Uplo::Lower, Uplo::Upper}) {
+            SCOPED_TRACE(::testing::Message() << "n=" << n
+                            << " uplo=" << (uplo == Uplo::Lower ? "Lower" : "Upper"));
+
+            Matrix<Scalar, MatrixFormat::Dense> A0 =
+                Matrix<Scalar, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/654);
+            Matrix<Scalar, MatrixFormat::Dense> A_jac = A0;
+
+            auto W_jac = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+            run_blocked<B, Scalar>(*this->ctx, A_jac.view(), W_jac.to_span(),
+                                   JobType::EigenVectors, uplo);
+
+            for (int b = 0; b < batch; ++b) {
+                check_orthonormal_columns(A_jac.view(), n, b, vec_tol<Scalar>(n));
+                check_eigen_residual(A0.view(), A_jac.view(), W_jac, n, b, vec_tol<Scalar>(n));
+            }
+        }
+    }
+}
+
+// Sizes that are not multiples of the auto-selected block width, plus odd n,
+// which pads the round-robin index space and forces the phantom-pivot skip.
+TYPED_TEST(SyevJacobiBlockedTest, RaggedAndOddSizes) {
+    using Scalar = typename TestFixture::ScalarType;
+    using Real = typename base_type<Scalar>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    const int batch = 2;
+
+    for (int n : {33, 47, 65, 97, 129}) {
+        SCOPED_TRACE(::testing::Message() << "n=" << n);
+
+        Matrix<Scalar, MatrixFormat::Dense> A0 = Matrix<Scalar, MatrixFormat::Dense>::Random(
+            n, n, /*hermitian=*/true, batch, /*seed=*/static_cast<unsigned>(2000 + n));
+        Matrix<Scalar, MatrixFormat::Dense> A_jac = A0;
+
+        auto W_jac = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+        run_blocked<B, Scalar>(*this->ctx, A_jac.view(), W_jac.to_span(),
+                               JobType::EigenVectors, Uplo::Lower);
+
+        for (int b = 0; b < batch; ++b) {
+            check_orthonormal_columns(A_jac.view(), n, b, vec_tol<Scalar>(n));
+            check_eigen_residual(A0.view(), A_jac.view(), W_jac, n, b, vec_tol<Scalar>(n));
+        }
+    }
+}
+
+// A narrow forced block width turns one pivot pair per sweep into many, so this
+// is the test that actually exercises the panel update, the mirror and the
+// cyclic block ordering rather than the fully resident degenerate case.
+TYPED_TEST(SyevJacobiBlockedTest, ForcedNarrowBlockWidth) {
+    using Scalar = typename TestFixture::ScalarType;
+    using Real = typename base_type<Scalar>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    const int n = 64;
+    const int batch = 2;
+
+    for (std::size_t nb : {std::size_t(4), std::size_t(8), std::size_t(11)}) {
+        SCOPED_TRACE(::testing::Message() << "nb=" << nb);
+
+        Matrix<Scalar, MatrixFormat::Dense> A0 =
+            Matrix<Scalar, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/777);
+        Matrix<Scalar, MatrixFormat::Dense> A_jac = A0;
+
+        JacobiParams<Scalar> params;
+        params.block_size = nb;
+
+        auto W_jac = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+        run_blocked<B, Scalar>(*this->ctx, A_jac.view(), W_jac.to_span(),
+                               JobType::EigenVectors, Uplo::Lower, params);
+
+        for (int b = 0; b < batch; ++b) {
+            check_orthonormal_columns(A_jac.view(), n, b, vec_tol<Scalar>(n));
+            check_eigen_residual(A0.view(), A_jac.view(), W_jac, n, b, vec_tol<Scalar>(n));
+        }
+    }
+}
+
+// inner_sweeps = 1 is the inexact/block-oriented variant; a value at or above
+// max_sweeps diagonalizes each pivot block exactly. Both have to reach the same
+// answer; only the sweep count (and hence the cost) differs.
+TYPED_TEST(SyevJacobiBlockedTest, InnerSweepVariantsAgree) {
+    using Scalar = typename TestFixture::ScalarType;
+    using Real = typename base_type<Scalar>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    const int n = 96;
+    const int batch = 2;
+
+    Matrix<Scalar, MatrixFormat::Dense> A0 =
+        Matrix<Scalar, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/8181);
+
+    auto W_inexact = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+    auto W_exact = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+
+    {
+        Matrix<Scalar, MatrixFormat::Dense> A = A0;
+        JacobiParams<Scalar> params;
+        params.inner_sweeps = 1;
+        params.block_size = 8;
+        run_blocked<B, Scalar>(*this->ctx, A.view(), W_inexact.to_span(),
+                               JobType::NoEigenVectors, Uplo::Lower, params);
+    }
+    {
+        Matrix<Scalar, MatrixFormat::Dense> A = A0;
+        JacobiParams<Scalar> params;
+        params.inner_sweeps = params.max_sweeps; // diagonalize each pivot block exactly
+        params.block_size = 8;
+        run_blocked<B, Scalar>(*this->ctx, A.view(), W_exact.to_span(),
+                               JobType::NoEigenVectors, Uplo::Lower, params);
+    }
+
+    const Real tol = eig_compare_tol<Scalar>(W_exact, n, batch);
+    for (int i = 0; i < n * batch; ++i) {
+        ASSERT_NEAR(W_inexact[static_cast<std::size_t>(i)], W_exact[static_cast<std::size_t>(i)], tol)
+            << "inexact and exact inner solves disagree at i=" << i;
+    }
+}
+
+TYPED_TEST(SyevJacobiBlockedTest, DescendingSortOrder) {
+    using Scalar = typename TestFixture::ScalarType;
+    using Real = typename base_type<Scalar>::type;
+    constexpr Backend B = TestFixture::BackendType;
+
+    const int n = 64;
+    const int batch = 2;
+
+    Matrix<Scalar, MatrixFormat::Dense> A0 =
+        Matrix<Scalar, MatrixFormat::Dense>::Random(n, n, /*hermitian=*/true, batch, /*seed=*/91);
+
+    auto W_asc = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+    auto W_desc = UnifiedVector<Real>(static_cast<std::size_t>(n * batch));
+
+    {
+        Matrix<Scalar, MatrixFormat::Dense> A = A0;
+        run_blocked<B, Scalar>(*this->ctx, A.view(), W_asc.to_span(), JobType::NoEigenVectors, Uplo::Lower);
+    }
+    {
+        Matrix<Scalar, MatrixFormat::Dense> A = A0;
+        JacobiParams<Scalar> params;
+        params.sort_order = SortOrder::Descending;
+        run_blocked<B, Scalar>(*this->ctx, A.view(), W_desc.to_span(),
+                               JobType::NoEigenVectors, Uplo::Lower, params);
+    }
+
+    for (int b = 0; b < batch; ++b) {
+        for (int i = 0; i < n; ++i) {
+            const std::size_t asc = static_cast<std::size_t>(b) * n + static_cast<std::size_t>(i);
+            const std::size_t desc = static_cast<std::size_t>(b) * n + static_cast<std::size_t>(n - 1 - i);
+            ASSERT_EQ(W_asc[asc], W_desc[desc]) << "descending order is not the reverse of ascending, i=" << i;
+        }
+        for (int i = 1; i < n; ++i) {
+            const std::size_t base = static_cast<std::size_t>(b) * n;
+            ASSERT_LE(W_asc[base + i - 1], W_asc[base + i]);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The payoff. Graded SPD input where kappa(A) ~ 1e36 but the column-equilibrated
+// condition number stays O(1). syev_jacobi_cta proves this at n <= 32; this test
+// is the statement that blocking does not destroy it at n = 64 and n = 128.
+//
+// The reference is an independent double-precision CPU Jacobi. The vendor/
+// blocked syev column is printed for context but deliberately not asserted --
+// it is expected to be catastrophically wrong here, and pinning someone else's
+// error is not this test's job.
+// ---------------------------------------------------------------------------
+TEST(SyevJacobiBlockedRelativeAccuracy, GradedSpd) {
+#if BATCHLAS_HAS_CUDA_BACKEND
+    constexpr Backend B = Backend::CUDA;
+#elif BATCHLAS_HAS_ROCM_BACKEND
+    constexpr Backend B = Backend::ROCM;
+#else
+    GTEST_SKIP() << "No GPU backend built.";
+#endif
+#if BATCHLAS_HAS_CUDA_BACKEND || BATCHLAS_HAS_ROCM_BACKEND
+    auto ctx = std::make_shared<Queue>(Device("gpu"), B);
+
+    for (int n : {64, 128}) {
+        SCOPED_TRACE(::testing::Message() << "n=" << n);
+
+        // kappa(A) ~ 2^(2*span) ~ 1e35, with the smallest eigenvalue near
+        // 2^-116 ~ 1e-35 -- three orders above FLT_MIN, so it is a number
+        // float can represent and therefore a number the solver is obliged to
+        // resolve. A tridiagonalizing solver's relative error here is
+        // ~ eps_float * kappa(A) ~ 1e28.
+        const int span = 58;
+
+        std::vector<double> Ad;
+        std::vector<float> Af;
+        make_graded_spd(n, span, /*seed=*/13, Ad, Af);
+
+        const std::vector<double> w_ref = reference_jacobi_eigenvalues(Ad, n);
+
+        Matrix<float, MatrixFormat::Dense> A(n, n, 1);
+        for (int j = 0; j < n; ++j) {
+            for (int i = 0; i < n; ++i) {
+                A.view()(i, j, 0) = Af[static_cast<std::size_t>(i + j * n)];
+            }
+        }
+
+        auto W = UnifiedVector<float>(static_cast<std::size_t>(n));
+        JacobiParams<float> params;
+        const std::size_t ws_bytes =
+            syev_jacobi_blocked_buffer_size<B, float>(*ctx, A.view(), JobType::NoEigenVectors, params);
+        auto ws = UnifiedVector<std::byte>(ws_bytes);
+        syev_jacobi_blocked<B, float>(*ctx, A.view(), W.to_span(), JobType::NoEigenVectors,
+                                      Uplo::Lower, ws.to_span(), params).wait();
+
+        auto max_relative_error = [&](const UnifiedVector<float>& w) {
+            double worst = 0.0;
+            for (int i = 0; i < n; ++i) {
+                const double ref = w_ref[static_cast<std::size_t>(i)];
+                if (ref == 0.0) continue;
+                worst = std::max(worst,
+                                 std::abs(double(w[static_cast<std::size_t>(i)]) - ref) / std::abs(ref));
+            }
+            return worst;
+        };
+
+        const double max_rel = max_relative_error(W);
+
+        // The routed syev on identical input, for contrast. It tridiagonalizes,
+        // so its relative error on the small end is ~ eps * kappa(A); the figure
+        // is printed rather than asserted, because pinning another solver's
+        // error is not this test's job.
+        Matrix<float, MatrixFormat::Dense> A_ref(n, n, 1);
+        for (int j = 0; j < n; ++j) {
+            for (int i = 0; i < n; ++i) {
+                A_ref.view()(i, j, 0) = Af[static_cast<std::size_t>(i + j * n)];
+            }
+        }
+        auto W_ref_dev = UnifiedVector<float>(static_cast<std::size_t>(n));
+        {
+            auto ws_ref = UnifiedVector<std::byte>(syev_buffer_size(
+                *ctx, A_ref.view(), W_ref_dev.to_span(), JobType::NoEigenVectors, Uplo::Lower));
+            syev(*ctx, A_ref.view(), W_ref_dev.to_span(),
+                 {.jobz = JobType::NoEigenVectors, .uplo = Uplo::Lower}, ws_ref.to_span()).wait();
+        }
+
+        std::cout << "  n=" << n << " span=" << span
+                  << " spectrum [" << w_ref.front() << ", " << w_ref.back() << "]"
+                  << "  max relative eigenvalue error: jacobi_blocked = " << max_rel
+                  << ", syev = " << max_relative_error(W_ref_dev) << std::endl;
+
+        // A tridiagonalizing solver has relative error ~ eps*kappa(A) here,
+        // i.e. astronomically large. Jacobi's bound is ~ eps * kappa of the
+        // equilibrated matrix, a small multiple of float eps. The constant is
+        // generous relative to the measured value so the test pins the property
+        // rather than the exact rounding.
+        EXPECT_LT(max_rel, 1e-4) << "relative accuracy on graded SPD input was lost at n=" << n;
+    }
+#endif
+}
+
+#endif // GPU backend


### PR DESCRIPTION
Implements **WP8 / C1** of `SYEV_PERF_IMPLEMENTATION_PLAN.md` ("block Jacobi at n = 64–256"), which defers to Tiers B and C of `JACOBI_EIGENSOLVER_PLAN.md`. Tier A (`syev_jacobi_cta`, n ≤ 32) was already in tree; B and C were design-only. Both now exist as one kernel.

Full write-up: `SYEV_JACOBI_BLOCKED_RESULTS.md`.

## Headline

**The accuracy payoff holds at scale; the speed bet does not.** Ships unrouted, as an opt-in accuracy backend — the role both plans already assign to Jacobi.

Graded SPD input, κ(A) ≈ 1e35, max **relative** eigenvalue error, both solvers in float on identical input:

| n | `syev_jacobi_blocked` | routed `syev` |
|---|---|---|
| 64 | **3.0e-06** | 1.6e+27 |
| 128 | **1.2e-05** | 4.8e+26 |

Speed, RTX 4090 / float / saturating batch / eigenvectors, µs per matrix:

| n | blocked Jacobi | routed `syev` | ratio |
|---|---|---|---|
| 64 | 2.92 | 1.44 | 2.03x slower |
| 128 | 44.7 | 6.54 | 6.83x |
| 256 | 370 | 32.1 | 11.5x |

## WP8's estimate was 3x optimistic, and the error is arithmetic

WP8 predicted "1.5–2.5x faster at n = 128–256" from "~8–10 sweeps × ~4n³". That counts **one** of the *three* block updates each round performs: `A·V` is 4n³ per sweep, but `V^H·A` is another 4n³ and `Z·V` a third. The real figure is 12n³ per sweep with vectors — a ~25x premium over syev's ~4n³, not 10x — so break-even at n = 256 needs ~51 TFLOP/s, above the ~47 this card sustains on cuBLAS SGEMM. **No implementation of this item could have won at n = 256.** The correction is written back into the plan.

What actually binds is global traffic, `6n³/nb` per sweep, with `nb` capped by the local memory the pivot block needs. That gives a cliff rather than a slope: n = 64 is fully resident (l = 2, zero global traffic between load and store) at 2.03x; n = 128 is not, at 6.83x.

## Design notes worth review

- **The row update is a transpose, not a second m × n GEMM.** `A'` is Hermitian and the column update already produced `A'[r, idx]`, so `A'[idx, r] = conj(A'[r, idx])`. The second product collapses to the m × m pivot block the inner solve already computed. Removes n·m² flops per pair and a strided-read panel.
- **`l == 2` degenerates into the fully resident Tier B solve** without a second kernel.
- The mirror stages through the dead `S` buffer so its transposed destination is one coalesced store, not m scattered ones.
- Converged pivot blocks are detected before the inner solve, so the final verification sweep doesn't pay m-1 rounds of barriers per pair.
- Block width, inner-sweep count and work-group size defaults are all measured; the inner-sweep and work-group rules split on the same `l == 2` residency boundary, each for a stated physical reason.

## Testing

25 tests over all four scalar types, both `Uplo`, both job modes, ragged and odd n (33/47/65/97/129), forced narrow block widths, and both inner-sweep variants — all passing. The existing 30 `syev_jacobi_cta` tests still pass (`JacobiParams` gained two fields, additively). Full tree builds.

Draft because the routing decision (ship unrouted) is a judgment call worth a second opinion, and because `complex` is ~2x behind `float` at every shape for a reason that is understood but untuned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juqo8pWNffi9yPjYyLNLBY