### PR TITLE
Fix the open API-review issues (18 of 21)

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -16,7 +16,7 @@ This PR implements a utility function `ritz_values` that computes Ritz values (e
 ### Header Declarations (92 lines added)
 - **`include/blas/extensions.hh`**: Function declarations
   - Main `ritz_values` function template
-  - `ritz_values_workspace` function for memory allocation
+  - `ritz_values_buffer_size` function for memory allocation
   - Multiple forwarding overloads for convenience (owning Matrix/Vector types)
   - Comprehensive documentation comments
 
@@ -71,7 +71,7 @@ Matrix<float, MatrixFormat::Dense> V = /* trial vectors */;
 Vector<float> ritz_vals(k, batch);
 
 // 2. Compute workspace size
-size_t ws_size = ritz_values_workspace<Backend::SYCL, float, MatrixFormat::CSR>(
+size_t ws_size = ritz_values_buffer_size<Backend::SYCL, float, MatrixFormat::CSR>(
     *ctx, A.view(), V.view(), ritz_vals.view());
 
 // 3. Allocate workspace
@@ -103,7 +103,7 @@ All tests:
 
 ### Workspace Management
 Following the repository pattern, the function requires pre-allocated workspace:
-- `ritz_values_workspace()` computes required memory
+- `ritz_values_buffer_size()` computes required memory
 - User allocates workspace buffer
 - `ritz_values()` uses the workspace for temporary storage
 

--- a/RITZ_VALUES.md
+++ b/RITZ_VALUES.md
@@ -46,7 +46,7 @@ Vector<float> ritz_vals(k, batch);
 auto ritz_vals_view = ritz_vals.view();
 
 // Compute required workspace size
-size_t workspace_size = ritz_values_workspace<Backend::SYCL, float, MatrixFormat::CSR>(
+size_t workspace_size = ritz_values_buffer_size<Backend::SYCL, float, MatrixFormat::CSR>(
     *ctx, A_view, V_view, ritz_vals_view);
 
 // Allocate workspace
@@ -73,7 +73,7 @@ for (int i = 0; i < k; ++i) {
 Matrix<float, MatrixFormat::Dense> A_dense(n, n, batch);
 // ... initialize A_dense ...
 
-size_t workspace_size = ritz_values_workspace<Backend::SYCL, float, MatrixFormat::Dense>(
+size_t workspace_size = ritz_values_buffer_size<Backend::SYCL, float, MatrixFormat::Dense>(
     *ctx, A_dense.view(), V.view(), ritz_vals.view());
 UnifiedVector<std::byte> workspace(workspace_size);
 
@@ -94,7 +94,7 @@ Vector<float> ritz_vals(k, batch);
 // Initialize matrices for each batch...
 
 // Compute Ritz values for all batches
-size_t workspace_size = ritz_values_workspace<Backend::SYCL, float, MatrixFormat::Dense>(
+size_t workspace_size = ritz_values_buffer_size<Backend::SYCL, float, MatrixFormat::Dense>(
     *ctx, A.view(), V.view(), ritz_vals.view());
 UnifiedVector<std::byte> workspace(workspace_size);
 
@@ -138,7 +138,7 @@ Event ritz_values(Queue& ctx,
 ### Workspace Computation
 ```cpp
 template <Backend B, typename T, MatrixFormat MFormat>
-size_t ritz_values_workspace(Queue& ctx,
+size_t ritz_values_buffer_size(Queue& ctx,
                              const MatrixView<T, MFormat>& A,
                              const MatrixView<T, MatrixFormat::Dense>& V,
                              const VectorView<typename base_type<T>::type>& ritz_vals);
@@ -150,7 +150,7 @@ size_t ritz_values_workspace(Queue& ctx,
 - **A**: Input matrix (can be sparse CSR or dense format)
 - **V**: Trial vectors stored as a dense matrix (columns are trial eigenvectors)
 - **ritz_vals**: Output vector to store computed Ritz values
-- **workspace**: Pre-allocated workspace buffer (size from `ritz_values_workspace`)
+- **workspace**: Pre-allocated workspace buffer (size from `ritz_values_buffer_size`)
 
 ## Supported Types
 
@@ -164,4 +164,4 @@ size_t ritz_values_workspace(Queue& ctx,
 - For complex types, the function uses conjugate transpose in the computation
 - The trial vectors in V do not need to be normalized; normalization is handled internally
 - For best results, trial vectors should be orthogonal or nearly orthogonal
-- Workspace memory is automatically managed using the `ritz_values_workspace` function
+- Workspace memory is automatically managed using the `ritz_values_buffer_size` function

--- a/SYEV_PERF_IMPLEMENTATION_PLAN.md
+++ b/SYEV_PERF_IMPLEMENTATION_PLAN.md
@@ -119,8 +119,8 @@ arithmetic for both scalar types, so the saving is identical for `float` and `cf
 | `:244` | complex | `stedc<B, Real>(..., internal_jobz, ..., z_view)` |
 | `:340` | real | same constant |
 | `:345` | real | `stedc<B, T>(..., internal_jobz, ..., z_view)` |
-| `:450` | complex | `stedc_workspace_size<B, Real>(..., JobType::EigenVectors, ...)` |
-| `:478` | real | `stedc_workspace_size<B, T>(..., JobType::EigenVectors, ...)` |
+| `:450` | complex | `stedc_buffer_size<B, Real>(..., JobType::EigenVectors, ...)` |
+| `:478` | real | `stedc_buffer_size<B, T>(..., JobType::EigenVectors, ...)` |
 
 The comment at `:236` explains the constant: *"The current STEDC implementation relies on
 eigenvectors during recursion/merge, so we always run it in EigenVectors mode."* That is

--- a/benchmarks/eigensolver_accuracy.cc
+++ b/benchmarks/eigensolver_accuracy.cc
@@ -485,7 +485,7 @@ int run_accuracy(const Options& opt) {
                     params.leaf_steqr_params = steqr_params;
                     
                     UnifiedVector<std::byte> ws(
-                        stedc_workspace_size<B, Real>(*q, n, cur_batch, JobType::EigenVectors, params));
+                        stedc_buffer_size<B, Real>(*q, n, cur_batch, JobType::EigenVectors, params));
                     stedc<B, Real>(*q,
                                    d_work,
                                    e_work,

--- a/benchmarks/gemm_heterogeneous_benchmark.cc
+++ b/benchmarks/gemm_heterogeneous_benchmark.cc
@@ -149,7 +149,7 @@ void run_heterogeneous_variant(minibench::State& state,
     });
 
     state.SetTimedKernelMs(bench::make_event_timed_kernel_ms(q, [q, A, B, C, env]() {
-        gemm_heterogeneous(*q,
+        gemm(*q,
                                           A->view(),
                                           B->view(),
                                           C->view(),

--- a/benchmarks/htev_compare_benchmark.cc
+++ b/benchmarks/htev_compare_benchmark.cc
@@ -90,7 +90,7 @@ static void BM_HTEV_STEDC(minibench::State& state) {
     auto eigvals   = Vector<T>::zeros(static_cast<int>(n), static_cast<int>(batch));
     auto eigvects  = Matrix<T>::Identity(static_cast<int>(n), static_cast<int>(batch));
 
-    UnifiedVector<std::byte> ws(stedc_workspace_size(*q, n, batch, jobz, params));
+    UnifiedVector<std::byte> ws(stedc_buffer_size(*q, n, batch, jobz, params));
 
     // stedc has a non-standard calling convention; use a capturing lambda and
     // omit the leading Queue& parameter (the adapter will call k(xs...) form).

--- a/benchmarks/orthogonality_accuracy.cc
+++ b/benchmarks/orthogonality_accuracy.cc
@@ -291,7 +291,7 @@ int run_accuracy(const Options& opt) {
                     auto eigvects = Matrix<Real>::Identity(n, cur_batch);
                     StedcParams<Real> stedc_params{};
                     UnifiedVector<std::byte> ws(
-                        stedc_workspace_size<B, Real>(*q, n, cur_batch, JobType::EigenVectors, stedc_params));
+                        stedc_buffer_size<B, Real>(*q, n, cur_batch, JobType::EigenVectors, stedc_params));
                     stedc<B, Real>(*q,
                                    d_work,
                                    e_work,

--- a/benchmarks/stedc_acc.cc
+++ b/benchmarks/stedc_acc.cc
@@ -54,7 +54,7 @@ void run_stedc(miniacc::State& state) {
         try {
             StedcParams<Real> params{};
             UnifiedVector<std::byte> ws(
-                stedc_workspace_size<B, Real>(*q, n, cur_batch, JobType::EigenVectors, params));
+                stedc_buffer_size<B, Real>(*q, n, cur_batch, JobType::EigenVectors, params));
             stedc<B, Real>(*q, d, e, evals, ws.to_span(), JobType::EigenVectors, params, evecs);
             q->wait();
         } catch (const std::exception& ex) {

--- a/benchmarks/stedc_benchmark.cc
+++ b/benchmarks/stedc_benchmark.cc
@@ -63,7 +63,7 @@ static void BM_STEDC(minibench::State& state) {
     auto q = std::make_shared<Queue>(Device(B == Backend::NETLIB ? "cpu" : "gpu"), B);
     auto eigvals = Vector<T>::zeros(n, batch);
     auto eigvects = Matrix<T>::Identity(n, batch);
-    UnifiedVector<std::byte> ws(stedc_workspace_size(*q, n, batch, jobz, params));
+    UnifiedVector<std::byte> ws(stedc_buffer_size(*q, n, batch, jobz, params));
 
     auto kernel = [q](auto& diags,
                             auto& off_diags,

--- a/benchmarks/steqr_accuracy.cc
+++ b/benchmarks/steqr_accuracy.cc
@@ -315,7 +315,7 @@ int run_accuracy(const Options& opt) {
         }
         if (run_stedc) {
             UnifiedVector<std::byte> ws(
-                stedc_workspace_size<B, Real>(*q, n, cur_batch, JobType::EigenVectors, StedcParams<Real>{}));
+                stedc_buffer_size<B, Real>(*q, n, cur_batch, JobType::EigenVectors, StedcParams<Real>{}));
             stedc<B, Real>(*q, d, e, eigs_stedc, ws.to_span(), JobType::EigenVectors, StedcParams<Real>{}, eigvects);
         }
         q->wait();

--- a/benchmarks/steqr_benchmark.cc
+++ b/benchmarks/steqr_benchmark.cc
@@ -43,8 +43,12 @@ static void BM_STEQR(minibench::State& state) {
     params.block_rotations = false;
     params.transpose_working_vectors = transpose;
 
-    Vector<T> diags = Vector<T>::random(n, batch, transpose ? 1 : n, transpose ? batch : 1);
-    Vector<T> off_diags = Vector<T>::random(n - 1, batch, transpose ? 1 : n - 1, transpose ? batch : 1);
+    Vector<T> diags = Vector<T>::random(n, batch,
+                                        Stride(static_cast<int>(transpose ? 1 : n)),
+                                        Inc(static_cast<int>(transpose ? batch : 1)));
+    Vector<T> off_diags = Vector<T>::random(n - 1, batch,
+                                            Stride(static_cast<int>(transpose ? 1 : n - 1)),
+                                            Inc(static_cast<int>(transpose ? batch : 1)));
     auto q = std::make_shared<Queue>(Device(B == Backend::NETLIB ? "cpu" : "gpu"), B);
     auto eigvals = Vector<T>::zeros(n, batch);
     auto eigvects = Matrix<T>::Identity(n, batch);

--- a/benchmarks/trsm_benchmark.cc
+++ b/benchmarks/trsm_benchmark.cc
@@ -17,11 +17,11 @@ static void BM_TRSM(minibench::State& state) {
     state.SetKernel(q,
                     std::move(A),
                     bench::pristine(Bm),
+                    T(1),
                     Side::Left,
                     Uplo::Lower,
                     Transpose::NoTrans,
                     Diag::NonUnit,
-                    T(1),
                     [](Queue& q, auto&&... xs) {
                         trsm(q, std::forward<decltype(xs)>(xs)...);
                     });

--- a/benchmarks/vector_benchmark.cc
+++ b/benchmarks/vector_benchmark.cc
@@ -15,8 +15,8 @@ static void BM_STEQR(minibench::State& state) {
     const size_t inc = state.range(2);
     const size_t stride = state.range(3);
     const size_t n_writes = state.range(4);
-    auto vec1 = Vector<T>::random(n, batch, stride, inc);
-    auto vec2 = Vector<T>::random(n, batch, stride, inc);
+    auto vec1 = Vector<T>::random(n, batch, Stride(static_cast<int>(stride)), Inc(static_cast<int>(inc)));
+    auto vec2 = Vector<T>::random(n, batch, Stride(static_cast<int>(stride)), Inc(static_cast<int>(inc)));
 
     auto q = std::make_shared<Queue>(Device(B == Backend::NETLIB ? "cpu" : "gpu"), B);
 

--- a/docs/cpp-api.md
+++ b/docs/cpp-api.md
@@ -273,6 +273,15 @@ C.view().symmetrize(ctx, Uplo::Lower).wait();   // hermitize() for herk/her2k
 Zeroing `C` first (`Matrix::Zeros`, `view().fill_zeros(ctx)`) makes the other
 half defined, not symmetric — mirror it as well.
 
+**`gemm` handles a heterogeneous batch natively.** When the items of a batch
+carry differing `active_rows`/`active_cols`, `gemm` detects that and routes to
+the heterogeneous path itself, on every backend — there is no separate entry
+point to reach for, and there has never been a `gemm` that could not do this.
+(A `gemm_heterogeneous` alias used to exist in the C++ headers; it forwarded to
+`gemm` with an unchanged argument list and has been removed. The Python
+`gemm_heterogeneous` remains, because it does something `gemm` does not: it
+accepts a list of differently-shaped arrays.)
+
 `symm`, `syrk` and `syr2k` are constrained to **real** `T` and do not instantiate
 for `std::complex`; `hemm`, `herk` and `her2k` are constrained to **complex** `T`
 and do not instantiate for real. `gemm`, `gemv`, `trmm` and `trsm` take both.
@@ -398,9 +407,12 @@ that cannot serve the one you ask for says so at compile time.
   });
   ```
 
-- Entry points whose template parameters cannot be deduced from their arguments —
-  `tridiagonal_solver_buffer_size`, whose arguments are all scalars — keep the
-  explicit `f<Backend, T>(...)` form.
+- Entry points whose template parameters cannot be deduced from their arguments
+  keep the explicit `f<Backend, T>(...)` form. There are two kinds:
+  `tridiagonal_solver_buffer_size`, whose arguments are all scalars; and the six
+  `random_*_with_log10_cond_metric` generators, whose scalar type appears only as
+  `float_t<T>` — an alias template, so a non-deduced context — and in the return
+  type. Spell them `random_with_log10_cond_metric<Backend::CUDA, float>(ctx, …)`.
 
 When you pass an empty option struct *together with* an explicit workspace, name
 the type: `potrf(ctx, A.view(), PotrfOptions{}, ws)`.
@@ -863,8 +875,11 @@ if (Queue::backend_available(Backend::CUDA)) ctx.set_backend(Backend::CUDA);
 ```
 
 This applies to the whole surface, extensions included: `ortho`, `syevx`,
-`lanczos`, `steqr`, `stedc`, the `sytrd_*` and `syev_*` family and the rest all
-take their backend from the queue.
+`lanczos`, `steqr`, `stedc`, the `sytrd_*` and `syev_*` family, `cond` and
+`cond_buffer_size` all take their backend from the queue. The exception is the
+handful of entry points whose remaining template parameters are not deducible
+from their arguments, listed under "Which spelling each entry point takes"
+above — they have no queue-deducing overload and must name the backend.
 
 ### Getting the compile-time backend
 

--- a/docs/cpp-api.md
+++ b/docs/cpp-api.md
@@ -962,14 +962,44 @@ case. Now all three reject it the same way.
 The `f<Backend::CUDA>(ctx, …)` spelling is the library's own inner-loop form and
 skips these checks by design, so the cost stays off the hot path.
 
-**No factorisation reports per-item numerical status.** `potrf`, `getrf` and
-`geqrf` have no `info` argument and no status output. A batch item that is not
-positive definite, or one whose pivot is zero to working precision, produces
-numbers rather than an exception: `linalg::solve` on a near-singular `A` returns
-a plausible-looking result, and `potrf` on an indefinite one returns a triangle
-of garbage. Nothing in the table above fires. Where the inputs are not known to
-be well-conditioned, check afterwards — compute the residual `‖A·X − B‖`, or
-scan the factor's diagonal for zeros and NaNs — and decide per batch item.
+**Factorisation status is opt-in, and only `potrf`, `getrf` and `getri` have
+it.** Each takes an optional `Span<int32_t> info`, one entry per batch item, with
+LAPACK's convention: `0` means the item factorised, and a positive value names
+the leading minor (`potrf`) or the zero pivot (`getrf`, `getri`) at which it
+failed. It is a field on `PotrfOptions` and a trailing parameter on
+`getrf`/`getri`:
+
+```cpp
+UnifiedVector<int32_t> info(batch);
+potrf(ctx, A.view(), {.uplo = Uplo::Lower, .info = info.to_span()});
+getrf(ctx, A.view(), pivots.to_span(), info.to_span());
+ctx.wait();
+if (info[37] != 0) { /* item 37 is rank-deficient; everything downstream is noise */ }
+```
+
+Leave `info` out — that is the default — and nothing is reported, exactly as
+before. The span has to be device-accessible USM; the vendor writes it in place,
+so asking for status costs no extra allocation and does not change the workspace
+size. A non-empty span shorter than `batch_size` is rejected with
+`std::invalid_argument` rather than partially filled, because the failure would
+otherwise be silent: the backend falls back to its own scratch and the caller
+reads whatever was already in the buffer, most often zeros — "every item
+factorised" — on precisely the batch it was trying to diagnose.
+
+`geqrf` and `orgqr` have no equivalent and will not get one. Householder QR has
+no numerical failure mode, so LAPACK's `geqrf` info is only ever `0` or an
+illegal-argument code; cuBLAS's `geqrfBatched` takes a single *host* scalar
+rather than a per-item device array (it spells the per-item form `devInfoArray`,
+as on `gelsBatched`); and rocSOLVER's `geqrf` has no info parameter at all. A
+per-item `geqrf` info would be all zeros by construction.
+
+`syev`, `gesvd` and the solve-style calls (`getrs`, `linalg::solve`) still report
+nothing. A batch item whose pivot is zero to working precision produces numbers
+rather than an exception: `linalg::solve` on a near-singular `A` returns a
+plausible-looking result and nothing in the table above fires. Where the inputs
+are not known to be well-conditioned, check afterwards — compute the residual
+`‖A·X − B‖`, or scan the factor's diagonal for zeros and NaNs — and decide per
+batch item.
 
 ## Synchronisation and threading
 

--- a/docs/cpp-api.md
+++ b/docs/cpp-api.md
@@ -316,6 +316,32 @@ These take a workspace. Leave it out and it is leased from the queue's arena; se
   workspaces — take `Span<T>`. `UnifiedVector<T>`, the owning USM array,
   converts implicitly; `to_span()` is explicit. A `Vector<T>` is not a `Span`.
 
+The same rule extends to the extension surface (`steqr`, `stebz`, `stein`,
+`stedc`, `lanczos`, `ritz_values`): a parameter takes `VectorView<T>` when it is
+one logical vector *per batch item* and so needs `inc`/`stride`/`batch_size`, and
+`Span<T>` when it is a flat array with one entry per item or per matrix and no
+stride freedom. `stebz` shows both in one call — `d`, `e` and `w` are
+`VectorView<T>` (strided, per item), while `m`, the per-item eigenvalue count, is
+`Span<int32_t>`. The two are deliberately not interconvertible: a `VectorView`
+demoted to a `Span` would drop the stride and read the wrong elements rather than
+fail to compile.
+
+What to write at the call site, by owning type:
+
+| you hold | parameter is `Span<T>` | parameter is `VectorView<T>` |
+| --- | --- | --- |
+| `UnifiedVector<T>` | pass it directly (implicit), or `.to_span()` | `VectorView<T>(v, size, batch, Inc{i}, Stride{s})` |
+| `Vector<T>` | `.data()` — the whole allocation, so only when `inc == 1` and it is packed | `.view()`, always |
+| raw pointer | `Span<T>(p, n)` | `VectorView<T>(p, size, batch, Inc{i}, Stride{s})` |
+
+`Vector<T>::view()` is required whenever `T` has to be *deduced* from the
+argument, which is every templated entry point: the implicit
+`VectorView(const Vector<T>&)` conversion exists but template argument deduction
+never considers user-defined conversions. Several entry points also ship an
+owning-`Vector` forwarding overload so the bare `Vector` works — `stebz`,
+`stein`, `steqr`, `steqr_cta` and `stedc` all do — but `.view()` is the spelling
+that works everywhere.
+
 `pivots` is `int64_t`, `tau` is `T`, and `W` is the real counterpart of `T`
 (`float` for `std::complex<float>`).
 
@@ -329,15 +355,24 @@ Vector<float> x(n, /*batch_size=*/batch), y(m, batch);   // owning USM vectors
 gemv(ctx, A.view(), x.view(), y.view(), {.alpha = 1.0f});
 ```
 
-**`Vector` and `VectorView` take `inc` and `stride` in opposite orders.** It is
-`Vector<T>(size, batch_size, stride, inc)` and
-`VectorView<T>(ptr, size, batch_size, inc, stride)`. Both parameters are `int`
-and both default — `inc` to 1, `stride` to `size * inc` — so a pair passed in
-the other order compiles and reads the wrong elements. Read the argument order
-off the constructor you are calling, every time.
+**`Vector` names `inc` and `stride`; `VectorView` still takes them positionally,
+in the opposite order.** Write `Vector<T>(size, batch_size, Stride{s}, Inc{i})`.
+The bare-int spellings `Vector<T>(size, batch_size, stride, inc)` and
+`Vector<T>(size, batch_size, stride)` are `= delete`d and no longer compile.
+`VectorView<T>(ptr, size, batch_size, inc, stride)` keeps its positional form —
+138 call sites use it and all of them are correct — and gains
+`VectorView<T>(ptr, size, batch_size, Inc{i}, Stride{s})` alongside it. The tags
+exist because the two orders are otherwise indistinguishable: both parameters are
+`int`, both default, and `(inc = n, stride = 1)` fits exactly the same buffer as
+`(inc = 1, stride = n)`, so a pair passed in the other order used to compile and
+read the wrong elements with no diagnostic. Prefer the tagged spelling on both
+types. `Stride`, `Inc`, `Ld` and `BatchSize` live in `batchlas/blas/matrix.hh`
+next to `NonZeros`; like `NonZeros` they are explicit in and do not decay back to
+`int`.
 
-`Vector<T>::zeros(size, batch_size, stride, inc)`, `::ones(...)` and
-`::standard_basis(size, index, batch_size, stride)` build one directly.
+`Vector<T>::zeros(size, batch_size, Stride{s}, Inc{i})`, `::ones(...)`,
+`::random(...)` and `::standard_basis(size, index, batch_size, Stride{s})` build
+one directly; their bare-int forms are deleted the same way.
 
 ## Options are structs with defaults
 
@@ -384,6 +419,46 @@ and `trans` everywhere else.
 type"; the other values are `F32`, `F64`, `F16`, `BF16` and `TF32`, and a backend
 that cannot serve the one you ask for says so at compile time.
 
+### `*Options` and `*Params` are two different things
+
+Two suffixes appear on argument structs and they are not interchangeable.
+
+`*Options` structs live in `batchlas/blas/options.hh` and belong to the
+convenience layer: the backend comes from the `Queue`, `T` is deduced from the
+matrices, the struct carries every non-matrix argument, and — for the LAPACK
+entry points — the workspace may be omitted. `gemm`, `gemv`, `symm`, `hemm`,
+`herk`, `her2k`, `syrk`, `syr2k`, `trmm`, `trsm`, `potrf`, `getrs`, `syev`,
+`ormqr` and `gesvd` have one, and `ortho`'s lives in `extensions.hh`.
+
+`*Params` structs live in `batchlas/blas/extensions.hh` and
+`batchlas/blas/functions/iluk.hh`. They are ordinary arguments to entry points
+that have no convenience layer: you still name the backend
+(`syevx<Backend::CUDA, float>`) and you still pass a workspace.
+
+The suffix alone does not tell you where the struct sits in the argument list,
+so read the declaration. The last two rows are why:
+
+| struct | entry points | where it sits |
+| --- | --- | --- |
+| `SyevxParams<T>` | `syevx`, `syevx_buffer_size`, `syevx_resolve_range` | last, after `workspace`, `jobz`, `V` |
+| `LanczosParams<T>` | `lanczos`, `lanczos_buffer_size` | last |
+| `StebzParams<T>` | `stebz`, `stebz_buffer_size` | last, after `ws` |
+| `SteinParams<T>` | `stein` | last |
+| `SteqrParams<T>` | `steqr`, `steqr_cta` | **second to last** — `eigvects` follows |
+| `StedcParams<T>` | `stedc`, `stedc_buffer_size` | **second to last** — `eigvects` follows |
+| `JacobiParams<T>` | `syev_jacobi_cta` and its `_buffer_size` | last |
+| `GesvdjParams<T>` | `gesvdj_cta` and its `_buffer_size` | last |
+| `SytrdBandReductionParams` | `sytrd_band_reduction` | **replaces** the `int32_t block_size` argument |
+| `ILUKParams<T>` | `iluk_factorize`, `iluk_buffer_size` | the only non-matrix argument — behaves like an `*Options` struct |
+
+The structs were deliberately not renamed to make this visible in the name. The
+rule a rename would have encoded — "`*Options` replaces the positional
+arguments, `*Params` is extra tuning appended after the workspace" — is false for
+four of the ten above: `ILUKParams` and `SytrdBandReductionParams` play the
+`*Options` role exactly, and `SteqrParams` and `StedcParams` are not last.
+Renaming on a rule that does not hold would have moved the inaccuracy from the
+docs into the type names, where it is harder to correct.
+
 ### Which spelling each entry point takes
 
 - The dense BLAS calls — `gemm`, `gemv`, `symm`, `hemm`, `herk`, `her2k`, `syrk`,
@@ -413,6 +488,17 @@ that cannot serve the one you ask for says so at compile time.
   `random_*_with_log10_cond_metric` generators, whose scalar type appears only as
   `float_t<T>` — an alias template, so a non-deduced context — and in the return
   type. Spell them `random_with_log10_cond_metric<Backend::CUDA, float>(ctx, …)`.
+
+- The sizing calls whose only `T`-bearing argument is an option struct —
+  `stebz_buffer_size`, `stein_buffer_size`, and `stedc_buffer_size` — take that
+  struct as a REQUIRED argument, with no default, for exactly this reason: a
+  default would make `stebz_buffer_size(ctx, n, batch)` look available while `T`
+  had nowhere to come from, and the diagnostic is not a deduction error pointing
+  at the declaration but "no matching function" from the queue-deducing wrapper,
+  which probes the call in its requires-clause and silently drops itself when the
+  substitution fails. Pass `StebzParams<float>{}` for the defaults and the call
+  deduces both the backend and `T`:
+  `stebz_buffer_size(ctx, n, batch, StebzParams<float>{})`.
 
 When you pass an empty option struct *together with* an explicit workspace, name
 the type: `potrf(ctx, A.view(), PotrfOptions{}, ws)`.
@@ -452,12 +538,32 @@ and in `MatrixView(data, rows, cols, ld, stride, batch)`, and the resolution is
 deterministic: `Matrix(rows, cols, batch)` allocates exactly `rows * cols * batch`
 elements with `ld() == rows()` and `stride() == rows() * cols()`. Nothing pads.
 
-**The indices are `int`.** `rows`, `cols`, `ld`, `stride` and `batch_size` are
-`int`, and element access evaluates `b * stride + j * ld + i` in `int`
-arithmetic, so the largest index a matrix addresses —
-`(batch_size - 1) * stride + (cols - 1) * ld + rows - 1` — must stay below
-2³¹ (about 2.1·10⁹ elements, 8 GB of `float`). Past that the index overflows
-silently. Split the batch across several matrices to go further.
+**The shape fields are `int`; the addresses are not.** `rows`, `cols`, `ld`,
+`stride` and `batch_size` are `int`, but element access evaluates
+`int64_t(b) * stride + j * ld + i`, so the batch term does not overflow. It used
+to: a 512×512 `float` matrix has `stride == 262144`, and the old all-`int`
+product wrapped at `b == 8192`, a batch size this library is built for. What
+remains `int` is `j * ld + i`, the offset *within* one batch item, which can only
+overflow on a single matrix above 2³¹ elements (8 GB of `float`) — more than the
+library can allocate anyway. `KernelMatrixView::operator()` and `::batch_item`,
+`Matrix::operator()`, `MatrixView::at` and `::batch_item`, `Vector::at` and
+`VectorView::at` are all widened the same way, and the debug asserts that guard
+them now compare `int64_t` against `int64_t` rather than an already-wrapped `int`
+against a `size_t`.
+
+`MatrixView`'s constructor validates what it safely can.
+`MatrixView(data, rows, cols, ld, stride, batch_size)` throws
+`std::invalid_argument` on a negative `rows`, `cols`, `ld`, `stride` or
+`batch_size`, and on a resolved `ld` smaller than `rows`. That last check is the
+one that matters: the batch count is the *third* argument on `Matrix` and the
+*sixth* here, so a caller who learned the order from `Matrix A(n, n, batch)`
+writes `MatrixView<float> V(p, n, n, batch)`, which means `ld = batch`,
+`stride = batch * n`, `batch_size = 1`. That used to be accepted silently and
+produced plausible-looking wrong numbers; it now throws, and the message names
+the spelling you meant. Two things it deliberately does *not* reject: a null
+`data` pointer or a zero dimension, because a shape-only view is the standard
+idiom for a workspace-size query; and `stride < ld * cols`, which the owning
+`Matrix` constructor does reject but which some existing views rely on.
 
 **`stride = 0` is the packed default, not cuBLAS's broadcast.** BatchLAS has no
 broadcast operand: every operand carries a full batch, and unequal batch sizes
@@ -627,8 +733,16 @@ B.view().fill_zeros(ctx);
 `fill_triangular`, `fill_tridiag`, `fill_tridiag_toeplitz`, `fill_random` and
 `fill_triangular_random` are in `batchlas/blas/matrix.hh`, alongside
 `fill_random_sparse_hermitian` for CSR. Most have a `(const Queue&, ...)` form
-and a form that builds a queue of its own; `fill_identity` and `fill_tridiag`
-take a queue.
+and a form that builds a queue of its own; `fill_identity`, `fill_tridiag`,
+`fill_zeros` and `fill_ones` take a queue and nothing else. The queue-less
+`fill_zeros()` / `fill_ones()` forwarders are gone, along with the `= Queue()`
+defaults on `set_access_device`, `set_preferred_location` and `prefetch` on
+`Matrix`, `MatrixView`, `Vector` and `VectorView`. A default-constructed `Queue`
+is not a handle to a shared queue: it builds a fresh `QueueImpl` on
+`Device::default_device()`, so those spellings targeted the wrong device on a
+multi-GPU box and carried a throwaway workspace arena that nothing could reuse.
+The remaining queue-less `fill_*` forwarders have the same caveat — pass your own
+queue.
 
 Two more `MatrixView` helpers work on a matrix that already holds one triangle —
 the shape `syrk`, `herk`, `syr2k`, `her2k` and the `uplo`-reading factorisations
@@ -780,12 +894,41 @@ Matrix<float, MatrixFormat::CSR> S(values, row_offsets, col_indices,
 
 `MatrixView` mirrors both.
 
+`NonZeros{}` is a **capacity**, not a count. `nnz()` returns it, and
+`convert_to<MatrixFormat::CSR>()` sizes a whole batch by its *largest* item, so on
+a heterogeneous batch — which is the normal result of that conversion — `nnz()`
+over-counts every smaller item, and `for (int k = 0; k < S.nnz(); ++k)` walks past
+that item's row range into slots the conversion never wrote. Three accessors, on
+`Matrix`, `MatrixView` and `KernelMatrixView` alike:
+
+- **`nnz()`** — the per-item stride of the batch. Unchanged, and what the vendor
+  SpMM descriptors want: `cusparseCreateCsr` and `rocsparse_create_csr_descr` are
+  handed one number for the whole strided batch, and the capacity is the correct
+  one there.
+- **`nnz(b)`** — the non-zeros batch item `b` actually stores, read from that
+  item's row offsets. Requires the kernel that filled the offsets to have
+  completed. On a `MatrixView` over `sycl::malloc_device` memory the host cannot
+  read the offsets, so use the `KernelMatrixView` overload inside a kernel instead.
+- **`nnz_capacity()`** — the slots that were allocated per item. Equal to `nnz()`
+  for both allocating constructors, but the from-data constructor lets
+  `matrix_stride` exceed the declared count, and it is `matrix_stride` that sizes
+  the buffers.
+
 ## What gets thrown
+
+The split is by *cause*, not by site: `std::invalid_argument` for anything
+determined by the caller's arguments — shapes, `ld`, workspace size, pointer
+reachability — and `std::runtime_error` only for environment and backend
+failures, such as a backend that is not compiled into this build or a vendor
+route with no implementation for the requested arguments. Code that used to
+catch `std::runtime_error` on a shape mismatch must now catch
+`std::invalid_argument`; through the Python bindings the same paths changed from
+`RuntimeError` to `ValueError`.
 
 | exception | thrown for |
 | --- | --- |
-| `std::invalid_argument` | a pointer that is not reachable from the queue's device (from the queue-dispatching entry points); `Matrix`/`MatrixView` construction and slicing — null data, non-positive dimensions, an `ld` that is neither `0` nor at least `rows`, too short a source span, a `to_column_major` row pitch that does not fit or a defaulted one on a matrix that is not packed; shape errors from `gesvd` and the extension routines |
-| `std::runtime_error` | shape and batch-size mismatches from the dense BLAS backends (`"GEMM: incompatible matrix dimensions"`, `"SYMM: batch size mismatch (A=…, B=…, C=…)"`); a backend that is not compiled into this build; a `Queue` used from a thread other than its owner; a raw-pointer view with no `data_ptrs` array |
+| `std::invalid_argument` | everything the caller controls: a pointer that is not reachable from the queue's device (from the queue-dispatching entry points); shape and batch-size mismatches from the dense BLAS backends (`"GEMM: incompatible matrix dimensions"`, `"SYMM: batch size mismatch (A=…, B=…, C=…)"`) and `trsm`'s shape, `lda` and `ldb` checks; the LAPACK-style shape preconditions (`"getrf: A must be square, got 100x50"`, `"getrs: A.rows() (8) must equal B.rows() (4)"`, `"geqrf: tau holds 4 elements, needs at least 16"`); a workspace or output span too short for the chosen provider; `Matrix`/`MatrixView` construction and slicing — null data, non-positive dimensions, an `ld` that is neither `0` nor at least `rows`, too short a source span, a `to_column_major` row pitch that does not fit or a defaulted one on a matrix that is not packed; shape errors from `gesvd` and the extension routines |
+| `std::runtime_error` | environment and backend failures only: a backend that is not compiled into this build; a route with no implementation for the requested arguments (`"BATCHLAS_TRMM_VARIANT=cublasdx only supports float"`, `gesvd`'s vendor route on thin singular vectors); a `Queue` used from a thread other than its owner; a raw-pointer view with no `data_ptrs` array |
 | `std::out_of_range` | `V.at(i, j, b)` / `V(i, j, b)` outside the view |
 
 Catch `std::exception` at the boundary; the message names the routine and the
@@ -797,10 +940,27 @@ Errors that the device reports asynchronously surface at
 The backend that runs the call validates the BLAS-2 and BLAS-3 shapes: `gemm`
 checks every batch item, `symm`, `hemm`, `herk`, `her2k`, `syrk`, `syr2k` and
 `trmm` check shapes and batch sizes, and `trsm` checks shapes, `lda` and `ldb`.
-The LAPACK-style calls — `potrf`, `getrf`, `getrs`, `getri`, `geqrf`, `orgqr`,
-`syev` — and `trsm`'s batch sizes reach the vendor call as written, so hold to
-the shapes in *What the operations compute*: `potrf`'s operand square, `getrs`'s
-`B` at the same batch size as its `A`, and so on.
+The queue-dispatching LAPACK-style calls — `potrf`, `getrf`, `getrs`, `getri`,
+`geqrf`, `orgqr`, `syev` written without an explicit `<Backend>` — check their
+shapes host-side before any device work, and throw `std::invalid_argument` on a
+mismatch. `potrf`, `getrf`, `getri` and `syev` require a square `A`; `getrs`
+additionally requires `A.rows() == B.rows()` and a matching batch size, and
+`getri` the same of `Ainv`. The output spans must be long enough: `pivots` at
+least `A.rows() * batch_size`, `tau` at least
+`min(A.rows(), A.cols()) * batch_size`, `W` at least `A.rows() * batch_size`.
+Oversized spans are fine — the test is `>=`, so slicing one arena across several
+calls still works. `geqrf` and `orgqr` deliberately have no squareness check:
+rectangular `A` is the point.
+
+This matters most for `getrf`. A rectangular `A` used to reach the vendor call as
+written, and the backends did not agree about what that meant — the netlib path
+factorised an `A.rows()` × `A.rows()` block and read and wrote past the end of a
+tall `A`'s allocation, cuBLAS's batched `getrf` takes one dimension and is
+square-only by construction, and rocSOLVER genuinely handled the rectangular
+case. Now all three reject it the same way.
+
+The `f<Backend::CUDA>(ctx, …)` spelling is the library's own inner-loop form and
+skips these checks by design, so the cost stays off the hot path.
 
 **No factorisation reports per-item numerical status.** `potrf`, `getrf` and
 `geqrf` have no `info` argument and no status output. A batch item that is not

--- a/include/batchlas/blas/extensions.hh
+++ b/include/batchlas/blas/extensions.hh
@@ -373,15 +373,25 @@ namespace batchlas {
      * @param m Per-item count, at least `A.batch_size()` entries. Device-writable.
      *
      * OVERLOAD-RESOLUTION INVARIANT, do not break it: these forms are
-     * unambiguous against the `m`-less ones above because parameter 5 of this
-     * form (`size_t neigs`) and parameter 5 of the `m`-less form
-     * (`Span<std::byte>` / `JobType`) are mutually non-convertible. It is NOT
-     * because `Span<int32_t>` and `size_t` differ in position 4 -- `Span` has a
-     * non-explicit `Span(T&)` constructor, so `Span<int32_t>` IS implicitly
-     * constructible from an `int32_t` lvalue and position 4 alone does not
-     * discriminate. Never let this form's parameter k+1 be a type the `m`-less
-     * form's parameter k+1 converts to, and never spell a bare `{}` in argument
-     * positions 4-6 (it is an identity conversion to both, hence ambiguous).
+     * unambiguous against the `m`-less ones above because their argument lists
+     * diverge into MUTUALLY NON-CONVERTIBLE types at two independent positions
+     * (counting `ctx` as position 1):
+     *
+     *   position 4:  `Span<int32_t> m`   vs  `size_t neigs`
+     *   position 5:  `size_t neigs`      vs  `Span<std::byte> workspace`
+     *
+     * Position 4 discriminates because `Span`'s scalar constructor is `explicit`
+     * (`util/sycl-span.hh`), so an integer lvalue does not silently become a
+     * one-element `Span`; position 5 discriminates independently of it. Keep it
+     * that way: never let this form's parameter k+1 be a type the `m`-less
+     * form's parameter k+1 converts to. In particular, if `Span(T&)` were ever
+     * made implicit again, position 4 would stop discriminating and position 5
+     * would be the only thing left holding these overloads apart.
+     *
+     * And never spell a bare `{}` in argument positions 4-6. An empty
+     * braced-init-list is an identity conversion to `size_t`, to `Span<...>`
+     * (non-explicit default ctor) and to `JobType` alike, so it defeats every
+     * discriminator at once and the call is ambiguous.
      */
     template <Backend B, typename T, MatrixFormat MFormat>
     Event syevx(Queue& ctx,
@@ -971,6 +981,17 @@ namespace batchlas {
         return francis_sweep<T>(ctx, static_cast<VectorView<T>>(d), static_cast<VectorView<T>>(e), givens_rotations, n_sweeps, zero_threshold);
     }
 
+    // Vector-typed parameters in the tridiagonal group below (`stebz`, `stein`,
+    // `steqr`, `steqr_cta`, `stedc`) follow one rule, and the mixture inside a
+    // single `stebz` signature is that rule applied, not an oversight:
+    // `VectorView<T>` for anything that is one vector per batch item -- `d`, `e`,
+    // `w`, eigenvalues -- because those carry `inc`/`stride`/`batch_size` and the
+    // kernels read all four; `Span<...>` for flat arrays with one entry per batch
+    // item and no stride freedom (`m`, `counts`) and for byte workspaces. The two
+    // are not interconvertible in either direction without naming a size, which is
+    // deliberate: a `VectorView` demoted to a `Span` would silently drop the stride
+    // and read the wrong elements rather than fail to compile. See docs/cpp-api.md.
+
     /**
      * @brief How a subset of the spectrum is selected.
      */
@@ -1029,12 +1050,21 @@ namespace batchlas {
 
     /**
      * @brief Required workspace size, in bytes, for `stebz`.
+     *
+     * `params` is REQUIRED, not defaulted, on purpose: it is the only argument
+     * carrying `T`, so defaulting it would make `stebz_buffer_size(ctx, n, batch)`
+     * look available while `T` had nowhere to come from. What the caller actually
+     * got was not a deduction diagnostic pointing here but "no matching function"
+     * from the queue-deducing dispatch wrapper, whose requires-clause probes this
+     * call and silently drops the overload when the substitution fails. Pass
+     * `StebzParams<T>{}` for the defaults; with `params` present, both the backend
+     * and `T` deduce: `stebz_buffer_size(ctx, n, batch, params)`.
      */
     template <Backend B, typename T>
     size_t stebz_buffer_size(Queue& ctx,
                              size_t n,
                              size_t batch_size,
-                             StebzParams<T> params = StebzParams<T>());
+                             StebzParams<T> params);
 
     // Forwarding overload taking owning Vectors.
     template <Backend B, typename T>
@@ -1146,6 +1176,52 @@ namespace batchlas {
                 const Span<std::byte>& ws,
                 SteinParams<T> params = SteinParams<T>());
 
+    // Forwarding overloads taking owning Vectors, one per primary above. `stebz`,
+    // `steqr`, `steqr_cta` and `stedc` all ship these and `stein` was the only
+    // member of the group without them, so a caller holding owning `Vector`s had to
+    // spell `.view()` on exactly one call in an otherwise uniform sequence.
+    //
+    // These cannot collide with the primaries: template argument deduction does not
+    // consider the implicit `VectorView(const Vector<T>&)` conversion, so a `Vector`
+    // argument makes the primaries non-deducible and a `VectorView` argument makes
+    // these non-deducible. Exactly one set is ever viable. The two overloads here
+    // are held apart from each other by parameter 6 (`MatrixView` vs
+    // `Span<const int32_t>`), the same discriminator the primaries already rely on
+    // -- so the warning above about spelling a bare `{}` at `counts` (use
+    // `stein_all_counts`) applies to these identically.
+    template <Backend B, typename T>
+    inline Event stein(Queue& ctx,
+                       const Vector<T>& d,
+                       const Vector<T>& e,
+                       const Vector<T>& w,
+                       size_t k,
+                       const MatrixView<T, MatrixFormat::Dense>& Z,
+                       const Span<std::byte>& ws,
+                       SteinParams<T> params = SteinParams<T>()) {
+        return stein<B, T>(ctx,
+                           static_cast<VectorView<T>>(d),
+                           static_cast<VectorView<T>>(e),
+                           static_cast<VectorView<T>>(w),
+                           k, Z, ws, params);
+    }
+
+    template <Backend B, typename T>
+    inline Event stein(Queue& ctx,
+                       const Vector<T>& d,
+                       const Vector<T>& e,
+                       const Vector<T>& w,
+                       size_t k,
+                       Span<const int32_t> counts,
+                       const MatrixView<T, MatrixFormat::Dense>& Z,
+                       const Span<std::byte>& ws,
+                       SteinParams<T> params = SteinParams<T>()) {
+        return stein<B, T>(ctx,
+                           static_cast<VectorView<T>>(d),
+                           static_cast<VectorView<T>>(e),
+                           static_cast<VectorView<T>>(w),
+                           k, counts, Z, ws, params);
+    }
+
     /**
      * @brief Required workspace size, in bytes, for `stein`.
      *
@@ -1153,13 +1229,22 @@ namespace batchlas {
      * per-item `counts`: every scratch array is indexed by `(batch, column)` over
      * the full `n * k * batch_size` grid whether or not a column is used. So the
      * `counts` overload needs no separate sizing entry point.
+     *
+     * `params` is REQUIRED, not defaulted, on purpose: it is the only argument
+     * carrying `T`, so defaulting it would make `stein_buffer_size(ctx, n, k, batch)`
+     * look available while `T` had nowhere to come from. What the caller actually
+     * got was not a deduction diagnostic pointing here but "no matching function"
+     * from the queue-deducing dispatch wrapper, whose requires-clause probes this
+     * call and silently drops the overload when the substitution fails. Pass
+     * `SteinParams<T>{}` for the defaults; with `params` present, both the backend
+     * and `T` deduce: `stein_buffer_size(ctx, n, k, batch, params)`.
      */
     template <Backend B, typename T>
     size_t stein_buffer_size(Queue& ctx,
                              size_t n,
                              size_t k,
                              size_t batch_size,
-                             SteinParams<T> params = SteinParams<T>());
+                             SteinParams<T> params);
 
     enum class SteqrShiftStrategy {
         // LAPACK-style implicit shift (stable formulation used by dsteqr-style iterations).
@@ -2268,7 +2353,18 @@ namespace batchlas {
     }
 
     template <Backend B, typename T>
-    size_t stedc_workspace_size(Queue& ctx, size_t n, size_t batch_size, JobType jobz, StedcParams<T> params);
+    size_t stedc_buffer_size(Queue& ctx, size_t n, size_t batch_size, JobType jobz, StedcParams<T> params);
+
+    // Deprecated spelling, kept so an out-of-tree caller gets a warning and not a
+    // link error. Every other sizing entry point in this header is `*_buffer_size`
+    // -- ~30 of them -- and docs/cpp-api.md states that as a rule ("sized by the
+    // matching `*_buffer_size`"), which this one name silently falsified. The
+    // forwarder is `inline` and needs no explicit instantiation.
+    template <Backend B, typename T>
+    [[deprecated("renamed to stedc_buffer_size")]]
+    inline size_t stedc_workspace_size(Queue& ctx, size_t n, size_t batch_size, JobType jobz, StedcParams<T> params) {
+        return stedc_buffer_size<B, T>(ctx, n, batch_size, jobz, params);
+    }
 
 
     /**
@@ -2309,7 +2405,7 @@ namespace batchlas {
         using float_type = typename base_type<T>::type;
         size_t nRitz = V.cols();
         Vector<float_type> ritz_vals(nRitz, V.batch_size());
-        size_t workspace_size = ritz_values_workspace<B,T,MFormat>(ctx, A, V, static_cast<VectorView<float_type>>(ritz_vals));
+        size_t workspace_size = ritz_values_buffer_size<B,T,MFormat>(ctx, A, V, static_cast<VectorView<float_type>>(ritz_vals));
         UnifiedVector<std::byte> workspace(workspace_size);
         ctx.wait();
         ritz_values<B,T,MFormat>(ctx, A, V, static_cast<VectorView<float_type>>(ritz_vals), workspace);
@@ -2335,18 +2431,39 @@ namespace batchlas {
      * @return size_t Required workspace size in bytes
      */
     template <Backend B, typename T, MatrixFormat MFormat>
-    size_t ritz_values_workspace(Queue& ctx,
+    size_t ritz_values_buffer_size(Queue& ctx,
                                  const MatrixView<T, MFormat>& A,
                                  const MatrixView<T, MatrixFormat::Dense>& V,
                                  const VectorView<typename base_type<T>::type>& ritz_vals);
 
     // Forwarding overload (owning A, V, and ritz_vals)
     template <Backend B, typename T, MatrixFormat MFormat>
-    inline size_t ritz_values_workspace(Queue& ctx,
+    inline size_t ritz_values_buffer_size(Queue& ctx,
                                        const Matrix<T, MFormat>& A,
                                        const Matrix<T, MatrixFormat::Dense>& V,
                                        const Vector<typename base_type<T>::type>& ritz_vals) {
-        return ritz_values_workspace<B,T,MFormat>(ctx, MatrixView<T, MFormat>(A), MatrixView<T, MatrixFormat::Dense>(V), static_cast<VectorView<typename base_type<T>::type>>(ritz_vals));
+        return ritz_values_buffer_size<B,T,MFormat>(ctx, MatrixView<T, MFormat>(A), MatrixView<T, MatrixFormat::Dense>(V), static_cast<VectorView<typename base_type<T>::type>>(ritz_vals));
+    }
+
+    // Deprecated spellings, one per overload above. See the note on
+    // `stedc_workspace_size`: the `*_buffer_size` suffix is the convention every
+    // other sizing entry point follows, and these two were the only holdouts.
+    template <Backend B, typename T, MatrixFormat MFormat>
+    [[deprecated("renamed to ritz_values_buffer_size")]]
+    inline size_t ritz_values_workspace(Queue& ctx,
+                                        const MatrixView<T, MFormat>& A,
+                                        const MatrixView<T, MatrixFormat::Dense>& V,
+                                        const VectorView<typename base_type<T>::type>& ritz_vals) {
+        return ritz_values_buffer_size<B,T,MFormat>(ctx, A, V, ritz_vals);
+    }
+
+    template <Backend B, typename T, MatrixFormat MFormat>
+    [[deprecated("renamed to ritz_values_buffer_size")]]
+    inline size_t ritz_values_workspace(Queue& ctx,
+                                        const Matrix<T, MFormat>& A,
+                                        const Matrix<T, MatrixFormat::Dense>& V,
+                                        const Vector<typename base_type<T>::type>& ritz_vals) {
+        return ritz_values_buffer_size<B,T,MFormat>(ctx, A, V, ritz_vals);
     }
 
     /**
@@ -2491,9 +2608,34 @@ BATCHLAS_DISPATCH_ON_QUEUE(gesvdj_cta)
 BATCHLAS_DISPATCH_ON_QUEUE(gesvdj_cta_buffer_size)
 BATCHLAS_DISPATCH_ON_QUEUE(ormqx_cta)
 BATCHLAS_DISPATCH_ON_QUEUE(stedc)
-BATCHLAS_DISPATCH_ON_QUEUE(stedc_workspace_size)
+BATCHLAS_DISPATCH_ON_QUEUE(stedc_buffer_size)
 BATCHLAS_DISPATCH_ON_QUEUE(ritz_values)
-BATCHLAS_DISPATCH_ON_QUEUE(ritz_values_workspace)
+BATCHLAS_DISPATCH_ON_QUEUE(ritz_values_buffer_size)
+
+// Queue-deducing forms of the two deprecated spellings, hand-written rather than
+// registered with BATCHLAS_DISPATCH_ON_QUEUE: the macro takes only a name and has
+// nowhere to put the [[deprecated]] attribute, so going through it would leave the
+// queue-deducing spelling silently un-deprecated while the explicit-backend one
+// warned. These forward to the queue-deducing `*_buffer_size` overloads defined
+// just above, so the pointer checks and backend switch still happen exactly once.
+template <typename... Args>
+    requires requires(Queue& probe_ctx, Args&&... probe_args) {
+        stedc_buffer_size<::batchlas::detail::kProbeBackend>(probe_ctx, std::forward<Args>(probe_args)...);
+    }
+[[deprecated("renamed to stedc_buffer_size")]]
+inline auto stedc_workspace_size(Queue& ctx, Args&&... args) {
+    return stedc_buffer_size(ctx, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+    requires requires(Queue& probe_ctx, Args&&... probe_args) {
+        ritz_values_buffer_size<::batchlas::detail::kProbeBackend>(probe_ctx, std::forward<Args>(probe_args)...);
+    }
+[[deprecated("renamed to ritz_values_buffer_size")]]
+inline auto ritz_values_workspace(Queue& ctx, Args&&... args) {
+    return ritz_values_buffer_size(ctx, std::forward<Args>(args)...);
+}
+
 BATCHLAS_DISPATCH_ON_QUEUE(inv)
 BATCHLAS_DISPATCH_ON_QUEUE(inv_buffer_size)
 BATCHLAS_DISPATCH_ON_QUEUE(inv_matrix)

--- a/include/batchlas/blas/extensions.hh
+++ b/include/batchlas/blas/extensions.hh
@@ -2640,4 +2640,243 @@ BATCHLAS_DISPATCH_ON_QUEUE(inv)
 BATCHLAS_DISPATCH_ON_QUEUE(inv_buffer_size)
 BATCHLAS_DISPATCH_ON_QUEUE(inv_matrix)
 
+// ---- ortho: option-struct and arena-backed spellings -----------------------
+//
+// Same layer as blas/options.hh -- an option struct plus a workspace-omitting
+// overload that leases from the queue's arena -- but it has to live HERE rather
+// than there. blas/linalg.hh includes blas/functions.hh (which ends by including
+// blas/options.hh) BEFORE it includes this header, so at the point options.hh is
+// parsed the name `ortho` is not yet declared and `ortho<B, T>(...)` in a
+// function body would not even parse as a template-id. Going the other way and
+// including options.hh from here is worse: this header is pulled in from
+// blas/functions/gesvd.hh, i.e. part-way through functions.hh's include list, so
+// options.hh's body would be parsed before potrf.hh/syev.hh had declared the
+// entry points it forwards to.
+//
+// Consequence of the split: none of options.hh's helpers are available here.
+// `detail::DenseMatrixLike`, `dense_scalar_t` and the BATCHLAS_DENSE_VIEW macro
+// (which options.hh #undefs) are all out of reach, so the MatrixView and Matrix
+// spellings are written out separately, exactly as the positional ortho
+// declarations above already do.
+//
+// The lease is released when the call returns. On an out-of-order Queue that
+// drains the device first, so the arena spelling is synchronous where the
+// span-taking spelling is not; see blas/options.hh and util/workspace.hh.
+
+struct OrthoOptions {
+    Transpose transA = Transpose::NoTrans;
+    OrthoAlgorithm algorithm = OrthoAlgorithm::Chol2;
+};
+
+struct OrthoAgainstOptions {
+    Transpose transA = Transpose::NoTrans;
+    Transpose transM = Transpose::NoTrans;
+    OrthoAlgorithm algorithm = OrthoAlgorithm::Chol2;
+    size_t iterations = 2;
+};
+
+// ---- in-place orthogonalisation --------------------------------------------
+
+template <Backend B, typename T>
+inline Event ortho(Queue& ctx,
+        const MatrixView<T, MatrixFormat::Dense>& A,
+        const OrthoOptions& opts,
+        Span<std::byte> workspace) {
+    return ortho<B, T>(ctx, A, opts.transA, workspace, opts.algorithm);
+}
+
+template <Backend B, typename T>
+inline Event ortho(Queue& ctx,
+        const MatrixView<T, MatrixFormat::Dense>& A,
+        const OrthoOptions& opts) {
+    // Sized with the same algorithm the call runs: Chol2, SVQB and the Householder
+    // path need different amounts of scratch, so a size query taken with the
+    // default would under-size every non-default request.
+    auto lease = ctx.workspace(ortho_buffer_size<B, T>(ctx, A, opts.transA, opts.algorithm));
+    return ortho<B, T>(ctx, A, opts.transA, lease.span(), opts.algorithm);
+}
+
+template <Backend B, typename T>
+inline Event ortho(Queue& ctx,
+        const Matrix<T, MatrixFormat::Dense>& A,
+        const OrthoOptions& opts,
+        Span<std::byte> workspace) {
+    return ortho<B, T>(ctx, MatrixView<T, MatrixFormat::Dense>(A), opts, workspace);
+}
+
+template <Backend B, typename T>
+inline Event ortho(Queue& ctx,
+        const Matrix<T, MatrixFormat::Dense>& A,
+        const OrthoOptions& opts) {
+    return ortho<B, T>(ctx, MatrixView<T, MatrixFormat::Dense>(A), opts);
+}
+
+template <typename T>
+inline Event ortho(Queue& ctx,
+        const MatrixView<T, MatrixFormat::Dense>& A,
+        const OrthoOptions& opts,
+        Span<std::byte> workspace) {
+    if (detail::pointer_checks_enabled()) {
+        detail::require_arg_accessible(ctx, A, "ortho: A");
+        detail::require_arg_accessible(ctx, workspace, "ortho: workspace");
+    }
+    return with_backend(ctx, [&](auto Back) { return ortho<Back.value, T>(ctx, A, opts, workspace); });
+}
+
+template <typename T>
+inline Event ortho(Queue& ctx,
+        const MatrixView<T, MatrixFormat::Dense>& A,
+        const OrthoOptions& opts = {}) {
+    if (detail::pointer_checks_enabled()) detail::require_arg_accessible(ctx, A, "ortho: A");
+    return with_backend(ctx, [&](auto Back) { return ortho<Back.value, T>(ctx, A, opts); });
+}
+
+template <typename T>
+inline Event ortho(Queue& ctx,
+        const Matrix<T, MatrixFormat::Dense>& A,
+        const OrthoOptions& opts,
+        Span<std::byte> workspace) {
+    return ortho<T>(ctx, MatrixView<T, MatrixFormat::Dense>(A), opts, workspace);
+}
+
+template <typename T>
+inline Event ortho(Queue& ctx,
+        const Matrix<T, MatrixFormat::Dense>& A,
+        const OrthoOptions& opts = {}) {
+    return ortho<T>(ctx, MatrixView<T, MatrixFormat::Dense>(A), opts);
+}
+
+namespace detail {
+// The bare-`{}` trap, in the one place ortho has it. `ortho(ctx, A, {}, ws)` is
+// four arguments, which matches BOTH the positional overload
+// `(ctx, A, Transpose, ws, algo = Chol2)` and the option overload
+// `(ctx, A, OrthoOptions, ws)`. `{}` is an exact match for a scoped enum but
+// only a user-defined conversion to a class type, so the positional overload
+// wins silently -- the caller writes what looks like "defaults" and gets
+// `Transpose{}` with no diagnostic.
+//
+// Today `Transpose{}` is NoTrans and `OrthoAlgorithm{}` is Chol2, so the two
+// readings happen to agree and the trap is dormant; it arms itself the moment
+// either enum gains a new first enumerator or either OrthoOptions default
+// changes. That is exactly how the same trap reached potrf's Cholesky path
+// (blas/options.hh, detail::EmptyBracesAreAmbiguous) and surfaced only as LOBPCG
+// failing to converge.
+//
+// A third candidate at the same exact-match rank makes the bare-`{}` call
+// ambiguous instead of silently wrong, and the diagnostic names all three. This
+// is a distinct type from options.hh's EmptyBracesAreAmbiguous only because that
+// one is not visible here; it does the same job. Neither `OrthoOptions{}` nor
+// `Transpose::NoTrans` converts to it, so every spelled-out call still resolves
+// exactly as before.
+enum class OrthoEmptyBracesAreAmbiguous {};
+}  // namespace detail
+
+template <Backend B, typename T>
+Event ortho(Queue&, const MatrixView<T, MatrixFormat::Dense>&,
+            detail::OrthoEmptyBracesAreAmbiguous, Span<std::byte>) = delete;
+
+template <Backend B, typename T>
+Event ortho(Queue&, const Matrix<T, MatrixFormat::Dense>&,
+            detail::OrthoEmptyBracesAreAmbiguous, Span<std::byte>) = delete;
+
+template <typename T>
+Event ortho(Queue&, const MatrixView<T, MatrixFormat::Dense>&,
+            detail::OrthoEmptyBracesAreAmbiguous, Span<std::byte>) = delete;
+
+template <typename T>
+Event ortho(Queue&, const Matrix<T, MatrixFormat::Dense>&,
+            detail::OrthoEmptyBracesAreAmbiguous, Span<std::byte>) = delete;
+
+// ---- orthogonalisation against an external metric ---------------------------
+//
+// No `{}` guard is needed on this family: the positional metric form needs at
+// least six arguments (ctx, A, M, transA, transM, ws) while the option forms
+// take four and five, so no argument list can reach both.
+
+template <Backend B, typename T>
+inline Event ortho(Queue& ctx,
+        const MatrixView<T, MatrixFormat::Dense>& A,
+        const MatrixView<T, MatrixFormat::Dense>& M,
+        const OrthoAgainstOptions& opts,
+        Span<std::byte> workspace) {
+    return ortho<B, T>(ctx, A, M, opts.transA, opts.transM, workspace, opts.algorithm,
+                       opts.iterations);
+}
+
+template <Backend B, typename T>
+inline Event ortho(Queue& ctx,
+        const MatrixView<T, MatrixFormat::Dense>& A,
+        const MatrixView<T, MatrixFormat::Dense>& M,
+        const OrthoAgainstOptions& opts) {
+    auto lease = ctx.workspace(ortho_buffer_size<B, T>(ctx, A, M, opts.transA, opts.transM,
+                                                       opts.algorithm, opts.iterations));
+    return ortho<B, T>(ctx, A, M, opts.transA, opts.transM, lease.span(), opts.algorithm,
+                       opts.iterations);
+}
+
+template <Backend B, typename T>
+inline Event ortho(Queue& ctx,
+        const Matrix<T, MatrixFormat::Dense>& A,
+        const Matrix<T, MatrixFormat::Dense>& M,
+        const OrthoAgainstOptions& opts,
+        Span<std::byte> workspace) {
+    return ortho<B, T>(ctx, MatrixView<T, MatrixFormat::Dense>(A),
+                       MatrixView<T, MatrixFormat::Dense>(M), opts, workspace);
+}
+
+template <Backend B, typename T>
+inline Event ortho(Queue& ctx,
+        const Matrix<T, MatrixFormat::Dense>& A,
+        const Matrix<T, MatrixFormat::Dense>& M,
+        const OrthoAgainstOptions& opts) {
+    return ortho<B, T>(ctx, MatrixView<T, MatrixFormat::Dense>(A),
+                       MatrixView<T, MatrixFormat::Dense>(M), opts);
+}
+
+template <typename T>
+inline Event ortho(Queue& ctx,
+        const MatrixView<T, MatrixFormat::Dense>& A,
+        const MatrixView<T, MatrixFormat::Dense>& M,
+        const OrthoAgainstOptions& opts,
+        Span<std::byte> workspace) {
+    if (detail::pointer_checks_enabled()) {
+        detail::require_arg_accessible(ctx, A, "ortho: A");
+        detail::require_arg_accessible(ctx, M, "ortho: M");
+        detail::require_arg_accessible(ctx, workspace, "ortho: workspace");
+    }
+    return with_backend(ctx,
+                        [&](auto Back) { return ortho<Back.value, T>(ctx, A, M, opts, workspace); });
+}
+
+template <typename T>
+inline Event ortho(Queue& ctx,
+        const MatrixView<T, MatrixFormat::Dense>& A,
+        const MatrixView<T, MatrixFormat::Dense>& M,
+        const OrthoAgainstOptions& opts = {}) {
+    if (detail::pointer_checks_enabled()) {
+        detail::require_arg_accessible(ctx, A, "ortho: A");
+        detail::require_arg_accessible(ctx, M, "ortho: M");
+    }
+    return with_backend(ctx, [&](auto Back) { return ortho<Back.value, T>(ctx, A, M, opts); });
+}
+
+template <typename T>
+inline Event ortho(Queue& ctx,
+        const Matrix<T, MatrixFormat::Dense>& A,
+        const Matrix<T, MatrixFormat::Dense>& M,
+        const OrthoAgainstOptions& opts,
+        Span<std::byte> workspace) {
+    return ortho<T>(ctx, MatrixView<T, MatrixFormat::Dense>(A),
+                    MatrixView<T, MatrixFormat::Dense>(M), opts, workspace);
+}
+
+template <typename T>
+inline Event ortho(Queue& ctx,
+        const Matrix<T, MatrixFormat::Dense>& A,
+        const Matrix<T, MatrixFormat::Dense>& M,
+        const OrthoAgainstOptions& opts = {}) {
+    return ortho<T>(ctx, MatrixView<T, MatrixFormat::Dense>(A),
+                    MatrixView<T, MatrixFormat::Dense>(M), opts);
+}
+
 }  // namespace batchlas

--- a/include/batchlas/blas/extra.hh
+++ b/include/batchlas/blas/extra.hh
@@ -3,6 +3,7 @@
 #include <batchlas/blas/enums.hh>
 #include <batchlas/util/sycl-vector.hh>
 #include <batchlas/util/sycl-device-queue.hh>
+#include <batchlas/blas/queue-dispatch.hh>
 
 namespace batchlas
 {
@@ -55,9 +56,29 @@ namespace batchlas
         return cond<B,T,MF>(ctx, MatrixView<T,MF>(A), norm_type, conds, workspace);
     }
 
+    // Workspace size for the `cond` overload above.
+    //
+    // This used to be declared as a non-template function hardwired to float,
+    // while the only definition (src/extra/cond.cc) was a template -- so the
+    // symbol the header promised did not exist and any caller got an undefined
+    // reference. The declaration now matches the definition.
+    //
+    // Instantiated for T in {float, double} with MF == MatrixFormat::Dense only
+    // (see COND_INSTANTIATE in src/extra/cond.cc). Complex `cond` is not
+    // implemented, so any other T or MF is a link error rather than a compile
+    // error; the Python binding reports it as not-implemented instead.
+    template <Backend B, typename T, MatrixFormat MF>
     size_t cond_buffer_size(Queue &ctx,
-                            const MatrixView<float, MatrixFormat::Dense> &A,
+                            const MatrixView<T, MF> &A,
                             const NormType norm_type);
+
+    // Forwarding overload (owning A)
+    template <Backend B, typename T, MatrixFormat MF>
+    inline size_t cond_buffer_size(Queue &ctx,
+                            const Matrix<T, MF> &A,
+                            const NormType norm_type) {
+        return cond_buffer_size<B,T,MF>(ctx, MatrixView<T,MF>(A), norm_type);
+    }
 
     //Convenience function which allocates memory internally
     template <Backend B, typename T, MatrixFormat MF>
@@ -198,5 +219,22 @@ namespace batchlas
                             const Matrix<T, MF> &A) {
         return transpose<T,MF>(ctx, MatrixView<T,MF>(A));
     }
+
+    // Backend-deducing overloads: `f(ctx, ...)` takes its backend from the
+    // queue. See BATCHLAS_DISPATCH_ON_QUEUE in blas/queue-dispatch.hh.
+    //
+    // `norm` and `transpose` above are not Backend-templated, so they need no
+    // dispatch overload -- they already work as written.
+    //
+    // The six random_*_with_log10_cond_metric generators are deliberately
+    // absent. Their scalar type appears only as `float_t<T>` -- an alias
+    // template, hence a non-deduced context -- and in the return type, so `T`
+    // cannot be deduced from the arguments. The macro's requires-clause would
+    // never be satisfied and it would expand to nothing at all, which reads as
+    // if the generators were dispatchable when they are not. They keep the
+    // explicit f<Backend, T>(...) spelling, for the same reason
+    // tridiagonal_solver_buffer_size does.
+    BATCHLAS_DISPATCH_ON_QUEUE(cond)
+    BATCHLAS_DISPATCH_ON_QUEUE(cond_buffer_size)
 
 }

--- a/include/batchlas/blas/functions/gemm.hh
+++ b/include/batchlas/blas/functions/gemm.hh
@@ -43,39 +43,17 @@ inline Event gemm(Queue& ctx,
         return gemm<Back,T>(ctx, MatrixView<T, MatrixFormat::Dense>(A), MatrixView<T, MatrixFormat::Dense>(Bmat), MatrixView<T, MatrixFormat::Dense>(Cmat), alpha, beta, transA, transB, precision);
 }
 
-template <Backend Back, typename T>
-inline Event gemm_heterogeneous(Queue& ctx,
-                                const MatrixView<T, MatrixFormat::Dense>& A,
-                                const MatrixView<T, MatrixFormat::Dense>& B,
-                                const MatrixView<T, MatrixFormat::Dense>& C,
-                                T alpha,
-                                T beta,
-                                Transpose transA,
-                                Transpose transB,
-                                ComputePrecision precision = ComputePrecision::Default) {
-        return gemm<Back, T>(ctx, A, B, C, alpha, beta, transA, transB, precision);
-}
-
-template <Backend Back, typename T>
-inline Event gemm_heterogeneous(Queue& ctx,
-                                const Matrix<T, MatrixFormat::Dense>& A,
-                                const Matrix<T, MatrixFormat::Dense>& B,
-                                const Matrix<T, MatrixFormat::Dense>& C,
-                                T alpha,
-                                T beta,
-                                Transpose transA,
-                                Transpose transB,
-                                ComputePrecision precision = ComputePrecision::Default) {
-        return gemm_heterogeneous<Back, T>(ctx,
-                                           MatrixView<T, MatrixFormat::Dense>(A),
-                                           MatrixView<T, MatrixFormat::Dense>(B),
-                                           MatrixView<T, MatrixFormat::Dense>(C),
-                                           alpha,
-                                           beta,
-                                           transA,
-                                           transB,
-                                           precision);
-}
+// There is no separate gemm_heterogeneous entry point. `gemm` handles a
+// heterogeneous batch -- one where the items carry differing active_rows /
+// active_cols -- natively on every backend: each of them tests
+// gemm_has_heterogeneous_batch(A, B, C) and routes accordingly. The alias that
+// used to live here forwarded to `gemm` with an unchanged argument list, so the
+// only thing the second name added was the impression that plain `gemm` did not
+// support heterogeneous batches.
+//
+// (The Python binding keeps a `gemm_heterogeneous` name, and that one is not
+// redundant: it coerces a list of differently-shaped arrays, which `gemm` does
+// not.)
 
 }  // namespace batchlas
 
@@ -85,6 +63,5 @@ namespace batchlas {
 // See BATCHLAS_DISPATCH_ON_QUEUE in blas/queue-dispatch.hh.
 
 BATCHLAS_DISPATCH_ON_QUEUE(gemm)
-BATCHLAS_DISPATCH_ON_QUEUE(gemm_heterogeneous)
 
 }  // namespace batchlas

--- a/include/batchlas/blas/functions/gesvd.hh
+++ b/include/batchlas/blas/functions/gesvd.hh
@@ -407,7 +407,7 @@ inline Event gesvd_dispatch(Queue& ctx,
     }
 
     if (workspace.size() < need_ws) {
-        throw std::runtime_error("gesvd: insufficient workspace for chosen provider");
+        throw std::invalid_argument("gesvd: insufficient workspace for chosen provider");
     }
 
     // std::optional, not a plain `Queue`: the default Queue constructor is not inert, it

--- a/include/batchlas/blas/functions/getrf.hh
+++ b/include/batchlas/blas/functions/getrf.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include <batchlas/util/sycl-device-queue.hh>
 #include <batchlas/util/sycl-span.hh>
 #include <batchlas/blas/matrix.hh>
@@ -14,7 +16,7 @@ namespace sig {
 template <typename T>
 using getrf = Event(Queue&,
                     const MatrixView<T, MatrixFormat::Dense>&,
-                    Span<int64_t>, Span<std::byte>);
+                    Span<int64_t>, Span<std::byte>, Span<int32_t>);
 
 template <typename T>
 using getrf_buffer_size = size_t(Queue&,
@@ -22,18 +24,51 @@ using getrf_buffer_size = size_t(Queue&,
 }  // namespace sig
 
 
+// `info` is the LAPACK per-item status: one int32 per batch item, 0 on success
+// and >0 for the column at which U became exactly singular. Every backend
+// already allocates that array for the vendor call and then throws it away, so
+// a caller could not tell "the batch factorised" from "item 37 is singular and
+// every getrs/getri downstream of it is noise" (see issue #73).
+//
+// An EMPTY span means "not requested" and is exactly today's behaviour: the
+// backend falls back to its own scratch allocation. The workspace size is
+// deliberately the same either way, so getrf_buffer_size stays correct whether
+// or not a caller asks for status.
 template <Backend B, typename T>
 Event getrf(Queue& ctx,
             const MatrixView<T, MatrixFormat::Dense>& A,
             Span<int64_t> pivots,
-            Span<std::byte> work_space);
+            Span<std::byte> work_space,
+            Span<int32_t> info);
+
+// Old-arity forwarder. `info` cannot be a defaulted trailing parameter: the
+// sig:: alias above is a function *type* and function types cannot carry
+// default arguments (see src/util/template-instantiations.hh), so a default
+// would not be part of the instantiated signature. A separate overload keeps
+// every existing four-argument call site compiling unchanged.
+template <Backend B, typename T>
+inline Event getrf(Queue& ctx,
+            const MatrixView<T, MatrixFormat::Dense>& A,
+            Span<int64_t> pivots,
+            Span<std::byte> work_space) {
+        return getrf<B,T>(ctx, A, pivots, work_space, Span<int32_t>{});
+}
+
+template <Backend B, typename T>
+inline Event getrf(Queue& ctx,
+                        const Matrix<T, MatrixFormat::Dense>& A,
+                        Span<int64_t> pivots,
+                        Span<std::byte> work_space,
+                        Span<int32_t> info) {
+        return getrf<B,T>(ctx, MatrixView<T, MatrixFormat::Dense>(A), pivots, work_space, info);
+}
 
 template <Backend B, typename T>
 inline Event getrf(Queue& ctx,
                         const Matrix<T, MatrixFormat::Dense>& A,
                         Span<int64_t> pivots,
                         Span<std::byte> work_space) {
-        return getrf<B,T>(ctx, MatrixView<T, MatrixFormat::Dense>(A), pivots, work_space);
+        return getrf<B,T>(ctx, MatrixView<T, MatrixFormat::Dense>(A), pivots, work_space, Span<int32_t>{});
 }
 
 template <Backend B, typename T>

--- a/include/batchlas/blas/functions/getri.hh
+++ b/include/batchlas/blas/functions/getri.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include <batchlas/util/sycl-device-queue.hh>
 #include <batchlas/util/sycl-span.hh>
 #include <batchlas/blas/matrix.hh>
@@ -15,7 +17,7 @@ template <typename T>
 using getri = Event(Queue&,
                     const MatrixView<T, MatrixFormat::Dense>&,
                     const MatrixView<T, MatrixFormat::Dense>&,
-                    Span<int64_t>, Span<std::byte>);
+                    Span<int64_t>, Span<std::byte>, Span<int32_t>);
 
 template <typename T>
 using getri_buffer_size = size_t(Queue&,
@@ -23,12 +25,46 @@ using getri_buffer_size = size_t(Queue&,
 }  // namespace sig
 
 
+// `info` is the LAPACK per-item status: one int32 per batch item, 0 on success
+// and >0 for the diagonal of U that was exactly zero, so the item has no
+// inverse. The vendor call already writes it and every backend discarded it
+// (see issue #73), leaving the caller to consume a matrix of infinities.
+//
+// An EMPTY span means "not requested" and is exactly today's behaviour: the
+// backend falls back to its own scratch allocation. The workspace size is
+// deliberately the same either way, so getri_buffer_size stays correct whether
+// or not a caller asks for status.
 template <Backend B, typename T>
 Event getri(Queue& ctx,
             const MatrixView<T, MatrixFormat::Dense>& A,
             const MatrixView<T, MatrixFormat::Dense>& C,
             Span<int64_t> pivots,
-            Span<std::byte> work_space);
+            Span<std::byte> work_space,
+            Span<int32_t> info);
+
+// Old-arity forwarder. `info` cannot be a defaulted trailing parameter: the
+// sig:: alias above is a function *type* and function types cannot carry
+// default arguments (see src/util/template-instantiations.hh), so a default
+// would not be part of the instantiated signature. A separate overload keeps
+// every existing five-argument call site compiling unchanged.
+template <Backend B, typename T>
+inline Event getri(Queue& ctx,
+            const MatrixView<T, MatrixFormat::Dense>& A,
+            const MatrixView<T, MatrixFormat::Dense>& C,
+            Span<int64_t> pivots,
+            Span<std::byte> work_space) {
+        return getri<B,T>(ctx, A, C, pivots, work_space, Span<int32_t>{});
+}
+
+template <Backend B, typename T>
+inline Event getri(Queue& ctx,
+                        const Matrix<T, MatrixFormat::Dense>& A,
+                        const Matrix<T, MatrixFormat::Dense>& Cmat,
+                        Span<int64_t> pivots,
+                        Span<std::byte> work_space,
+                        Span<int32_t> info) {
+        return getri<B,T>(ctx, MatrixView<T, MatrixFormat::Dense>(A), MatrixView<T, MatrixFormat::Dense>(Cmat), pivots, work_space, info);
+}
 
 template <Backend B, typename T>
 inline Event getri(Queue& ctx,
@@ -36,7 +72,7 @@ inline Event getri(Queue& ctx,
                         const Matrix<T, MatrixFormat::Dense>& Cmat,
                         Span<int64_t> pivots,
                         Span<std::byte> work_space) {
-        return getri<B,T>(ctx, MatrixView<T, MatrixFormat::Dense>(A), MatrixView<T, MatrixFormat::Dense>(Cmat), pivots, work_space);
+        return getri<B,T>(ctx, MatrixView<T, MatrixFormat::Dense>(A), MatrixView<T, MatrixFormat::Dense>(Cmat), pivots, work_space, Span<int32_t>{});
 }
 
 template <Backend B, typename T>

--- a/include/batchlas/blas/functions/ormqr.hh
+++ b/include/batchlas/blas/functions/ormqr.hh
@@ -219,7 +219,7 @@ inline Event ormqr_dispatch(Queue& ctx,
     }
 
     if (workspace.size() < need_ws) {
-        throw std::runtime_error("ormqr: insufficient workspace for chosen provider");
+        throw std::invalid_argument("ormqr: insufficient workspace for chosen provider");
     }
 
     // std::optional, not a plain `Queue`: the default Queue constructor is not inert, it

--- a/include/batchlas/blas/functions/potrf.hh
+++ b/include/batchlas/blas/functions/potrf.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include <batchlas/util/sycl-device-queue.hh>
 #include <batchlas/util/sycl-span.hh>
 #include <batchlas/blas/matrix.hh>
@@ -14,7 +16,7 @@ namespace sig {
 template <typename T>
 using potrf = Event(Queue&,
                     const MatrixView<T, MatrixFormat::Dense>&,
-                    Uplo, Span<std::byte>);
+                    Uplo, Span<std::byte>, Span<int32_t>);
 
 template <typename T>
 using potrf_buffer_size = size_t(Queue&,
@@ -28,11 +30,36 @@ size_t potrf_buffer_size(Queue& ctx,
                     const MatrixView<T, MatrixFormat::Dense>& A,
                     Uplo uplo);
 
+// `info` is the LAPACK per-item status: one int32 per batch item, 0 on success
+// and >0 for the leading minor at which the item stopped being positive
+// definite. It used to be unreachable -- every backend allocated the array the
+// vendor call needs, passed it, and dropped it -- so a caller could not tell a
+// batch that factorised from one where item 37 is rank-deficient and everything
+// downstream is noise (see issue #73).
+//
+// An EMPTY span means "not requested" and is exactly today's behaviour: the
+// backend falls back to its own scratch allocation. The workspace size is
+// deliberately the same either way, so potrf_buffer_size stays correct whether
+// or not a caller asks for status.
 template <Backend B, typename T>
 Event potrf(Queue& ctx,
         const MatrixView<T, MatrixFormat::Dense>& descrA,
         Uplo uplo,
-        Span<std::byte> workspace);
+        Span<std::byte> workspace,
+        Span<int32_t> info);
+
+// Old-arity forwarder. `info` cannot be a defaulted trailing parameter: the
+// sig:: aliases above are function *types* and function types cannot carry
+// default arguments (see src/util/template-instantiations.hh), so a default
+// would not be part of the instantiated signature. A separate overload keeps
+// every existing four-argument call site compiling unchanged.
+template <Backend B, typename T>
+inline Event potrf(Queue& ctx,
+        const MatrixView<T, MatrixFormat::Dense>& descrA,
+        Uplo uplo,
+        Span<std::byte> workspace) {
+        return potrf<B,T>(ctx, descrA, uplo, workspace, Span<int32_t>{});
+}
 
 template <Backend B, typename T>
 inline size_t potrf_buffer_size(Queue& ctx,
@@ -45,8 +72,17 @@ template <Backend B, typename T>
 inline Event potrf(Queue& ctx,
                 const Matrix<T, MatrixFormat::Dense>& descrA,
                 Uplo uplo,
+                Span<std::byte> workspace,
+                Span<int32_t> info) {
+        return potrf<B,T>(ctx, MatrixView<T, MatrixFormat::Dense>(descrA), uplo, workspace, info);
+}
+
+template <Backend B, typename T>
+inline Event potrf(Queue& ctx,
+                const Matrix<T, MatrixFormat::Dense>& descrA,
+                Uplo uplo,
                 Span<std::byte> workspace) {
-        return potrf<B,T>(ctx, MatrixView<T, MatrixFormat::Dense>(descrA), uplo, workspace);
+        return potrf<B,T>(ctx, MatrixView<T, MatrixFormat::Dense>(descrA), uplo, workspace, Span<int32_t>{});
 }
 
 }  // namespace batchlas

--- a/include/batchlas/blas/functions/trsm.hh
+++ b/include/batchlas/blas/functions/trsm.hh
@@ -18,7 +18,7 @@ template <typename T>
 using trsm = Event(Queue&,
                    const MatrixView<T, MatrixFormat::Dense>&,
                    const MatrixView<T, MatrixFormat::Dense>&,
-                   Side, Uplo, Transpose, Diag, T);
+                   T, Side, Uplo, Transpose, Diag);
 }  // namespace sig
 
 
@@ -34,72 +34,95 @@ inline void trsm_validate_params(
         int lda = A.ld(), ldb = B.ld();
 
         if (m < 0 || n < 0) {
-                throw std::runtime_error("TRSM: Matrix dimensions cannot be negative (m=" + std::to_string(m) + 
+                throw std::invalid_argument("TRSM: Matrix dimensions cannot be negative (m=" + std::to_string(m) + 
                                           ", n=" + std::to_string(n) + ")");
         }
 
         if (transA != Transpose::NoTrans && transA != Transpose::Trans && transA != Transpose::ConjTrans) {
-                throw std::runtime_error("TRSM: Invalid transpose operation: " + std::to_string(static_cast<int>(transA)));
+                throw std::invalid_argument("TRSM: Invalid transpose operation: " + std::to_string(static_cast<int>(transA)));
         }
         if (uplo != Uplo::Lower && uplo != Uplo::Upper) {
-                throw std::runtime_error("TRSM: Invalid uplo parameter: " + std::to_string(static_cast<int>(uplo)));
+                throw std::invalid_argument("TRSM: Invalid uplo parameter: " + std::to_string(static_cast<int>(uplo)));
         }
         if (side != Side::Left && side != Side::Right) {
-                throw std::runtime_error("TRSM: Invalid side parameter: " + std::to_string(static_cast<int>(side)));
+                throw std::invalid_argument("TRSM: Invalid side parameter: " + std::to_string(static_cast<int>(side)));
         }
         if (diag != Diag::NonUnit && diag != Diag::Unit) {
-                throw std::runtime_error("TRSM: Invalid diag parameter: " + std::to_string(static_cast<int>(diag)));
+                throw std::invalid_argument("TRSM: Invalid diag parameter: " + std::to_string(static_cast<int>(diag)));
         }
 
         if (side == Side::Left) {
                 if (A.rows() != m || A.cols() != m) {
-                        throw std::runtime_error("TRSM: For left side, A must be square matrix of size m x m. Got " + 
+                        throw std::invalid_argument("TRSM: For left side, A must be square matrix of size m x m. Got " + 
                                                 std::to_string(A.rows()) + "x" + std::to_string(A.cols()) + 
                                                 " instead of " + std::to_string(m) + "x" + std::to_string(m));
                 }
                 if (lda < std::max(1, m)) {
-                        throw std::runtime_error("TRSM: lda must be >= max(1, m). Got lda=" + 
+                        throw std::invalid_argument("TRSM: lda must be >= max(1, m). Got lda=" + 
                                                 std::to_string(lda) + ", m=" + std::to_string(m));
                 }
         } else {
                 if (A.rows() != n || A.cols() != n) {
-                        throw std::runtime_error("TRSM: For right side, A must be square matrix of size n x n. Got " + 
+                        throw std::invalid_argument("TRSM: For right side, A must be square matrix of size n x n. Got " + 
                                                 std::to_string(A.rows()) + "x" + std::to_string(A.cols()) + 
                                                 " instead of " + std::to_string(n) + "x" + std::to_string(n));
                 }
                 if (lda < std::max(1, n)) {
-                        throw std::runtime_error("TRSM: lda must be >= max(1, n). Got lda=" + 
+                        throw std::invalid_argument("TRSM: lda must be >= max(1, n). Got lda=" + 
                                                 std::to_string(lda) + ", n=" + std::to_string(n));
                 }
         }
 
         if (ldb < std::max(1, m)) {
-                throw std::runtime_error("TRSM: ldb must be >= max(1, m). Got ldb=" + 
+                throw std::invalid_argument("TRSM: ldb must be >= max(1, m). Got ldb=" + 
                                         std::to_string(ldb) + ", m=" + std::to_string(m));
         }
 }
 
+// alpha sits in position 4, immediately after the matrices, to match trmm (see
+// functions/trmm.hh). It used to come last here, so the two triangular routines
+// disagreed on where the scalar went and only one of them could be written from
+// memory; the deleted overloads below turn the old spelling into a diagnostic
+// rather than leaving it to be rediscovered.
 template <Backend Back, typename T>
 Event trsm(Queue& ctx,
            const MatrixView<T, MatrixFormat::Dense>& A,
            const MatrixView<T, MatrixFormat::Dense>& B,
+           T alpha,
            Side side,
            Uplo uplo,
            Transpose transA,
-           Diag diag,
-           T alpha);
+           Diag diag);
 
 template <Backend Back, typename T>
 inline Event trsm(Queue& ctx,
                    const Matrix<T, MatrixFormat::Dense>& A,
                    const Matrix<T, MatrixFormat::Dense>& Bmat,
+                   T alpha,
                    Side side,
                    Uplo uplo,
                    Transpose transA,
-                   Diag diag,
-                   T alpha) {
-        return trsm<Back,T>(ctx, MatrixView<T, MatrixFormat::Dense>(A), MatrixView<T, MatrixFormat::Dense>(Bmat), side, uplo, transA, diag, alpha);
+                   Diag diag) {
+        return trsm<Back,T>(ctx, MatrixView<T, MatrixFormat::Dense>(A), MatrixView<T, MatrixFormat::Dense>(Bmat), alpha, side, uplo, transA, diag);
 }
+
+// Tombstones for the pre-reorder argument order. Side/Uplo/Transpose/Diag are
+// all enum class, so nothing implicitly converts to or from T and a stale call
+// could never have silently compiled into a wrong answer -- but without these
+// the error would be "no matching function", which does not say what changed.
+// Both spellings need one: deleting only the MatrixView overload would leave a
+// Matrix-argument call binding to the new order with alpha where side belongs.
+template <Backend Back, typename T>
+Event trsm(Queue&,
+           const MatrixView<T, MatrixFormat::Dense>&,
+           const MatrixView<T, MatrixFormat::Dense>&,
+           Side, Uplo, Transpose, Diag, T) = delete;
+
+template <Backend Back, typename T>
+Event trsm(Queue&,
+           const Matrix<T, MatrixFormat::Dense>&,
+           const Matrix<T, MatrixFormat::Dense>&,
+           Side, Uplo, Transpose, Diag, T) = delete;
 
 }  // namespace batchlas
 

--- a/include/batchlas/blas/linalg-ops.hh
+++ b/include/batchlas/blas/linalg-ops.hh
@@ -1,8 +1,17 @@
 #pragma once
 
+#include <algorithm>
+#include <stdexcept>
 #include <utility>
 
 #include <batchlas/blas/enums.hh>
+// extensions.hh (inv) and extra.hh (norm, transpose, cond) are needed here, not
+// merely by whoever includes this header: the forwarding wrappers below name
+// their targets with a QUALIFIED ::batchlas:: id, and qualified lookup happens
+// at template-definition context, so the declarations have to be visible now.
+// Neither costs measurable parse time -- both are declaration-only.
+#include <batchlas/blas/extensions.hh>
+#include <batchlas/blas/extra.hh>
 #include <batchlas/blas/matrix.hh>
 #include <batchlas/blas/options.hh>
 #include <batchlas/util/sycl-device-queue.hh>
@@ -24,9 +33,43 @@
 // an inner loop, keep using the out-parameter forms in `batchlas`, which let the
 // caller own and reuse the output.
 //
-// Every entry point here takes its backend from the Queue and its workspace from
-// the queue's arena, so none of them is templated on Backend and none takes a
-// workspace.
+// The rule that decides which namespace an operation belongs in:
+//
+//   value-returning, backend from the Queue, workspace from the arena => linalg::
+//   out-parameter, workspace yours                                    => batchlas::
+//
+// So every entry point here takes its backend from the Queue and its workspace
+// from the queue's arena; none of them is templated on Backend and none takes a
+// workspace. Several are one-line forwards to a `batchlas::` entry point that
+// already satisfies the rule -- they are here so that a caller reaching for the
+// convenience layer finds the whole of it in one namespace, rather than having
+// to know which of two namespaces a given convenience form happens to live in.
+//
+// Three exceptions, each documented again at the entry point:
+//
+//   * `norm` and `cond` WAIT. Their `batchlas::` implementations call .wait()
+//     internally (src/extra/norm.cc, src/extra/cond.cc), so unlike everything
+//     else here they do not merely enqueue. Fixing that belongs with those
+//     implementations, not with a wrapper that would hide it.
+//   * `svd` WAITS, for a different reason: it holds local scratch the caller
+//     never sees, and a Matrix's destructor frees its USM without waiting, so
+//     returning early would hand those pages back underneath kernels that have
+//     only been enqueued. The wait is what keeps the scratch alive; it is not a
+//     synchronisation convenience. `eigvalsh` (`work`) and `solve` (`LU`) have
+//     the same shape and no wait -- they survive on a shorter kernel chain
+//     rather than by construction, and want the same treatment or an
+//     arena-owned scratch. Left as they were so this change stays scoped to
+//     what it verifies.
+//   * `transpose` is real-only. transpose_impl moves data without conjugating,
+//     so the complex instantiations are deliberately switched off in
+//     src/extra/transpose.cc rather than hand callers a non-conjugating
+//     "transpose" under a name most read as the adjoint.
+//   * `cond` is float/double only, for the same instantiation reason.
+//
+// The two scalar-type restrictions are spelled as `requires` clauses so that a
+// rejected type is a compile error naming the constraint, rather than an
+// undefined symbol at link time -- which is what the unconstrained wrapper
+// would have produced, and the worst place to learn it.
 namespace batchlas::linalg {
 
 // ---- elementwise -----------------------------------------------------------
@@ -52,6 +95,13 @@ using axpby_into = Event(Queue&,
 
 template <typename T>
 using scale = Event(Queue&, const MatrixView<T, MatrixFormat::Dense>&, T);
+
+template <typename T>
+using triangular_mask_into = Event(Queue&,
+                                   const MatrixView<T, MatrixFormat::Dense>&,
+                                   const MatrixView<T, MatrixFormat::Dense>&,
+                                   Uplo,
+                                   int64_t);
 }  // namespace sig
 
 // C = op(A, B), elementwise, for matching shapes. Aliasing C with A or B is
@@ -77,6 +127,24 @@ Event axpby_into(Queue& ctx,
 // A <- alpha * A.
 template <typename T>
 Event scale(Queue& ctx, const MatrixView<T, MatrixFormat::Dense>& A, T alpha);
+
+// C = A with everything outside the requested triangle set to zero. `k` follows
+// NumPy: k = 0 keeps the main diagonal, k > 0 moves the boundary toward the
+// upper right, k < 0 toward the lower left. Aliasing C with A is allowed: each
+// work-item reads and writes one element.
+//
+// This is a *mask* over an existing matrix, which is what MatrixView's
+// fill_triangular does not do -- that one generates a triangular matrix from
+// scalars. Masking is what lets an in-place LAPACK factorisation be split into
+// its factors -- recovering R from a geqrf result before orgqr overwrites it is
+// what this was written for. See the note further down about why the qr wrapper
+// that would have used it is not here.
+template <typename T>
+Event triangular_mask_into(Queue& ctx,
+                           const MatrixView<T, MatrixFormat::Dense>& A,
+                           const MatrixView<T, MatrixFormat::Dense>& C,
+                           Uplo uplo,
+                           int64_t k = 0);
 
 template <typename T>
 inline Event add_into(Queue& ctx,
@@ -165,21 +233,43 @@ inline Matrix<T, MatrixFormat::Dense> scaled(Queue& ctx,
 
 // ---- value-returning wrappers ---------------------------------------------
 
+// matmul's own options -- deliberately NOT GemmOptions. matmul allocates C, so
+// `beta` has no meaning here: any non-zero value would read uninitialised
+// memory, and the wrapper used to overwrite the field silently, so
+// `{.alpha = 2, .beta = 1}` compiled and quietly computed 2*A*B. Omitting the
+// field makes naming it a compile error instead.
+//
+// This lives here, not in blas/options.hh, because it is a linalg-layer type:
+// nothing in batchlas:: takes it.
+template <typename T>
+struct MatmulOptions {
+    T alpha = T(1);
+    Transpose transA = Transpose::NoTrans;
+    Transpose transB = Transpose::NoTrans;
+    ComputePrecision precision = ComputePrecision::Default;
+};
+
 // C = alpha * op(A) * op(B). The result is allocated here and fully written, so
 // it is never read before it is set and needs no zeroing.
 template <typename T>
 inline Matrix<T, MatrixFormat::Dense> matmul(Queue& ctx,
                                              const MatrixView<T, MatrixFormat::Dense>& A,
                                              const MatrixView<T, MatrixFormat::Dense>& B,
-                                             const GemmOptions<T>& opts = {}) {
+                                             const MatmulOptions<T>& opts = {}) {
     const bool ta = opts.transA != Transpose::NoTrans;
     const bool tb = opts.transB != Transpose::NoTrans;
     const auto m = ta ? A.cols() : A.rows();
     const auto n = tb ? B.rows() : B.cols();
     Matrix<T, MatrixFormat::Dense> C(m, n, A.batch_size());
-    auto o = opts;
-    o.beta = T(0);  // C is fresh; anything else would read uninitialised memory
-    gemm(ctx, A, B, C.view(), o);
+    // The designated initialisers are in GemmOptions' declaration order, which
+    // C++20 requires; a field reorder there is a compile error here, not a
+    // silent argument swap.
+    gemm(ctx, A, B, C.view(),
+         GemmOptions<T>{.alpha = opts.alpha,
+                        .beta = T(0),  // C is fresh; anything else would read uninitialised memory
+                        .transA = opts.transA,
+                        .transB = opts.transB,
+                        .precision = opts.precision});
     return C;
 }
 
@@ -254,5 +344,184 @@ inline Matrix<T, MatrixFormat::Dense> solve(Queue& ctx,
     getrs(ctx, LU.view(), X.view(), pivots, {.trans = trans});
     return X;
 }
+
+// A with everything below (triu) or above (tril) the k-th diagonal zeroed. A is
+// not modified.
+template <typename T>
+inline Matrix<T, MatrixFormat::Dense> triu(Queue& ctx,
+                                           const MatrixView<T, MatrixFormat::Dense>& A,
+                                           int64_t k = 0) {
+    auto C = detail::like(A);
+    triangular_mask_into<T>(ctx, A, C.view(), Uplo::Upper, k);
+    return C;
+}
+
+template <typename T>
+inline Matrix<T, MatrixFormat::Dense> tril(Queue& ctx,
+                                           const MatrixView<T, MatrixFormat::Dense>& A,
+                                           int64_t k = 0) {
+    auto C = detail::like(A);
+    triangular_mask_into<T>(ctx, A, C.view(), Uplo::Lower, k);
+    return C;
+}
+
+// ---- forwarding aliases ----------------------------------------------------
+//
+// Every call below is EXPLICITLY qualified with ::batchlas::. batchlas::linalg
+// is nested inside batchlas, so unqualified lookup finds the linalg:: name
+// first and stops: `return inv(ctx, A);` written here is infinite recursion,
+// and there is no diagnostic for it -- the call matches, so nothing is
+// ill-formed. The wrappers above get away with unqualified `gemm`/`getrf`/
+// `syev` only because no linalg:: name shadows those.
+
+// A^-1, as a new matrix. A is not modified. Square only (getrf's precondition).
+template <typename T>
+inline Matrix<T, MatrixFormat::Dense> inv(Queue& ctx,
+                                          const MatrixView<T, MatrixFormat::Dense>& A) {
+    return ::batchlas::inv(ctx, A);
+}
+
+// Plain transpose, NOT the conjugate transpose. Real scalars only: the complex
+// instantiations of ::batchlas::transpose are commented out in
+// src/extra/transpose.cc because transpose_impl moves data without conjugating,
+// so a complex call would either be an undefined symbol at link time or -- if
+// those lines were uncommented -- silently compute a non-conjugating adjoint.
+// The constraint turns the first failure into a compile error and refuses to
+// make the second one possible.
+template <typename T>
+    requires RealScalar<T>
+inline Matrix<T, MatrixFormat::Dense> transpose(Queue& ctx,
+                                                const MatrixView<T, MatrixFormat::Dense>& A) {
+    return ::batchlas::transpose<T, MatrixFormat::Dense>(ctx, A);
+}
+
+// One norm per batch item. THIS ONE WAITS: the value-returning
+// ::batchlas::norm calls .wait() internally (src/extra/norm.cc), so unlike the
+// rest of this header it has returned only once the result is readable. Use the
+// out-parameter ::batchlas::norm(ctx, A, norm_type, norms) to stay asynchronous.
+template <typename T>
+inline UnifiedVector<typename base_type<T>::type> norm(
+        Queue& ctx,
+        const MatrixView<T, MatrixFormat::Dense>& A,
+        NormType norm_type = NormType::Frobenius) {
+    return ::batchlas::norm<T, MatrixFormat::Dense>(ctx, A, norm_type);
+}
+
+// Condition number per batch item, as ||A|| * ||A^-1|| (or the eigenvalue ratio
+// for NormType::Spectral). WAITS, for the same reason norm does
+// (src/extra/cond.cc).
+//
+// Real scalars only. ::batchlas::cond is instantiated for float and double on
+// Dense alone (COND_INSTANTIATE in src/extra/cond.cc) because there is no
+// complex implementation behind it; without the constraint a complex call would
+// compile here and fail at link time with an undefined symbol, which is the
+// worst place to learn it.
+template <typename T>
+    requires RealScalar<T>
+inline UnifiedVector<T> cond(Queue& ctx,
+                             const MatrixView<T, MatrixFormat::Dense>& A,
+                             NormType norm_type = NormType::Frobenius) {
+    return ::batchlas::cond(ctx, A, norm_type);
+}
+
+// ---- composites ------------------------------------------------------------
+
+template <typename T>
+struct Svd {
+    Matrix<T, MatrixFormat::Dense> U;                   // m x m (All) or m x k (Thin)
+    UnifiedVector<typename base_type<T>::type> values;  // k = min(m, n) per batch item
+    Matrix<T, MatrixFormat::Dense> Vh;                  // n x n (All) or k x n (Thin)
+};
+
+// Singular value decomposition. A is not modified -- gesvd overwrites its input,
+// so it gets a copy.
+//
+// `vectors` sizes U and Vh through the same helpers the shape check uses
+// (svd_u_cols/svd_vh_rows in blas/enums.hh), so the two cannot disagree.
+// SvdVectors::None is rejected here rather than silently returning empty
+// matrices: a values-only spelling would need default-constructed views for U
+// and Vh, and that path is not exercised by this layer.
+//
+// Complex input can throw std::runtime_error rather than fail to compile: the
+// blocked provider's complex native path is not implemented
+// (src/extensions/gesvd_blocked.cc) and the cta provider rejects
+// max(m, n) > 32, so whether a given complex shape is served depends on the
+// dispatch heuristic and on BATCHLAS_GESVD_PROVIDER.
+template <typename T>
+inline Svd<T> svd(Queue& ctx,
+                  const MatrixView<T, MatrixFormat::Dense>& A,
+                  SvdVectors vectors = SvdVectors::All) {
+    if (vectors == SvdVectors::None) {
+        throw std::invalid_argument(
+            "linalg::svd: SvdVectors::None would leave U and Vh empty; use "
+            "::batchlas::gesvd directly for a values-only decomposition");
+    }
+    const int64_t m = A.rows();
+    const int64_t n = A.cols();
+    const int64_t k = std::min(m, n);
+    const int batch = A.batch_size();
+
+    auto work = detail::like(A);
+    MatrixView<T, MatrixFormat::Dense>::copy(ctx, work.view(), A);
+
+    Matrix<T, MatrixFormat::Dense> U(static_cast<int>(m),
+                                     static_cast<int>(svd_u_cols(vectors, m, k)), batch);
+    Matrix<T, MatrixFormat::Dense> Vh(static_cast<int>(svd_vh_rows(vectors, n, k)),
+                                      static_cast<int>(n), batch);
+    UnifiedVector<typename base_type<T>::type> S(static_cast<size_t>(k) *
+                                                 static_cast<size_t>(batch));
+
+    ::batchlas::gesvd(ctx, work.view(), S.to_span(), U.view(), Vh.view(),
+                      GesvdOptions{.jobu = vectors, .jobvh = vectors});
+
+    // `work` is local scratch that gesvd both reads and overwrites, and a
+    // Matrix's destructor frees its USM without waiting -- see the longer note
+    // in qr() for the failure this produces once the queue is under load.
+    ctx.wait();
+    return Svd<T>{std::move(U), std::move(S), std::move(Vh)};
+}
+
+template <typename T>
+struct Lu {
+    Matrix<T, MatrixFormat::Dense> factors;  // L and U packed; L's unit diagonal is implicit
+    UnifiedVector<int64_t> pivots;           // rows * batch_size, LAPACK ipiv convention
+};
+
+// LU factorisation with partial pivoting. A is not modified. Square only, which
+// is getrf's own precondition.
+//
+// The pivots are a UnifiedVector rather than an arena lease -- the deliberate
+// opposite of `solve` above. solve's pivots die with the call, so a lease is
+// right; these are returned to the caller, so they have to outlive it.
+template <typename T>
+inline Lu<T> lu(Queue& ctx, const MatrixView<T, MatrixFormat::Dense>& A) {
+    auto LU = detail::like(A);
+    MatrixView<T, MatrixFormat::Dense>::copy(ctx, LU.view(), A);
+    UnifiedVector<int64_t> pivots(static_cast<size_t>(A.rows()) *
+                                  static_cast<size_t>(A.batch_size()));
+    ::batchlas::getrf(ctx, LU.view(), pivots.to_span());
+    return Lu<T>{std::move(LU), std::move(pivots)};
+}
+
+// linalg::qr is deliberately absent.
+//
+// It was implemented (geqrf, mask R out of the factored array with
+// triangular_mask_into, then orgqr for Q) and it is WRONG under conditions the
+// test suite reaches: with another linalg::qr-using test having run earlier in
+// the same process, Q R != A by four orders of magnitude, at the same value
+// every time, in 2-4 of 4 concurrent runs of the test binary -- and it passes
+// every time the test runs alone or the suite runs serially.
+//
+// What it is NOT: the answer is deterministic rather than random, so it is not
+// reading freed pages; zero-filling Q and R before use does not change it, so it
+// is not reading them uninitialised; and draining the queue before the local
+// scratch dies does not change it either. It looks like arena state left by an
+// earlier call, but that was not established, and shipping a factorisation that
+// returns confident wrong numbers is worse than not shipping one.
+//
+// triangular_mask_into / triu / tril below were built for it and are correct and
+// tested on their own, so whoever picks this up has the piece that was missing.
+// Reproducer: tests/linalg_layer_tests.cc, run the binary four times at once.
+
 
 }  // namespace batchlas::linalg

--- a/include/batchlas/blas/matrix.hh
+++ b/include/batchlas/blas/matrix.hh
@@ -24,7 +24,7 @@ namespace batchlas {
 
     //Forward declare VectorView with default parameter
     template <typename T = float>
-    struct VectorView;
+    class VectorView;
 
     // Forward declare the backend handle - implementation will be in src/ folder
     template <typename T = float, MatrixFormat MType = MatrixFormat::Dense>
@@ -39,6 +39,56 @@ namespace batchlas {
         constexpr operator int() const = delete;   // no silent decay back to int
     };
     static_assert(std::is_trivially_copyable_v<NonZeros>, "NonZeros must stay trivially copyable");
+
+    // The same treatment for the layout parameters that a positional int list cannot
+    // keep straight. Two concrete confusions motivated these:
+    //
+    //   Vector(size, batch_size, stride, inc)  vs  VectorView(data, size, batch_size, inc, stride)
+    //       -- positions 3 and 4 are swapped between the owning type and its view, both
+    //          are plain int, and the view's only check (a span-length assert) cannot
+    //          tell the two readings apart, because (inc = n, stride = 1) and
+    //          (inc = 1, stride = n) fit in exactly the same buffer. Transliterating one
+    //          into the other therefore reads every element from the wrong address and
+    //          reports nothing. src/sort.hh writes both spellings twenty lines apart.
+    //
+    //   Matrix(rows, cols, batch_size, ld, stride)  vs  MatrixView(p, rows, cols, ld, stride, batch_size)
+    //       -- the batch count is third in one and sixth in the other, so
+    //          `MatrixView<float> V(p, n, n, batch)` compiles and means ld = batch.
+    //
+    // `operator int() const = delete` is the load-bearing part: without it the tag
+    // decays back into the ambiguity it exists to remove.
+    //
+    // Inc and Stride are live on Vector (see below). Ld and BatchSize are declared here
+    // so that the tagged MatrixView spelling, which has to rewrite ~148 call sites and is
+    // therefore a change of its own, does not have to reopen this block to add a second
+    // `Stride` under a different name.
+    struct Inc {
+        int value;
+        explicit constexpr Inc(int v = 1) : value(v) {}
+        constexpr operator int() const = delete;
+    };
+    static_assert(std::is_trivially_copyable_v<Inc>, "Inc must stay trivially copyable");
+
+    struct Stride {
+        int value;
+        explicit constexpr Stride(int v = 0) : value(v) {}
+        constexpr operator int() const = delete;
+    };
+    static_assert(std::is_trivially_copyable_v<Stride>, "Stride must stay trivially copyable");
+
+    struct Ld {
+        int value;
+        explicit constexpr Ld(int v = 0) : value(v) {}
+        constexpr operator int() const = delete;
+    };
+    static_assert(std::is_trivially_copyable_v<Ld>, "Ld must stay trivially copyable");
+
+    struct BatchSize {
+        int value;
+        explicit constexpr BatchSize(int v = 1) : value(v) {}
+        constexpr operator int() const = delete;
+    };
+    static_assert(std::is_trivially_copyable_v<BatchSize>, "BatchSize must stay trivially copyable");
 
     struct SliceEnd {};
     struct Slice { //Default Slice selects entire matrix
@@ -86,8 +136,22 @@ namespace batchlas {
             assert(i < rows_); assert(i >= 0);
             assert(j < cols_); assert(j >= 0);
             assert(b < batch_size_); assert(b >= 0);
-            assert(b * stride_ + j * ld_ + i < batch_size_ * stride_);
-            return data_[b * stride_ + j * ld_ + i]; }
+            // Both sides in int64_t. The old form compared two already-overflowed ints
+            // (a 512x512 float batch has stride 262144, so b * stride_ wraps at b = 8192,
+            // a batch size this library is built for), and it was additionally false for
+            // every access whenever stride_ was 0 -- which the 3-argument spelling of the
+            // constructor below used to produce. The `stride_ > 0` fallback keeps that
+            // case meaningful for views built by hand with the batch packed.
+            assert(static_cast<int64_t>(b) * stride_ + static_cast<int64_t>(j) * ld_ + i <
+                   static_cast<int64_t>(batch_size_) *
+                       (stride_ > 0 ? static_cast<int64_t>(stride_)
+                                    : static_cast<int64_t>(ld_) * cols_));
+            // Only the batch term is widened: b and stride_ are loop-invariant in every
+            // hot kernel here, so this is one 64-bit imad the compiler hoists, while
+            // j * ld_ + i can only overflow on a single matrix above 2^31 elements (8 GB
+            // for float), which the library cannot allocate. Span::operator[] takes a
+            // size_t, so the index was already being sign-extended to 64 bits anyway.
+            return data_[static_cast<int64_t>(b) * stride_ + j * ld_ + i]; }
 
         // CSR coefficient lookup (returns zero if absent)
         template <MatrixFormat MF = MType>
@@ -108,15 +172,19 @@ namespace batchlas {
             KernelMatrixView out = *this;
             if (b < 0 || b >= batch_size_) { out.rows_ = out.cols_ = 0; return out; }
             if constexpr (MType == MatrixFormat::Dense) {
-                out.data_ += b * stride_;
+                // int64_t for the same reason as operator() above, and this one matters
+                // more: batch_item is how most kernels reach their batch slice, and an
+                // overflowed int product here poisons a raw pointer rather than a single
+                // element index.
+                out.data_ += static_cast<int64_t>(b) * stride_;
                 out.rows_ = active_rows_ ? active_rows_[b] : rows_;
                 out.cols_ = active_cols_ ? active_cols_[b] : cols_;
                 out.active_rows_ = nullptr;
                 out.active_cols_ = nullptr;
             } else if constexpr (MType == MatrixFormat::CSR) {
-                out.data_        += b * matrix_stride_;
-                out.row_offsets_ += b * offset_stride_;
-                out.col_indices_ += b * matrix_stride_; // assumes same stride
+                out.data_        += static_cast<int64_t>(b) * matrix_stride_;
+                out.row_offsets_ += static_cast<int64_t>(b) * offset_stride_;
+                out.col_indices_ += static_cast<int64_t>(b) * matrix_stride_; // assumes same stride
             }
             out.batch_size_ = 1;
             return out;
@@ -131,6 +199,14 @@ namespace batchlas {
         inline auto ld() const { return ld_; }
         inline auto stride() const { return stride_; }
         inline auto nnz() const { return nnz_; }
+        // Non-zeros actually stored by one batch item, read from that item's row offsets.
+        // nnz() above is the per-item *capacity*: convert_to<CSR> sizes a heterogeneous
+        // batch by its largest item, so nnz() over-counts every smaller one. This overload
+        // is always safe here -- a KernelMatrixView runs where its pointers live.
+        inline auto nnz(int b) const {
+            const auto base = static_cast<int64_t>(b) * offset_stride_;
+            return row_offsets_[base + rows_] - row_offsets_[base];
+        }
         inline bool is_heterogeneous() const { return active_rows_ || active_cols_; }
         
         // Dense slicing operators (host-side; mirror MatrixView logic)
@@ -157,11 +233,18 @@ namespace batchlas {
 
         // Dense-shaped; constrained so a CSR kernel view cannot be built from it with the
         // CSR fields left null. CSR kernel views come from Matrix/MatrixView::kernel_view().
+        // stride_ resolves against the *resolved* ld, not the raw parameter. Written as
+        // `ld * cols` this produced stride_ = 0 for the three-argument spelling
+        // (ld defaulted to 0), which is live in src/extensions/steqr_legacy.cc; the
+        // resulting view addressed correctly only because batch_size is 1 there, but the
+        // element-access assert compares against batch_size_ * stride_ and so fired on
+        // every access in an assert-enabled build. MatrixView's equivalent constructor in
+        // src/matrix.cc has always resolved it this way.
         template <MatrixFormat MF = MType>
             requires DenseMatrixFormat<MF>
         KernelMatrixView(T* data, int rows, int cols, int ld = 0, int stride = 0, int batch_size = 1)
             : data_(data), rows_(rows), cols_(cols), batch_size_(batch_size),
-              ld_(ld > 0 ? ld : rows), stride_(stride > 0 ? stride : ld * cols) {}
+              ld_(ld > 0 ? ld : rows), stride_(stride > 0 ? stride : (ld > 0 ? ld : rows) * cols) {}
     };
 
     // (Slice already defined earlier)
@@ -596,13 +679,15 @@ namespace batchlas {
         template <typename U = T, MatrixFormat M = MType>
             requires DenseMatrixFormat<M>
         U& operator()(int row, int col, int batch) {
-            return data_.at(batch * stride_ + col * ld_ + row);
+            // The batch term in int64_t; see KernelMatrixView::operator() for why only
+            // that term. Span::at takes a size_t, so the wider index converts cleanly.
+            return data_.at(static_cast<int64_t>(batch) * stride_ + col * ld_ + row);
         }
 
         template <typename U = T, MatrixFormat M = MType>
             requires DenseMatrixFormat<M>
         const U& operator()(int row, int col, int batch) const {
-            return data_.at(batch * stride_ + col * ld_ + row);
+            return data_.at(static_cast<int64_t>(batch) * stride_ + col * ld_ + row);
         }
 
         // Methods to initialize backend
@@ -622,7 +707,17 @@ namespace batchlas {
 
         // Data access - provides non-owning view of the data
         // USM preparation helpers (non-owning, safe to call on const objects)
-        Event set_access_device(const Queue& ctx = Queue()) const {
+        //
+        // The Queue is mandatory, and deliberately so. These used to default to
+        // `Queue()`, which is not a handle to a shared queue: Queue's default
+        // constructor builds a brand-new QueueImpl on Device::default_device() every
+        // call (src/util/queue-impl.cc). So `A.set_access_device()` set the USM hint to
+        // the *default* device even when the caller's work runs on another one -- wrong
+        // on any multi-GPU box -- and the throwaway Queue carries its own workspace
+        // arena, so nothing allocated through it was ever reused. Do not re-add the
+        // default; the signature is the only place a caller can be told which device
+        // the hint lands on.
+        Event set_access_device(const Queue& ctx) const {
             if constexpr (MType == MatrixFormat::CSR) {
                 (void)row_offsets_.to_span().set_access_device(ctx);
                 (void)col_indices_.to_span().set_access_device(ctx);
@@ -630,7 +725,7 @@ namespace batchlas {
             return data_.to_span().set_access_device(ctx);
         }
 
-        Event prefetch(const Queue& ctx = Queue()) const {
+        Event prefetch(const Queue& ctx) const {
             if constexpr (MType == MatrixFormat::CSR) {
                 (void)row_offsets_.to_span().prefetch(ctx);
                 (void)col_indices_.to_span().prefetch(ctx);
@@ -727,9 +822,37 @@ namespace batchlas {
             requires CsrMatrixFormat<M>
         Span<int> col_indices() const { return col_indices_.to_span(); }
 
+        // The slots allocated per batch item -- what NonZeros{} asked for at
+        // construction, and what this has always returned. It is a capacity, not a count:
+        // convert_to<MatrixFormat::CSR> sizes the whole batch by its LARGEST item
+        // (src/matrix.cc), so on a heterogeneous batch this over-counts every smaller
+        // item and `for (int k = 0; k < S.nnz(); ++k)` walks off the end of that item's
+        // row range into slots the conversion never wrote. Its meaning is deliberately
+        // left alone: the vendor SpMM descriptors in src/backends/backend_handle_impl.hh
+        // hand this number to cusparseCreateCsr / rocsparse_create_csr_descr for a whole
+        // strided batch, where the capacity is the correct value and a per-item count
+        // would describe the batch short with no error.
         template <MatrixFormat M = MType>
             requires CsrMatrixFormat<M>
         int nnz() const { return nnz_; }
+
+        // The slots that were actually allocated per item. Equal to nnz() for both
+        // allocating paths, but the from-data constructor lets matrix_stride exceed the
+        // declared count, and it is matrix_stride that sizes the buffers.
+        template <MatrixFormat M = MType>
+            requires CsrMatrixFormat<M>
+        int nnz_capacity() const { return matrix_stride_; }
+
+        // Non-zeros actually stored by batch item `batch_index`, derived from that item's
+        // row offsets. Requires whatever kernel filled the offsets to have completed.
+        // Safe on an owning Matrix: row_offsets_ is USM shared and host-readable.
+        template <MatrixFormat M = MType>
+            requires CsrMatrixFormat<M>
+        int nnz(int batch_index) const {
+            const std::size_t base = static_cast<std::size_t>(batch_index) *
+                                     static_cast<std::size_t>(offset_stride_);
+            return row_offsets_[base + static_cast<std::size_t>(rows_)] - row_offsets_[base];
+        }
 
         template <MatrixFormat M = MType>
             requires CsrMatrixFormat<M>
@@ -738,7 +861,7 @@ namespace batchlas {
         template <MatrixFormat M = MType>
             requires CsrMatrixFormat<M>
         int offset_stride() const { return offset_stride_; }
-        
+
         // Backend handle access
         std::shared_ptr<BackendMatrixHandle<T, MType>> backend_handle() const { 
             return backend_handle_; 
@@ -876,8 +999,10 @@ namespace batchlas {
 
         // Data access
         Span<T> data() const { return data_; }
-        // USM preparation helpers (non-owning, safe to call on const views)
-        Event set_access_device(const Queue& ctx = Queue()) const {
+        // USM preparation helpers (non-owning, safe to call on const views).
+        // The Queue is mandatory; see the note on Matrix::set_access_device for why the
+        // `= Queue()` default was a device-placement bug rather than a convenience.
+        Event set_access_device(const Queue& ctx) const {
             if constexpr (MType == MatrixFormat::CSR) {
                 (void)row_offsets_.set_access_device(ctx);
                 (void)col_indices_.set_access_device(ctx);
@@ -885,7 +1010,7 @@ namespace batchlas {
             return data_.set_access_device(ctx);
         }
 
-        Event prefetch(const Queue& ctx = Queue()) const {
+        Event prefetch(const Queue& ctx) const {
             if constexpr (MType == MatrixFormat::CSR) {
                 (void)row_offsets_.prefetch(ctx);
                 (void)col_indices_.prefetch(ctx);
@@ -943,9 +1068,26 @@ namespace batchlas {
             requires CsrMatrixFormat<M>
         Span<int> col_indices() const { return col_indices_; }
 
+        // Per-item capacity, not a per-item count -- see the note on Matrix::nnz().
         template <MatrixFormat M = MType>
             requires CsrMatrixFormat<M>
         int nnz() const { return nnz_; }
+
+        // The slots actually allocated per item; see the note on Matrix::nnz_capacity().
+        template <MatrixFormat M = MType>
+            requires CsrMatrixFormat<M>
+        int nnz_capacity() const { return matrix_stride_; }
+
+        // Non-zeros actually stored by batch item `batch_index`. Only valid when the row
+        // offsets are host-reachable. A MatrixView built over sycl::malloc_device memory
+        // is not; use KernelMatrixView::nnz(b) inside a kernel instead.
+        template <MatrixFormat M = MType>
+            requires CsrMatrixFormat<M>
+        int nnz(int batch_index) const {
+            const std::size_t base = static_cast<std::size_t>(batch_index) *
+                                     static_cast<std::size_t>(offset_stride_);
+            return row_offsets_[base + static_cast<std::size_t>(rows_)] - row_offsets_[base];
+        }
 
         template <MatrixFormat M = MType>
             requires CsrMatrixFormat<M>
@@ -1099,20 +1241,18 @@ namespace batchlas {
             return fill(Queue(), value);
         }
 
+        // The queue-less fill_zeros()/fill_ones() forwarders are gone. They spelled
+        // `fill_zeros(Queue())`, and a default-constructed Queue is a brand-new QueueImpl
+        // on Device::default_device() (src/util/queue-impl.cc) -- so the fill ran on a
+        // different device from the caller's queue, built and tore down a SYCL queue per
+        // call, and carried its own workspace arena that nothing could reuse. Neither had
+        // a single caller in the repository. Pass the queue you are working on.
         Event fill_zeros(const Queue& ctx) const {
             return fill(ctx, detail::convert_to_fill_value<T>(0));
         }
 
-        Event fill_zeros() const {
-            return fill_zeros(Queue());
-        }
-
         Event fill_ones(const Queue& ctx) const {
             return fill(ctx, detail::convert_to_fill_value<T>(1));
-        }
-
-        Event fill_ones() const {
-            return fill_ones(Queue());
         }
 
         template <MatrixFormat M = MType>
@@ -1351,21 +1491,46 @@ namespace batchlas {
             }
 
         Vector() : data_(), size_(0), inc_(1), stride_(0), batch_size_(1) {}
-        Vector(int size, int batch_size = 1, int stride = 0, int inc = 1)
-            : data_(required_span_length(size, inc, (stride > 0 ? stride : size * inc), batch_size)),
-              size_(size), inc_(inc), stride_(stride > 0 ? stride : size * inc), batch_size_(batch_size) {}
-        Vector(int size, T value, int batch_size = 1, int stride = 0, int inc = 1)
-            : data_(required_span_length(size, inc, (stride > 0 ? stride : size * inc), batch_size), value),
-              size_(size), inc_(inc), stride_(stride > 0 ? stride : size * inc), batch_size_(batch_size) {}
+
+        // stride and inc carry tag types rather than being the third and fourth ints in
+        // a row. VectorView takes the same two values in the OPPOSITE order
+        // (data, size, batch_size, inc, stride), and both readings fit the same buffer,
+        // so transliterating a Vector spelling into a VectorView one -- which src/sort.hh
+        // does, twenty lines apart -- silently read every element from the wrong address.
+        // Neither the compiler nor VectorView's span-length assert could see it.
+        //
+        // The deleted bare-int overloads below are the other half of the fix: the old
+        // spelling `Vector<T>(n, batch, n, 1)` is now a compile error rather than a
+        // reinterpretation, so there is nothing left in the codebase to transliterate
+        // FROM. Vector was the cheap side to change -- six 4-argument call sites against
+        // VectorView's 138 -- which is why the view keeps its positional constructors and
+        // merely gains tagged ones alongside them.
+        Vector(int size, int batch_size = 1, Stride stride = Stride{0}, Inc inc = Inc{1})
+            : data_(required_span_length(size, inc.value, (stride.value > 0 ? stride.value : size * inc.value), batch_size)),
+              size_(size), inc_(inc.value), stride_(stride.value > 0 ? stride.value : size * inc.value), batch_size_(batch_size) {}
+        Vector(int size, T value, int batch_size = 1, Stride stride = Stride{0}, Inc inc = Inc{1})
+            : data_(required_span_length(size, inc.value, (stride.value > 0 ? stride.value : size * inc.value), batch_size), value),
+              size_(size), inc_(inc.value), stride_(stride.value > 0 ? stride.value : size * inc.value), batch_size_(batch_size) {}
+
+        Vector(int size, int batch_size, int stride, int inc) = delete;
+        Vector(int size, T value, int batch_size, int stride, int inc) = delete;
+        // The three-int spelling has to be deleted too, and for a nastier reason: with it
+        // gone from the tagged constructor, `Vector<float>(n, batch, stride)` would still
+        // have compiled -- by picking the (size, value, batch_size) overload and
+        // converting `batch` to a float element value. Deleting it turns that into a
+        // compile error. The cost is that Vector<int> loses its (size, value, batch)
+        // spelling to ambiguity; nothing in the repository uses it (the one integral
+        // vector, benchmarks/permuted_copy_benchmark.cc, goes through zeros()).
+        Vector(int size, int batch_size, int stride) = delete;
 
         // Convenience vectors
-        static Vector<T> zeros(int size, int batch_size = 1, int stride = 0, int inc = 1) {
+        static Vector<T> zeros(int size, int batch_size = 1, Stride stride = Stride{0}, Inc inc = Inc{1}) {
             return Vector<T>(size, T(0), batch_size, stride, inc);
         }
-        static Vector<T> ones(int size, int batch_size = 1, int stride = 0, int inc = 1) {
+        static Vector<T> ones(int size, int batch_size = 1, Stride stride = Stride{0}, Inc inc = Inc{1}) {
             return Vector<T>(size, T(1), batch_size, stride, inc);
         }
-        static Vector<T> random(int size, int batch_size = 1, int stride = 0, int inc = 1) {
+        static Vector<T> random(int size, int batch_size = 1, Stride stride = Stride{0}, Inc inc = Inc{1}) {
             Vector<T> vec(size, batch_size, stride, inc);
             std::mt19937 rng(42); // Mersenne Twister engine with fixed seed
             std::uniform_real_distribution<float_t<T>> dist(0.0f, 1.0f);
@@ -1376,13 +1541,25 @@ namespace batchlas {
             }
             return vec;
         }
-        static Vector<T> standard_basis(int size, int index, int batch_size = 1, int stride = 0) {
-            Vector<T> vec(size, T(0), batch_size, stride, 1);
+        static Vector<T> standard_basis(int size, int index, int batch_size = 1, Stride stride = Stride{0}) {
+            Vector<T> vec(size, T(0), batch_size, stride, Inc{1});
             for (int b = 0; b < batch_size; ++b) {
                 vec(index, b) = T(1);
             }
             return vec;
         }
+
+        // The bare-int spellings of the above, deleted so that the old argument order is
+        // a compile error rather than a reinterpretation. standard_basis's third argument
+        // really is batch_size, so standard_basis(size, index, batch) stays legal; only
+        // its fourth position needs the tag.
+        static Vector<T> zeros(int size, int batch_size, int stride, int inc) = delete;
+        static Vector<T> ones(int size, int batch_size, int stride, int inc) = delete;
+        static Vector<T> random(int size, int batch_size, int stride, int inc) = delete;
+        static Vector<T> zeros(int size, int batch_size, int stride) = delete;
+        static Vector<T> ones(int size, int batch_size, int stride) = delete;
+        static Vector<T> random(int size, int batch_size, int stride) = delete;
+        static Vector<T> standard_basis(int size, int index, int batch_size, int stride) = delete;
 
         Span<T> data() const { return data_.to_span(); }
 
@@ -1393,12 +1570,13 @@ namespace batchlas {
         // parameter is VectorView<T> therefore need this at the call site.
         VectorView<T> view() const { return VectorView<T>(*this); }
 
-        // USM preparation helpers (safe to call on const vectors)
-        Event set_access_device(const Queue& ctx = Queue()) const {
+        // USM preparation helpers (safe to call on const vectors).
+        // The Queue is mandatory; see the note on Matrix::set_access_device.
+        Event set_access_device(const Queue& ctx) const {
             return data_.to_span().set_access_device(ctx);
         }
 
-        Event prefetch(const Queue& ctx = Queue()) const {
+        Event prefetch(const Queue& ctx) const {
             return data_.to_span().prefetch(ctx);
         }
         T* data_ptr() const { return data_.data(); }
@@ -1411,8 +1589,9 @@ namespace batchlas {
         template <typename U>
         Vector<U> astype() const;
 
-        // Access element at (i, batch)
-        T& at(int i, int batch = 0) { return data_[i * inc_ + batch * stride_]; }
+        // Access element at (i, batch). The batch term is int64_t: batch * stride_ in int
+        // wraps well inside the batch sizes this library targets, and the wrap is UB.
+        T& at(int i, int batch = 0) { return data_[i * inc_ + static_cast<int64_t>(batch) * stride_]; }
         //const T& at(int i, int batch = 0) const { return data_[i * inc_ + batch * stride_]; }
 
         // Flat indexing (for backward compatibility)
@@ -1423,7 +1602,7 @@ namespace batchlas {
         // Get a view of a single batch
         VectorView<T> batch_item(int batch_index) const {
             const std::size_t single_batch_length = (size_ > 0) ? ((size_ - 1) * inc_ + 1) : 0;
-            return VectorView<T>(Span<T>(data_.data() + batch_index * stride_, single_batch_length), size_, 1, inc_, 0);
+            return VectorView<T>(Span<T>(data_.data() + static_cast<int64_t>(batch_index) * stride_, single_batch_length), size_, 1, inc_, 0);
         }
 
         void print(std::ostream& os = std::cout, int max_elements = 10) const {
@@ -1475,6 +1654,21 @@ namespace batchlas {
             : data_(data, required_span_length(size, inc, (stride > 0 ? stride : size * inc), batch_size)),
               size_(size), inc_(inc), stride_(stride > 0 ? stride : size * inc), batch_size_(batch_size) {}
 
+        // Tagged spellings, for new code. The positional ones above take inc before
+        // stride while Vector's constructor takes stride before inc, and both readings
+        // fit the same buffer, so the span-length assert cannot tell them apart -- see
+        // the Inc/Stride declarations at the top of this header. These are additive: the
+        // 138 in-repo positional constructions are all correct as written, and deleting
+        // the positional form would have to rewrite every one of them in the same commit,
+        // which is a change of its own. Vector's side of the mismatch is what carries the
+        // compile-time guarantee; here the tag is available rather than enforced.
+        VectorView(Span<T> data, int size, int batch_size, Inc inc, Stride stride = Stride{0})
+            : VectorView(data, size, batch_size, inc.value, stride.value) {}
+        VectorView(UnifiedVector<T>& data, int size, int batch_size, Inc inc, Stride stride = Stride{0})
+            : VectorView(data, size, batch_size, inc.value, stride.value) {}
+        VectorView(T* data, int size, int batch_size, Inc inc, Stride stride = Stride{0})
+            : VectorView(data, size, batch_size, inc.value, stride.value) {}
+
         // Construct from Vector
         VectorView(const Vector<T>& vec)
             : data_(vec.data()), size_(vec.size()), inc_(vec.inc()), stride_(vec.stride()), batch_size_(vec.batch_size()) {}
@@ -1487,16 +1681,17 @@ namespace batchlas {
 
         // Data access
         Span<T> data() const { return data_; }
-        // USM preparation helpers (non-owning, safe to call on const views)
-        Event set_access_device(const Queue& ctx = Queue()) const {
+        // USM preparation helpers (non-owning, safe to call on const views).
+        // The Queue is mandatory; see the note on Matrix::set_access_device.
+        Event set_access_device(const Queue& ctx) const {
             return data_.set_access_device(ctx);
         }
 
-        Event set_preferred_location(const Queue& ctx = Queue()) const {
+        Event set_preferred_location(const Queue& ctx) const {
             return data_.set_preferred_location(ctx);
         }
 
-        Event prefetch(const Queue& ctx = Queue()) const {
+        Event prefetch(const Queue& ctx) const {
             return data_.prefetch(ctx);
         }
         T* data_ptr() const { return data_.data(); }
@@ -1523,13 +1718,18 @@ namespace batchlas {
         }
 
         // Access element at (i, batch)
-        T& at(int i, int batch = 0) const { 
+        T& at(int i, int batch = 0) const {
             assert(i < size_); assert(i >= 0);
             assert(batch < batch_size_); assert(batch >= 0);
-            assert(i * inc_ + batch * stride_ < data_.size());
-                return data_[i * inc_ + batch * stride_]; }
+            // Both sides int64_t. The old assert built the index in int (so it compared
+            // an already-wrapped value) and then converted it to the size_t returned by
+            // Span::size(), which turns a negative index into an enormous positive one
+            // and makes the check pass exactly when it should fail.
+            assert(static_cast<int64_t>(i) * inc_ + static_cast<int64_t>(batch) * stride_ <
+                   static_cast<int64_t>(data_.size()));
+                return data_[static_cast<int64_t>(i) * inc_ + static_cast<int64_t>(batch) * stride_]; }
 
-        T& operator[](int i) const { assert(i < size_); assert(i >= 0); assert(i * inc_ < data_.size()); return data_[i * inc_]; }
+        T& operator[](int i) const { assert(i < size_); assert(i >= 0); assert(static_cast<int64_t>(i) * inc_ < static_cast<int64_t>(data_.size())); return data_[static_cast<int64_t>(i) * inc_]; }
 
         T& operator()(int i, int batch = 0) const {return at(i, batch);}
 
@@ -1537,7 +1737,7 @@ namespace batchlas {
         VectorView<T> batch_item(int batch_index) const {
             // For a single batch, we need (size-1)*inc + 1 elements starting at batch_index * stride
             const std::size_t single_batch_length = (size_ > 0) ? ((size_ - 1) * inc_ + 1) : 0;
-            return VectorView<T>(Span<T>(data_.data() + batch_index * stride_, single_batch_length), size_, 1, inc_, 0);
+            return VectorView<T>(Span<T>(data_.data() + static_cast<int64_t>(batch_index) * stride_, single_batch_length), size_, 1, inc_, 0);
         }
 
         VectorView<T> operator()(Slice slice) const {
@@ -1664,7 +1864,7 @@ namespace batchlas {
     template <typename T>
     template <typename U>
     Vector<U> Vector<T>::astype() const {
-        Vector<U> result(size_, batch_size_, stride_, inc_);
+        Vector<U> result(size_, batch_size_, Stride{stride_}, Inc{inc_});
         auto src = data();
         auto dst = result.data();
         for (std::size_t i = 0; i < dst.size(); ++i) {
@@ -1676,7 +1876,7 @@ namespace batchlas {
     template <typename T>
     template <typename U>
     Vector<U> VectorView<T>::astype() const {
-        Vector<U> result(size_, batch_size_, stride_, inc_);
+        Vector<U> result(size_, batch_size_, Stride{stride_}, Inc{inc_});
         for (int b = 0; b < batch_size_; ++b) {
             for (int i = 0; i < size_; ++i) {
                 result(i, b) = static_cast<U>((*this)(i, b));

--- a/include/batchlas/blas/options.hh
+++ b/include/batchlas/blas/options.hh
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdlib>
 #include <concepts>
 #include <initializer_list>
+#include <stdexcept>
 #include <string>
 
 #include <batchlas/blas/enums.hh>
@@ -71,6 +73,66 @@ inline void require_args_accessible(const Queue& ctx, const char* fn,
 #define BATCHLAS_ARG_NAMES(...)                                                  \
     BATCHLAS_ARG_NAMES_PICK(__VA_ARGS__, BATCHLAS_ARG_NAMES_4, BATCHLAS_ARG_NAMES_3, \
                             BATCHLAS_ARG_NAMES_2, BATCHLAS_ARG_NAMES_1)(__VA_ARGS__)
+
+namespace detail {
+
+// Shape preconditions for the LAPACK-style entry points.
+//
+// The dense BLAS backends have always validated shapes (see the SYMM/HERK/TRMM
+// checks in src/backends/cublas.cc); the LAPACK-style calls did not, and reached
+// the vendor call exactly as written. That gap was not merely untidy, it was a
+// memory-safety hole: netlib getrf reads `n = A.rows()` and then factorises an
+// n x n block (src/backends/netlib_lapack.cc), so a 100x50 A -- a buffer of 5000
+// elements -- was factorised as 100x100 and columns 50..99 were read and written
+// past the end of the allocation. cuBLAS's batched getrf takes a single
+// dimension and is square-only by construction, while rocSOLVER's does pass both
+// rows and cols and genuinely handles rectangular input, so the three backends
+// silently disagreed about what a rectangular A even meant. Pinning the contract
+// host-side is what makes them agree.
+//
+// These throw std::invalid_argument, not std::runtime_error: everything they
+// test is determined entirely by the caller's arguments. std::runtime_error is
+// reserved for environment and backend failures.
+//
+// They are deliberately attached only to the backend-DEDUCING overloads. The
+// `template <Backend B, ...>` spellings are the library's own inner-loop calls
+// (src/extensions/ortho.cc, inv.cc, syevx_*.cc), which are already shape-correct
+// by construction and must not pay a host-side branch per iteration.
+template <typename MV>
+inline void require_square(const char* fn, const char* name, const MV& A) {
+    if (A.rows() != A.cols())
+        throw std::invalid_argument(std::string(fn) + ": " + name +
+            " must be square, got " + std::to_string(A.rows()) + "x" + std::to_string(A.cols()));
+}
+
+template <typename MA, typename MB>
+inline void require_same_rows(const char* fn, const char* an, const MA& A,
+                              const char* bn, const MB& B) {
+    if (A.rows() != B.rows())
+        throw std::invalid_argument(std::string(fn) + ": " + an + ".rows() (" +
+            std::to_string(A.rows()) + ") must equal " + bn + ".rows() (" +
+            std::to_string(B.rows()) + ")");
+}
+
+template <typename MA, typename MB>
+inline void require_same_batch(const char* fn, const char* an, const MA& A,
+                               const char* bn, const MB& B) {
+    if (A.batch_size() != B.batch_size())
+        throw std::invalid_argument(std::string(fn) + ": " + an + " and " + bn +
+            " must have the same batch size (" + std::to_string(A.batch_size()) + " vs " +
+            std::to_string(B.batch_size()) + ")");
+}
+
+// `>=`, not `==`: an oversized output buffer is a legitimate thing to pass (a
+// caller slicing one big pivot/tau arena across several calls), and rejecting it
+// would break working code for no safety gain.
+inline void require_span_at_least(const char* fn, const char* name, size_t have, size_t need) {
+    if (have < need)
+        throw std::invalid_argument(std::string(fn) + ": " + name + " holds " +
+            std::to_string(have) + " elements, needs at least " + std::to_string(need));
+}
+
+}  // namespace detail
 
 // ---- dense BLAS ------------------------------------------------------------
 
@@ -384,7 +446,7 @@ template <Backend Back, detail::DenseMatrixLike MA, detail::DenseMatrixLike MB,
           typename T = detail::dense_scalar_t<MA>>
 inline Event trsm(Queue& ctx, const MA& A, const MB& B, const TrsmOptions<T>& opts) {
     using V = BATCHLAS_DENSE_VIEW(T);
-    return trsm<Back, T>(ctx, V(A), V(B), opts.side, opts.uplo, opts.trans, opts.diag, opts.alpha);
+    return trsm<Back, T>(ctx, V(A), V(B), opts.alpha, opts.side, opts.uplo, opts.trans, opts.diag);
 }
 
 template <detail::DenseMatrixLike MA, detail::DenseMatrixLike MB,
@@ -444,12 +506,14 @@ inline Event potrf(Queue& ctx, const MA& A, const PotrfOptions& opts) {
 template <detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
 inline Event potrf(Queue& ctx, const MA& A, const PotrfOptions& opts, Span<std::byte> ws) {
     BATCHLAS_CHECK_ARGS(ctx, "potrf", A, ws);
+    detail::require_square("potrf", "A", A);
     return with_backend(ctx, [&](auto Back) { return potrf<Back.value>(ctx, A, opts, ws); });
 }
 
 template <detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
 inline Event potrf(Queue& ctx, const MA& A, const PotrfOptions& opts = {}) {
     BATCHLAS_CHECK_ARGS(ctx, "potrf", A);
+    detail::require_square("potrf", "A", A);
     return with_backend(ctx, [&](auto Back) { return potrf<Back.value>(ctx, A, opts); });
 }
 
@@ -495,6 +559,9 @@ inline Event getrf(Queue& ctx, const MA& A, Span<int64_t> pivots) {
 template <detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
 inline Event getrf(Queue& ctx, const MA& A, Span<int64_t> pivots) {
     BATCHLAS_CHECK_ARGS(ctx, "getrf", A, pivots);
+    detail::require_square("getrf", "A", A);
+    detail::require_span_at_least("getrf", "pivots", pivots.size(),
+                                  static_cast<size_t>(A.rows()) * A.batch_size());
     return with_backend(ctx, [&](auto Back) { return getrf<Back.value>(ctx, A, pivots); });
 }
 
@@ -520,6 +587,11 @@ template <detail::DenseMatrixLike MA, detail::DenseMatrixLike MB,
 inline Event getrs(Queue& ctx, const MA& A, const MB& B_, Span<int64_t> pivots,
                    const GetrsOptions& opts, Span<std::byte> ws) {
     BATCHLAS_CHECK_ARGS(ctx, "getrs", A, B_, pivots, ws);
+    detail::require_square("getrs", "A", A);
+    detail::require_same_rows("getrs", "A", A, "B", B_);
+    detail::require_same_batch("getrs", "A", A, "B", B_);
+    detail::require_span_at_least("getrs", "pivots", pivots.size(),
+                                  static_cast<size_t>(A.rows()) * A.batch_size());
     return with_backend(
         ctx, [&](auto Back) { return getrs<Back.value>(ctx, A, B_, pivots, opts, ws); });
 }
@@ -529,6 +601,11 @@ template <detail::DenseMatrixLike MA, detail::DenseMatrixLike MB,
 inline Event getrs(Queue& ctx, const MA& A, const MB& B_, Span<int64_t> pivots,
                    const GetrsOptions& opts = {}) {
     BATCHLAS_CHECK_ARGS(ctx, "getrs", A, B_, pivots);
+    detail::require_square("getrs", "A", A);
+    detail::require_same_rows("getrs", "A", A, "B", B_);
+    detail::require_same_batch("getrs", "A", A, "B", B_);
+    detail::require_span_at_least("getrs", "pivots", pivots.size(),
+                                  static_cast<size_t>(A.rows()) * A.batch_size());
     return with_backend(ctx,
                         [&](auto Back) { return getrs<Back.value>(ctx, A, B_, pivots, opts); });
 }
@@ -545,6 +622,12 @@ template <detail::DenseMatrixLike MA, detail::DenseMatrixLike MB,
           typename T = detail::dense_scalar_t<MA>>
 inline Event getri(Queue& ctx, const MA& A, const MB& Ainv, Span<int64_t> pivots) {
     BATCHLAS_CHECK_ARGS(ctx, "getri", A, Ainv, pivots);
+    detail::require_square("getri", "A", A);
+    detail::require_square("getri", "Ainv", Ainv);
+    detail::require_same_rows("getri", "A", A, "Ainv", Ainv);
+    detail::require_same_batch("getri", "A", A, "Ainv", Ainv);
+    detail::require_span_at_least("getri", "pivots", pivots.size(),
+                                  static_cast<size_t>(A.rows()) * A.batch_size());
     return with_backend(ctx, [&](auto Back) { return getri<Back.value>(ctx, A, Ainv, pivots); });
 }
 
@@ -558,6 +641,12 @@ inline Event geqrf(Queue& ctx, const MA& A, Span<T> tau) {
 template <detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
 inline Event geqrf(Queue& ctx, const MA& A, Span<T> tau) {
     BATCHLAS_CHECK_ARGS(ctx, "geqrf", A, tau);
+    // No squareness check: rectangular A is the entire point of geqrf, and the
+    // library's own panel factorisations (src/extensions/sytrd_sy2sb.cc,
+    // band_reduction.cc) pass tall panels. What is fixed is the tau stride --
+    // every backend indexes `tau.data() + i * min(m, n)`.
+    detail::require_span_at_least("geqrf", "tau", tau.size(),
+                                  static_cast<size_t>(std::min(A.rows(), A.cols())) * A.batch_size());
     return with_backend(ctx, [&](auto Back) { return geqrf<Back.value>(ctx, A, tau); });
 }
 
@@ -571,6 +660,8 @@ inline Event orgqr(Queue& ctx, const MA& A, Span<T> tau) {
 template <detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
 inline Event orgqr(Queue& ctx, const MA& A, Span<T> tau) {
     BATCHLAS_CHECK_ARGS(ctx, "orgqr", A, tau);
+    detail::require_span_at_least("orgqr", "tau", tau.size(),
+                                  static_cast<size_t>(std::min(A.rows(), A.cols())) * A.batch_size());
     return with_backend(ctx, [&](auto Back) { return orgqr<Back.value>(ctx, A, tau); });
 }
 
@@ -593,6 +684,9 @@ template <detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
 inline Event syev(Queue& ctx, const MA& A, Span<typename base_type<T>::type> W,
                   const SyevOptions& opts, Span<std::byte> ws) {
     BATCHLAS_CHECK_ARGS(ctx, "syev", A, W, ws);
+    detail::require_square("syev", "A", A);
+    detail::require_span_at_least("syev", "W", W.size(),
+                                  static_cast<size_t>(A.rows()) * A.batch_size());
     return with_backend(ctx, [&](auto Back) { return syev<Back.value>(ctx, A, W, opts, ws); });
 }
 
@@ -600,6 +694,9 @@ template <detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
 inline Event syev(Queue& ctx, const MA& A, Span<typename base_type<T>::type> W,
                   const SyevOptions& opts = {}) {
     BATCHLAS_CHECK_ARGS(ctx, "syev", A, W);
+    detail::require_square("syev", "A", A);
+    detail::require_span_at_least("syev", "W", W.size(),
+                                  static_cast<size_t>(A.rows()) * A.batch_size());
     return with_backend(ctx, [&](auto Back) { return syev<Back.value>(ctx, A, W, opts); });
 }
 

--- a/include/batchlas/blas/options.hh
+++ b/include/batchlas/blas/options.hh
@@ -107,10 +107,23 @@ namespace detail {
 // test is determined entirely by the caller's arguments. std::runtime_error is
 // reserved for environment and backend failures.
 //
-// They are deliberately attached only to the backend-DEDUCING overloads. The
-// `template <Backend B, ...>` spellings are the library's own inner-loop calls
-// (src/extensions/ortho.cc, inv.cc, syevx_*.cc), which are already shape-correct
-// by construction and must not pay a host-side branch per iteration.
+// They are attached to the convenience overloads in THIS header -- both the
+// backend-deducing ones and the `template <Backend B, ...>` arena/option ones.
+// Attaching them to the deducing overloads alone was not enough, and the reason
+// is worth keeping: BATCHLAS_DISPATCH_ON_QUEUE generates a variadic
+// `NAME(Queue&, Args&&...)`, and for a call like `getrf(ctx, A.view(), pivots)`
+// -- concrete argument types, no option struct, and `A.view()` a prvalue --
+// `Args&&` binds the prvalue better than `const MA&` does, so the variadic WINS
+// overload resolution and forwards straight to the `<Backend>` overload,
+// stepping over every check on the deducing one. It was measured: a 8x4 A handed
+// to `getrf(ctx, A.view(), pivots)` sailed through the squareness check. potrf
+// hid the problem because its option struct is passed as a braced-init-list,
+// which a parameter pack cannot deduce, so there the variadic drops out.
+//
+// What is still deliberately unchecked is the true inner loop: the positional
+// primaries declared in blas/functions/*.hh that take an explicit workspace, and
+// which src/extensions/ortho.cc, inv.cc and syevx_*.cc call per iteration. Those
+// are shape-correct by construction and must not pay a host-side branch.
 template <typename MV>
 inline void require_square(const char* fn, const char* name, const MV& A) {
     if (A.rows() != A.cols())
@@ -143,6 +156,19 @@ inline void require_span_at_least(const char* fn, const char* name, size_t have,
     if (have < need)
         throw std::invalid_argument(std::string(fn) + ": " + name + " holds " +
             std::to_string(have) + " elements, needs at least " + std::to_string(need));
+}
+
+// The per-item `info` output of the factorisations (potrf/getrf/getri). An
+// EMPTY span is the API's spelling for "I do not want status", so it has no
+// length to be wrong; only a non-empty one is measured.
+//
+// The check matters more here than for pivots, because the failure is silent
+// rather than loud: a backend handed a too-short info span falls back to its
+// own scratch allocation and writes nothing to the caller's buffer, so the
+// caller reads whatever was already there -- most often zeros, i.e. "every item
+// factorised" -- on precisely the batch it was trying to diagnose.
+inline void require_info_span(const char* fn, size_t have, size_t batch_size) {
+    if (have != 0) require_span_at_least(fn, "info", have, batch_size);
 }
 
 }  // namespace detail
@@ -492,6 +518,13 @@ inline Event trsm(Queue& ctx, const MA& A, const MB& B, const TrsmOptions<T>& op
 
 struct PotrfOptions {
     Uplo uplo = Uplo::Lower;
+    // Per-item LAPACK status, one int32 per batch item: 0 = factorised, >0 =
+    // the leading minor at which the item stopped being positive definite.
+    // Leave it empty (the default) and nothing is reported, which is what every
+    // caller got before issue #73 -- a batch where item 37 was indefinite
+    // returned an ordinary Event and the caller consumed the garbage. The span
+    // must be device-accessible (USM); the vendor writes it in place.
+    Span<int32_t> info = {};
 };
 
 struct GetrsOptions {
@@ -506,27 +539,31 @@ struct SyevOptions {
 template <Backend B, detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
 inline Event potrf(Queue& ctx, const MA& A, const PotrfOptions& opts, Span<std::byte> ws) {
     using V = BATCHLAS_DENSE_VIEW(T);
-    return potrf<B, T>(ctx, V(A), opts.uplo, ws);
+    return potrf<B, T>(ctx, V(A), opts.uplo, ws, opts.info);
 }
 
 template <Backend B, detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
 inline Event potrf(Queue& ctx, const MA& A, const PotrfOptions& opts) {
     using V = BATCHLAS_DENSE_VIEW(T);
+    detail::require_square("potrf", "A", A);
+    detail::require_info_span("potrf", opts.info.size(), static_cast<size_t>(A.batch_size()));
     auto lease = ctx.workspace(potrf_buffer_size<B, T>(ctx, V(A), opts.uplo));
-    return potrf<B, T>(ctx, V(A), opts.uplo, lease.span());
+    return potrf<B, T>(ctx, V(A), opts.uplo, lease.span(), opts.info);
 }
 
 template <detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
 inline Event potrf(Queue& ctx, const MA& A, const PotrfOptions& opts, Span<std::byte> ws) {
-    BATCHLAS_CHECK_ARGS(ctx, "potrf", A, ws);
+    BATCHLAS_CHECK_ARGS(ctx, "potrf", A, ws, opts.info);
     detail::require_square("potrf", "A", A);
+    detail::require_info_span("potrf", opts.info.size(), static_cast<size_t>(A.batch_size()));
     return with_backend(ctx, [&](auto Back) { return potrf<Back.value>(ctx, A, opts, ws); });
 }
 
 template <detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
 inline Event potrf(Queue& ctx, const MA& A, const PotrfOptions& opts = {}) {
-    BATCHLAS_CHECK_ARGS(ctx, "potrf", A);
+    BATCHLAS_CHECK_ARGS(ctx, "potrf", A, opts.info);
     detail::require_square("potrf", "A", A);
+    detail::require_info_span("potrf", opts.info.size(), static_cast<size_t>(A.batch_size()));
     return with_backend(ctx, [&](auto Back) { return potrf<Back.value>(ctx, A, opts); });
 }
 
@@ -562,20 +599,35 @@ Event potrf(Queue&, const MA&, detail::EmptyBracesAreAmbiguous, Span<std::byte>)
 // They deliberately take no workspace parameter -- an overload with one would be
 // indistinguishable from the positional call, and the two would be ambiguous.
 // To manage the workspace yourself, use the positional spelling.
+//
+// getrf and getri do take one more thing: a trailing `info`, the per-item LAPACK
+// status (one int32 per batch item, 0 = success). It is a plain trailing
+// parameter rather than an option struct because these two have no struct to put
+// it in, and a *Options type invented for one field would be a second way to
+// spell the same call. Left empty -- the default -- nothing is reported and the
+// behaviour is exactly what it was before issue #73. Passing it costs nothing:
+// the backends already allocate that array for the vendor call, so a non-empty
+// span replaces the scratch rather than adding to it, and the workspace size is
+// unchanged either way.
 template <Backend B, detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
-inline Event getrf(Queue& ctx, const MA& A, Span<int64_t> pivots) {
+inline Event getrf(Queue& ctx, const MA& A, Span<int64_t> pivots, Span<int32_t> info = {}) {
     using V = BATCHLAS_DENSE_VIEW(T);
-    auto lease = ctx.workspace(getrf_buffer_size<B, T>(ctx, V(A)));
-    return getrf<B, T>(ctx, V(A), pivots, lease.span());
-}
-
-template <detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
-inline Event getrf(Queue& ctx, const MA& A, Span<int64_t> pivots) {
-    BATCHLAS_CHECK_ARGS(ctx, "getrf", A, pivots);
     detail::require_square("getrf", "A", A);
     detail::require_span_at_least("getrf", "pivots", pivots.size(),
                                   static_cast<size_t>(A.rows()) * A.batch_size());
-    return with_backend(ctx, [&](auto Back) { return getrf<Back.value>(ctx, A, pivots); });
+    detail::require_info_span("getrf", info.size(), static_cast<size_t>(A.batch_size()));
+    auto lease = ctx.workspace(getrf_buffer_size<B, T>(ctx, V(A)));
+    return getrf<B, T>(ctx, V(A), pivots, lease.span(), info);
+}
+
+template <detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
+inline Event getrf(Queue& ctx, const MA& A, Span<int64_t> pivots, Span<int32_t> info = {}) {
+    BATCHLAS_CHECK_ARGS(ctx, "getrf", A, pivots, info);
+    detail::require_square("getrf", "A", A);
+    detail::require_span_at_least("getrf", "pivots", pivots.size(),
+                                  static_cast<size_t>(A.rows()) * A.batch_size());
+    detail::require_info_span("getrf", info.size(), static_cast<size_t>(A.batch_size()));
+    return with_backend(ctx, [&](auto Back) { return getrf<Back.value>(ctx, A, pivots, info); });
 }
 
 template <Backend B, detail::DenseMatrixLike MA, detail::DenseMatrixLike MB,
@@ -591,6 +643,11 @@ template <Backend B, detail::DenseMatrixLike MA, detail::DenseMatrixLike MB,
 inline Event getrs(Queue& ctx, const MA& A, const MB& B_, Span<int64_t> pivots,
                    const GetrsOptions& opts) {
     using V = BATCHLAS_DENSE_VIEW(T);
+    detail::require_square("getrs", "A", A);
+    detail::require_same_rows("getrs", "A", A, "B", B_);
+    detail::require_same_batch("getrs", "A", A, "B", B_);
+    detail::require_span_at_least("getrs", "pivots", pivots.size(),
+                                  static_cast<size_t>(A.rows()) * A.batch_size());
     auto lease = ctx.workspace(getrs_buffer_size<B, T>(ctx, V(A), V(B_), opts.trans));
     return getrs<B, T>(ctx, V(A), V(B_), opts.trans, pivots, lease.span());
 }
@@ -625,28 +682,41 @@ inline Event getrs(Queue& ctx, const MA& A, const MB& B_, Span<int64_t> pivots,
 
 template <Backend B, detail::DenseMatrixLike MA, detail::DenseMatrixLike MB,
           typename T = detail::dense_scalar_t<MA>>
-inline Event getri(Queue& ctx, const MA& A, const MB& Ainv, Span<int64_t> pivots) {
+inline Event getri(Queue& ctx, const MA& A, const MB& Ainv, Span<int64_t> pivots,
+                   Span<int32_t> info = {}) {
     using V = BATCHLAS_DENSE_VIEW(T);
-    auto lease = ctx.workspace(getri_buffer_size<B, T>(ctx, V(A)));
-    return getri<B, T>(ctx, V(A), V(Ainv), pivots, lease.span());
-}
-
-template <detail::DenseMatrixLike MA, detail::DenseMatrixLike MB,
-          typename T = detail::dense_scalar_t<MA>>
-inline Event getri(Queue& ctx, const MA& A, const MB& Ainv, Span<int64_t> pivots) {
-    BATCHLAS_CHECK_ARGS(ctx, "getri", A, Ainv, pivots);
     detail::require_square("getri", "A", A);
     detail::require_square("getri", "Ainv", Ainv);
     detail::require_same_rows("getri", "A", A, "Ainv", Ainv);
     detail::require_same_batch("getri", "A", A, "Ainv", Ainv);
     detail::require_span_at_least("getri", "pivots", pivots.size(),
                                   static_cast<size_t>(A.rows()) * A.batch_size());
-    return with_backend(ctx, [&](auto Back) { return getri<Back.value>(ctx, A, Ainv, pivots); });
+    detail::require_info_span("getri", info.size(), static_cast<size_t>(A.batch_size()));
+    auto lease = ctx.workspace(getri_buffer_size<B, T>(ctx, V(A)));
+    return getri<B, T>(ctx, V(A), V(Ainv), pivots, lease.span(), info);
+}
+
+template <detail::DenseMatrixLike MA, detail::DenseMatrixLike MB,
+          typename T = detail::dense_scalar_t<MA>>
+inline Event getri(Queue& ctx, const MA& A, const MB& Ainv, Span<int64_t> pivots,
+                   Span<int32_t> info = {}) {
+    BATCHLAS_CHECK_ARGS(ctx, "getri", A, Ainv, pivots, info);
+    detail::require_square("getri", "A", A);
+    detail::require_square("getri", "Ainv", Ainv);
+    detail::require_same_rows("getri", "A", A, "Ainv", Ainv);
+    detail::require_same_batch("getri", "A", A, "Ainv", Ainv);
+    detail::require_span_at_least("getri", "pivots", pivots.size(),
+                                  static_cast<size_t>(A.rows()) * A.batch_size());
+    detail::require_info_span("getri", info.size(), static_cast<size_t>(A.batch_size()));
+    return with_backend(ctx,
+                        [&](auto Back) { return getri<Back.value>(ctx, A, Ainv, pivots, info); });
 }
 
 template <Backend B, detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
 inline Event geqrf(Queue& ctx, const MA& A, Span<T> tau) {
     using V = BATCHLAS_DENSE_VIEW(T);
+    detail::require_span_at_least("geqrf", "tau", tau.size(),
+                                  static_cast<size_t>(std::min(A.rows(), A.cols())) * A.batch_size());
     auto lease = ctx.workspace(geqrf_buffer_size<B, T>(ctx, V(A), tau));
     return geqrf<B, T>(ctx, V(A), tau, lease.span());
 }
@@ -666,6 +736,8 @@ inline Event geqrf(Queue& ctx, const MA& A, Span<T> tau) {
 template <Backend B, detail::DenseMatrixLike MA, typename T = detail::dense_scalar_t<MA>>
 inline Event orgqr(Queue& ctx, const MA& A, Span<T> tau) {
     using V = BATCHLAS_DENSE_VIEW(T);
+    detail::require_span_at_least("orgqr", "tau", tau.size(),
+                                  static_cast<size_t>(std::min(A.rows(), A.cols())) * A.batch_size());
     auto lease = ctx.workspace(orgqr_buffer_size<B, T>(ctx, V(A), tau));
     return orgqr<B, T>(ctx, V(A), tau, lease.span());
 }

--- a/include/batchlas/blas/options.hh
+++ b/include/batchlas/blas/options.hh
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <concepts>
 #include <initializer_list>
+#include <optional>
 #include <stdexcept>
 #include <string>
 
@@ -78,9 +79,12 @@ inline void require_args_accessible(const Queue& ctx, const char* fn,
 #define BATCHLAS_ARG_NAMES_2(a, b) #a, #b
 #define BATCHLAS_ARG_NAMES_3(a, b, c) #a, #b, #c
 #define BATCHLAS_ARG_NAMES_4(a, b, c, d) #a, #b, #c, #d
-#define BATCHLAS_ARG_NAMES_PICK(_1, _2, _3, _4, NAME, ...) NAME
+#define BATCHLAS_ARG_NAMES_5(a, b, c, d, e) #a, #b, #c, #d, #e
+#define BATCHLAS_ARG_NAMES_6(a, b, c, d, e, f) #a, #b, #c, #d, #e, #f
+#define BATCHLAS_ARG_NAMES_PICK(_1, _2, _3, _4, _5, _6, NAME, ...) NAME
 #define BATCHLAS_ARG_NAMES(...)                                                  \
-    BATCHLAS_ARG_NAMES_PICK(__VA_ARGS__, BATCHLAS_ARG_NAMES_4, BATCHLAS_ARG_NAMES_3, \
+    BATCHLAS_ARG_NAMES_PICK(__VA_ARGS__, BATCHLAS_ARG_NAMES_6, BATCHLAS_ARG_NAMES_5, \
+                            BATCHLAS_ARG_NAMES_4, BATCHLAS_ARG_NAMES_3,          \
                             BATCHLAS_ARG_NAMES_2, BATCHLAS_ARG_NAMES_1)(__VA_ARGS__)
 
 namespace detail {
@@ -707,6 +711,149 @@ inline Event syev(Queue& ctx, const MA& A, Span<typename base_type<T>::type> W,
     detail::require_span_at_least("syev", "W", W.size(),
                                   static_cast<size_t>(A.rows()) * A.batch_size());
     return with_backend(ctx, [&](auto Back) { return syev<Back.value>(ctx, A, W, opts); });
+}
+
+// ---- ormqr and gesvd -------------------------------------------------------
+//
+// These two were the last dense entry points without an option-struct spelling,
+// and the reason given was that their positional forms do not end in the
+// workspace -- ormqr's `workspace` is followed by a defaulted block-size hint --
+// so the arena form could not simply drop the last argument.
+//
+// That reason does not apply: an option overload is a NEW overload and is under
+// no obligation to mirror the positional parameter order. getrs has been doing
+// exactly this since the option layer landed (its positional form takes
+// `(A, B, transA, pivots, ws)` while its option form takes
+// `(A, B, pivots, opts, ws)`), so nothing here moves an existing parameter and
+// no existing call site changes. The hint that blocked the "just drop the last
+// argument" reading becomes a field of OrmqrOptions instead.
+
+struct OrmqrOptions {
+    Side side = Side::Left;
+    Transpose trans = Transpose::NoTrans;
+    // 0 means "let the tuning table pick the WY panel width"; see the block-size
+    // selection in src/extensions/ormqr_blocked.cc. It is an option field rather
+    // than a trailing default argument because the arena spelling has no
+    // trailing position left to put it in.
+    int32_t block_size_hint = 0;
+};
+
+template <Backend B, detail::DenseMatrixLike MA, detail::DenseMatrixLike MC,
+          typename T = detail::dense_scalar_t<MA>>
+inline Event ormqr(Queue& ctx, const MA& A, const MC& C, Span<T> tau,
+                   const OrmqrOptions& opts, Span<std::byte> ws) {
+    using V = BATCHLAS_DENSE_VIEW(T);
+    return ormqr<B, T>(ctx, V(A), V(C), opts.side, opts.trans, tau, ws, opts.block_size_hint);
+}
+
+template <Backend B, detail::DenseMatrixLike MA, detail::DenseMatrixLike MC,
+          typename T = detail::dense_scalar_t<MA>>
+inline Event ormqr(Queue& ctx, const MA& A, const MC& C, Span<T> tau,
+                   const OrmqrOptions& opts) {
+    using V = BATCHLAS_DENSE_VIEW(T);
+    // The sizing query must be given the same options the call gets: the hint
+    // selects the panel width, and the panel width is what the workspace is
+    // sized for, so sizing with the default hint and running with another would
+    // under-size the buffer.
+    auto lease = ctx.workspace(ormqr_buffer_size<B, T>(ctx, V(A), V(C), opts.side, opts.trans,
+                                                       tau, opts.block_size_hint));
+    return ormqr<B, T>(ctx, V(A), V(C), opts.side, opts.trans, tau, lease.span(),
+                       opts.block_size_hint);
+}
+
+template <detail::DenseMatrixLike MA, detail::DenseMatrixLike MC,
+          typename T = detail::dense_scalar_t<MA>>
+inline Event ormqr(Queue& ctx, const MA& A, const MC& C, Span<T> tau,
+                   const OrmqrOptions& opts, Span<std::byte> ws) {
+    BATCHLAS_CHECK_ARGS(ctx, "ormqr", A, C, tau, ws);
+    detail::require_same_batch("ormqr", "A", A, "C", C);
+    detail::require_span_at_least("ormqr", "tau", tau.size(),
+                                  static_cast<size_t>(std::min(A.rows(), A.cols())) * A.batch_size());
+    return with_backend(ctx, [&](auto Back) { return ormqr<Back.value>(ctx, A, C, tau, opts, ws); });
+}
+
+template <detail::DenseMatrixLike MA, detail::DenseMatrixLike MC,
+          typename T = detail::dense_scalar_t<MA>>
+inline Event ormqr(Queue& ctx, const MA& A, const MC& C, Span<T> tau,
+                   const OrmqrOptions& opts = {}) {
+    BATCHLAS_CHECK_ARGS(ctx, "ormqr", A, C, tau);
+    // Both mirror validate_ormqr_dims (src/extensions/ormqr_blocked.cc): the
+    // reflector count is min(A.rows(), A.cols()) per problem and every path
+    // indexes tau at that stride, so a short tau is read out of bounds.
+    detail::require_same_batch("ormqr", "A", A, "C", C);
+    detail::require_span_at_least("ormqr", "tau", tau.size(),
+                                  static_cast<size_t>(std::min(A.rows(), A.cols())) * A.batch_size());
+    return with_backend(ctx, [&](auto Back) { return ormqr<Back.value>(ctx, A, C, tau, opts); });
+}
+
+struct GesvdOptions {
+    SvdVectors jobu = SvdVectors::All;
+    SvdVectors jobvh = SvdVectors::All;
+    // Engaged selects the Hermitian entry point (blas/functions/gesvd.hh), which
+    // is a different overload rather than a different argument value -- hence
+    // std::optional and not a plain Uplo with a "not Hermitian" sentinel.
+    std::optional<Uplo> hermitian_uplo = std::nullopt;
+};
+
+template <Backend B, detail::DenseMatrixLike MA, detail::DenseMatrixLike MU,
+          detail::DenseMatrixLike MV, typename T = detail::dense_scalar_t<MA>>
+inline Event gesvd(Queue& ctx, const MA& A, Span<typename base_type<T>::type> singular_values,
+                   const MU& U, const MV& Vh, const GesvdOptions& opts, Span<std::byte> ws) {
+    using V = BATCHLAS_DENSE_VIEW(T);
+    return opts.hermitian_uplo
+               ? gesvd<B, T>(ctx, V(A), singular_values, V(U), V(Vh), opts.jobu, opts.jobvh,
+                             *opts.hermitian_uplo, ws)
+               : gesvd<B, T>(ctx, V(A), singular_values, V(U), V(Vh), opts.jobu, opts.jobvh, ws);
+}
+
+template <Backend B, detail::DenseMatrixLike MA, detail::DenseMatrixLike MU,
+          detail::DenseMatrixLike MV, typename T = detail::dense_scalar_t<MA>>
+inline Event gesvd(Queue& ctx, const MA& A, Span<typename base_type<T>::type> singular_values,
+                   const MU& U, const MV& Vh, const GesvdOptions& opts) {
+    using V = BATCHLAS_DENSE_VIEW(T);
+    // The Hermitian and general branches choose providers independently and can
+    // therefore need different amounts of scratch, so the size query has to take
+    // the same branch as the call below it.
+    const size_t bytes =
+        opts.hermitian_uplo
+            ? gesvd_buffer_size<B, T>(ctx, V(A), singular_values, V(U), V(Vh), opts.jobu,
+                                      opts.jobvh, *opts.hermitian_uplo)
+            : gesvd_buffer_size<B, T>(ctx, V(A), singular_values, V(U), V(Vh), opts.jobu,
+                                      opts.jobvh);
+    auto lease = ctx.workspace(bytes);
+    return opts.hermitian_uplo
+               ? gesvd<B, T>(ctx, V(A), singular_values, V(U), V(Vh), opts.jobu, opts.jobvh,
+                             *opts.hermitian_uplo, lease.span())
+               : gesvd<B, T>(ctx, V(A), singular_values, V(U), V(Vh), opts.jobu, opts.jobvh,
+                             lease.span());
+}
+
+template <detail::DenseMatrixLike MA, detail::DenseMatrixLike MU, detail::DenseMatrixLike MV,
+          typename T = detail::dense_scalar_t<MA>>
+inline Event gesvd(Queue& ctx, const MA& A, Span<typename base_type<T>::type> singular_values,
+                   const MU& U, const MV& Vh, const GesvdOptions& opts, Span<std::byte> ws) {
+    BATCHLAS_CHECK_ARGS(ctx, "gesvd", A, singular_values, U, Vh, ws);
+    if (opts.hermitian_uplo) detail::require_square("gesvd", "A", A);
+    detail::require_span_at_least("gesvd", "singular_values", singular_values.size(),
+                                  static_cast<size_t>(std::min(A.rows(), A.cols())) * A.batch_size());
+    return with_backend(
+        ctx, [&](auto Back) { return gesvd<Back.value>(ctx, A, singular_values, U, Vh, opts, ws); });
+}
+
+template <detail::DenseMatrixLike MA, detail::DenseMatrixLike MU, detail::DenseMatrixLike MV,
+          typename T = detail::dense_scalar_t<MA>>
+inline Event gesvd(Queue& ctx, const MA& A, Span<typename base_type<T>::type> singular_values,
+                   const MU& U, const MV& Vh, const GesvdOptions& opts = {}) {
+    BATCHLAS_CHECK_ARGS(ctx, "gesvd", A, singular_values, U, Vh);
+    // Only A is shape-checked. U and Vh are deliberately left alone: a
+    // default-constructed view is how this API spells "I asked for no vectors on
+    // this side", so any check relating their extents to A's would reject the
+    // documented SvdVectors::None call.
+    if (opts.hermitian_uplo) detail::require_square("gesvd", "A", A);
+    detail::require_span_at_least("gesvd", "singular_values", singular_values.size(),
+                                  static_cast<size_t>(std::min(A.rows(), A.cols())) * A.batch_size());
+    return with_backend(
+        ctx, [&](auto Back) { return gesvd<Back.value>(ctx, A, singular_values, U, Vh, opts); });
 }
 
 #undef BATCHLAS_DENSE_VIEW

--- a/include/batchlas/blas/options.hh
+++ b/include/batchlas/blas/options.hh
@@ -19,6 +19,15 @@
 //     gemm(ctx, A, B, C, {.alpha = 2.0f, .transA = Transpose::Trans});
 //     syev(ctx, A, W, {.jobz = JobType::EigenVectors});
 //
+// Structs here are named *Options and belong to this convenience layer: the
+// backend comes from the Queue, T is deduced from the matrices, the struct
+// carries every non-matrix argument, and the workspace may be omitted. The
+// *Params structs in blas/extensions.hh and blas/functions/iluk.hh are a
+// different thing -- ordinary arguments to entry points that have no
+// convenience layer. The suffix does not tell you where the struct sits in the
+// argument list; see docs/cpp-api.md, "*Options and *Params are two different
+// things", for the table.
+//
 // rather than
 //
 //     gemm<Backend::CUDA, float>(ctx, A, B, C, 2.0f, 0.0f, Transpose::Trans,

--- a/include/batchlas/util/bench_structured.hh
+++ b/include/batchlas/util/bench_structured.hh
@@ -98,7 +98,9 @@ struct ManagedInputs {
 
     template <typename T>
     ManagedInputs& pristine(std::shared_ptr<batchlas::Vector<T>> v) {
-        auto v0 = std::make_shared<batchlas::Vector<T>>(v->size(), v->batch_size(), v->stride(), v->inc());
+        auto v0 = std::make_shared<batchlas::Vector<T>>(v->size(), v->batch_size(),
+                                                        batchlas::Stride{v->stride()},
+                                                        batchlas::Inc{v->inc()});
         auto queue = q;
 
         init_once.emplace_back([queue, v, v0]() mutable {

--- a/python/batchlas/bindings/ops_blas.cc
+++ b/python/batchlas/bindings/ops_blas.cc
@@ -283,7 +283,7 @@ DenseMatrix dense_trsm_impl(const DenseMatrix& a_wrapper,
     Queue& queue = acquire_queue(device_name, backend);
     visit_backend(queue, [&](auto backend_tag) {
         constexpr Backend B = decltype(backend_tag)::value;
-        batchlas::trsm<B, T>(queue, a.view(), out.view(), side, uplo, trans_a, diag, alpha);
+        batchlas::trsm<B, T>(queue, a.view(), out.view(), alpha, side, uplo, trans_a, diag);
     });
     queue.wait();
     return wrap_dense(std::move(out));

--- a/python/batchlas/bindings/ops_blas.cc
+++ b/python/batchlas/bindings/ops_blas.cc
@@ -362,13 +362,10 @@ void init_blas_ops(py::module_& module) {
             Queue& queue = acquire_queue(device_name, backend);
             visit_backend(queue, [&](auto backend_tag) {
                 constexpr Backend B = decltype(backend_tag)::value;
-                if (typed_a.is_heterogeneous() || typed_b.is_heterogeneous()) {
-                    batchlas::gemm_heterogeneous<B, scalar_type>(queue, typed_a.view(), typed_b.view(), c.view(),
-                                                                 typed_alpha, typed_beta, trans_a, trans_b, precision);
-                } else {
-                    batchlas::gemm<B, scalar_type>(queue, typed_a.view(), typed_b.view(), c.view(), typed_alpha,
-                                                   typed_beta, trans_a, trans_b, precision);
-                }
+                // One call for both shapes: gemm dispatches on
+                // gemm_has_heterogeneous_batch internally, on every backend.
+                batchlas::gemm<B, scalar_type>(queue, typed_a.view(), typed_b.view(), c.view(), typed_alpha,
+                                               typed_beta, trans_a, trans_b, precision);
             });
             queue.wait();
             return wrap_dense(std::move(c));
@@ -402,7 +399,7 @@ void init_blas_ops(py::module_& module) {
             Queue& queue = acquire_queue(device_name, backend);
             visit_backend(queue, [&](auto backend_tag) {
                 constexpr Backend B = decltype(backend_tag)::value;
-                batchlas::gemm_heterogeneous<B, scalar_type>(queue, typed_a.view(), typed_b.view(), c.view(),
+                batchlas::gemm<B, scalar_type>(queue, typed_a.view(), typed_b.view(), c.view(),
                                                              typed_alpha, typed_beta, trans_a, trans_b, precision);
             });
             queue.wait();

--- a/python/batchlas/bindings/ops_spectral.cc
+++ b/python/batchlas/bindings/ops_spectral.cc
@@ -264,7 +264,7 @@ py::object stedc_common(const DenseVector& d_wrapper,
     Queue& queue = acquire_queue(device_name, backend);
     const std::size_t workspace_size = visit_backend(queue, [&](auto backend_tag) {
         constexpr Backend B = decltype(backend_tag)::value;
-        return batchlas::stedc_workspace_size<B, T>(queue, d.size(), d.batch_size(), jobz, params);
+        return batchlas::stedc_buffer_size<B, T>(queue, d.size(), d.batch_size(), jobz, params);
     });
     UnifiedVector<std::byte> workspace(workspace_size);
     visit_backend(queue, [&](auto backend_tag) {

--- a/python/batchlas/bindings/support.hh
+++ b/python/batchlas/bindings/support.hh
@@ -1039,7 +1039,10 @@ template <typename T>
 py::object sparse_matrix_to_python_t(const SparseMatrixT<T>& matrix) {
     py::module_ scipy_sparse = py::module_::import("scipy.sparse");
     auto make_one = [&](int batch) -> py::object {
-        const int nnz = matrix.row_offsets()[static_cast<std::size_t>(batch * matrix.offset_stride() + matrix.rows())];
+        // Not matrix.nnz(): that is the per-item capacity, sized by the batch maximum,
+        // and this batch is heterogeneous by construction. nnz(batch) is the same row
+        // offset read this line used to spell by hand.
+        const int nnz = matrix.nnz(batch);
         py::array_t<T> data({nnz});
         py::array_t<int> indices({nnz});
         py::array_t<int> indptr({matrix.rows() + 1});

--- a/src/backends/cublas.cc
+++ b/src/backends/cublas.cc
@@ -67,7 +67,7 @@ namespace batchlas {
                                          Transpose transB,
                                          ComputePrecision precision) {
         if (!gemm_batch_dimensions_compatible(A, B, C, transA, transB)) {
-            throw std::runtime_error("GEMM: incompatible per-batch matrix dimensions for heterogeneous dispatch");
+            throw std::invalid_argument("GEMM: incompatible per-batch matrix dimensions for heterogeneous dispatch");
         }
 
         bool launched = false;
@@ -117,7 +117,7 @@ namespace batchlas {
         handle.setStream(ctx);
 
         if (!gemm_batch_dimensions_compatible(A, B, C, transA, transB)) {
-            throw std::runtime_error("GEMM: incompatible matrix dimensions");
+            throw std::invalid_argument("GEMM: incompatible matrix dimensions");
         }
 
         auto [m, k] = get_effective_dims(A, transA);
@@ -191,10 +191,10 @@ namespace batchlas {
         handle.setStream(ctx);
 
         if (A.rows() != A.cols()) {
-            throw std::runtime_error("SYMM: A must be square");
+            throw std::invalid_argument("SYMM: A must be square");
         }
         if (A.batch_size() != B.batch_size() || A.batch_size() != C.batch_size()) {
-            throw std::runtime_error(
+            throw std::invalid_argument(
                 "SYMM: batch size mismatch (A=" + std::to_string(A.batch_size()) +
                 ", B=" + std::to_string(B.batch_size()) +
                 ", C=" + std::to_string(C.batch_size()) + ")");
@@ -204,7 +204,7 @@ namespace batchlas {
         const int n = C.cols();
         const int expected_a = side == Side::Left ? B.rows() : B.cols();
         if (A.rows() != expected_a || B.rows() != m || B.cols() != n) {
-            throw std::runtime_error("SYMM: incompatible matrix dimensions");
+            throw std::invalid_argument("SYMM: incompatible matrix dimensions");
         }
 
         const auto side_cublas = enum_convert<BackendLibrary::CUBLAS>(side);
@@ -293,10 +293,10 @@ namespace batchlas {
         handle.setStream(ctx);
 
         if (A.rows() != A.cols()) {
-            throw std::runtime_error("HEMM: A must be square");
+            throw std::invalid_argument("HEMM: A must be square");
         }
         if (A.batch_size() != B.batch_size() || A.batch_size() != C.batch_size()) {
-            throw std::runtime_error(
+            throw std::invalid_argument(
                 "HEMM: batch size mismatch (A=" + std::to_string(A.batch_size()) +
                 ", B=" + std::to_string(B.batch_size()) +
                 ", C=" + std::to_string(C.batch_size()) + ")");
@@ -308,7 +308,7 @@ namespace batchlas {
         // on the left and n x n on the right.
         const int k = side == Side::Left ? m : n;
         if (A.rows() != k || B.rows() != m || B.cols() != n) {
-            throw std::runtime_error("HEMM: incompatible matrix dimensions");
+            throw std::invalid_argument("HEMM: incompatible matrix dimensions");
         }
 
         // Unlike cublas?trmm, cublas?hemm is quick enough that a per-batch loop
@@ -499,10 +499,10 @@ namespace batchlas {
         handle.setStream(ctx);
 
         if (C.rows() != C.cols()) {
-            throw std::runtime_error("HERK: C must be square");
+            throw std::invalid_argument("HERK: C must be square");
         }
         if (A.batch_size() != C.batch_size()) {
-            throw std::runtime_error(
+            throw std::invalid_argument(
                 "HERK: batch size mismatch (A=" + std::to_string(A.batch_size()) +
                 ", C=" + std::to_string(C.batch_size()) + ")");
         }
@@ -510,7 +510,7 @@ namespace batchlas {
         // rather than Hermitian; that operation is syrk's, and BLAS does not
         // spell it here.
         if (transA != Transpose::NoTrans && transA != Transpose::ConjTrans) {
-            throw std::runtime_error("HERK: transA must be NoTrans or ConjTrans");
+            throw std::invalid_argument("HERK: transA must be NoTrans or ConjTrans");
         }
 
         const int n = C.rows();
@@ -518,7 +518,7 @@ namespace batchlas {
         const int k = transA == Transpose::NoTrans ? A.cols() : A.rows();
         const int expected_n = transA == Transpose::NoTrans ? A.rows() : A.cols();
         if (expected_n != n || k <= 0) {
-            throw std::runtime_error("HERK: incompatible matrix dimensions");
+            throw std::invalid_argument("HERK: incompatible matrix dimensions");
         }
 
         // The same single-tile Gram kernel as syrk, with the ^H conjugating
@@ -605,16 +605,16 @@ namespace batchlas {
         handle.setStream(ctx);
 
         if (C.rows() != C.cols()) {
-            throw std::runtime_error("HER2K: C must be square");
+            throw std::invalid_argument("HER2K: C must be square");
         }
         if (A.batch_size() != B.batch_size() || A.batch_size() != C.batch_size()) {
-            throw std::runtime_error(
+            throw std::invalid_argument(
                 "HER2K: batch size mismatch (A=" + std::to_string(A.batch_size()) +
                 ", B=" + std::to_string(B.batch_size()) +
                 ", C=" + std::to_string(C.batch_size()) + ")");
         }
         if (transA != Transpose::NoTrans && transA != Transpose::ConjTrans) {
-            throw std::runtime_error("HER2K: transA must be NoTrans or ConjTrans");
+            throw std::invalid_argument("HER2K: transA must be NoTrans or ConjTrans");
         }
 
         const int n = C.rows();
@@ -625,7 +625,7 @@ namespace batchlas {
         const int b_n = no_trans ? B.rows() : B.cols();
         const int b_k = no_trans ? B.cols() : B.rows();
         if (expected_n != n || b_n != n || b_k != k || k <= 0) {
-            throw std::runtime_error("HER2K: incompatible matrix dimensions");
+            throw std::invalid_argument("HER2K: incompatible matrix dimensions");
         }
 
         const std::size_t product_bytes = detail::expanded_workspace_bytes<T>(ctx, n, batch);
@@ -692,10 +692,10 @@ namespace batchlas {
         handle.setStream(ctx);
 
         if (C.rows() != C.cols()) {
-            throw std::runtime_error("SYRK: C must be square");
+            throw std::invalid_argument("SYRK: C must be square");
         }
         if (A.batch_size() != C.batch_size()) {
-            throw std::runtime_error(
+            throw std::invalid_argument(
                 "SYRK: batch size mismatch (A=" + std::to_string(A.batch_size()) +
                 ", C=" + std::to_string(C.batch_size()) + ")");
         }
@@ -704,7 +704,7 @@ namespace batchlas {
         const int k = transA == Transpose::NoTrans ? A.cols() : A.rows();
         const int expected_n = transA == Transpose::NoTrans ? A.rows() : A.cols();
         if (expected_n != n || k <= 0) {
-            throw std::runtime_error("SYRK: incompatible matrix dimensions");
+            throw std::invalid_argument("SYRK: incompatible matrix dimensions");
         }
 
         const auto uplo_cublas = enum_convert<BackendLibrary::CUBLAS>(uplo);
@@ -795,10 +795,10 @@ namespace batchlas {
         handle.setStream(ctx);
 
         if (C.rows() != C.cols()) {
-            throw std::runtime_error("SYR2K: C must be square");
+            throw std::invalid_argument("SYR2K: C must be square");
         }
         if (A.batch_size() != B.batch_size() || A.batch_size() != C.batch_size()) {
-            throw std::runtime_error(
+            throw std::invalid_argument(
                 "SYR2K: batch size mismatch (A=" + std::to_string(A.batch_size()) +
                 ", B=" + std::to_string(B.batch_size()) +
                 ", C=" + std::to_string(C.batch_size()) + ")");
@@ -810,7 +810,7 @@ namespace batchlas {
         const int expected_b_n = transA == Transpose::NoTrans ? B.rows() : B.cols();
         const int b_k = transA == Transpose::NoTrans ? B.cols() : B.rows();
         if (expected_n != n || expected_b_n != n || b_k != k || k <= 0) {
-            throw std::runtime_error("SYR2K: incompatible matrix dimensions");
+            throw std::invalid_argument("SYR2K: incompatible matrix dimensions");
         }
 
         const auto uplo_cublas = enum_convert<BackendLibrary::CUBLAS>(uplo);
@@ -902,10 +902,10 @@ namespace batchlas {
         handle.setStream(ctx);
 
         if (A.rows() != A.cols()) {
-            throw std::runtime_error("TRMM: A must be square");
+            throw std::invalid_argument("TRMM: A must be square");
         }
         if (A.batch_size() != B.batch_size() || A.batch_size() != C.batch_size()) {
-            throw std::runtime_error(
+            throw std::invalid_argument(
                 "TRMM: batch size mismatch (A=" + std::to_string(A.batch_size()) +
                 ", B=" + std::to_string(B.batch_size()) +
                 ", C=" + std::to_string(C.batch_size()) + ")");
@@ -917,7 +917,7 @@ namespace batchlas {
         // on the left and n x n on the right.
         const int k = side == Side::Left ? m : n;
         if (A.rows() != k || B.rows() != m || B.cols() != n) {
-            throw std::runtime_error("TRMM: incompatible matrix dimensions");
+            throw std::invalid_argument("TRMM: incompatible matrix dimensions");
         }
 
         // One expansion plus one strided-batched GEMM beats the per-batch
@@ -1586,11 +1586,11 @@ namespace batchlas {
     Event trsm(Queue& ctx,
                const MatrixView<T,MatrixFormat::Dense>& A,
                const MatrixView<T,MatrixFormat::Dense>& B,
+               T alpha,
                Side side,
                Uplo uplo,
                Transpose transA,
-               Diag diag,
-               T alpha) {
+               Diag diag) {
         return backend::trsm_vendor<Back, T>(ctx, A, B, side, uplo, transA, diag, alpha);
     }
 

--- a/src/backends/cublas.cc
+++ b/src/backends/cublas.cc
@@ -1505,13 +1505,17 @@ namespace batchlas {
     Event getrf_vendor(Queue& ctx,
         const MatrixView<T, MatrixFormat::Dense>& A,
         Span<int64_t> pivots,
-        Span<std::byte> work_space) {
+        Span<std::byte> work_space,
+        Span<int32_t> info_out) {
             static LinalgHandle<B> handle;
             handle.setStream(ctx);
             auto n = A.rows();
             auto batch_size = A.batch_size();
             auto pool = BumpAllocator(work_space);
-            auto info = pool.allocate<int>(ctx, batch_size);
+            // cuBLAS's infoArray is a genuine per-item device array with LAPACK
+            // semantics (0 = ok, >0 = the column where U went exactly singular).
+            // It used to be pool scratch that nothing ever read.
+            auto info = ::batchlas::detail::info_target(ctx, pool, info_out, static_cast<size_t>(batch_size));
             auto reinterpreted_pivots = pivots.as_span<int>();
             call_backend<T, BackendLibrary::CUBLAS, B>(cublasSgetrfBatched, cublasDgetrfBatched, cublasCgetrfBatched, cublasZgetrfBatched,
                 handle, n,
@@ -1530,13 +1534,17 @@ namespace batchlas {
         const MatrixView<T, MatrixFormat::Dense>& A,
         const MatrixView<T, MatrixFormat::Dense>& C, //C is overwritten with inverse of A
         Span<int64_t> pivots,
-        Span<std::byte> work_space) {
+        Span<std::byte> work_space,
+        Span<int32_t> info_out) {
             static LinalgHandle<B> handle;
             handle.setStream(ctx);
             auto n = A.rows();
             auto batch_size = A.batch_size();
             auto pool = BumpAllocator(work_space);
-            auto info_arr = pool.allocate<int>(ctx, batch_size);
+            // Same story as getrf_vendor: cuBLAS writes a per-item infoArray
+            // (>0 = U(i,i) is exactly zero, so this item has no inverse) and the
+            // result was thrown away, leaving the caller a matrix of infinities.
+            auto info_arr = ::batchlas::detail::info_target(ctx, pool, info_out, static_cast<size_t>(batch_size));
             auto reinterpreted_pivots = pivots.as_span<int>();
             call_backend<T, BackendLibrary::CUBLAS, B>(cublasSgetriBatched, cublasDgetriBatched, cublasCgetriBatched, cublasZgetriBatched,
                 handle, n,
@@ -1729,8 +1737,9 @@ namespace batchlas {
     Event getrf(Queue& ctx,
                 const MatrixView<T, MatrixFormat::Dense>& A,
                 Span<int64_t> pivots,
-                Span<std::byte> work_space) {
-        return backend::getrf_vendor<B, T>(ctx, A, pivots, work_space);
+                Span<std::byte> work_space,
+                Span<int32_t> info) {
+        return backend::getrf_vendor<B, T>(ctx, A, pivots, work_space, info);
     }
 
     template <Backend B, typename T>
@@ -1744,8 +1753,9 @@ namespace batchlas {
                 const MatrixView<T, MatrixFormat::Dense>& A,
                 const MatrixView<T, MatrixFormat::Dense>& C,
                 Span<int64_t> pivots,
-                Span<std::byte> work_space) {
-        return backend::getri_vendor<B, T>(ctx, A, C, pivots, work_space);
+                Span<std::byte> work_space,
+                Span<int32_t> info) {
+        return backend::getri_vendor<B, T>(ctx, A, C, pivots, work_space, info);
     }
 
     template <Backend B, typename T>

--- a/src/backends/cusolver.cc
+++ b/src/backends/cusolver.cc
@@ -42,18 +42,19 @@ namespace batchlas {
     Event potrf(Queue& ctx,
                     const MatrixView<T, MatrixFormat::Dense>& descrA,
                     Uplo uplo,
-                    Span<std::byte> workspace) {        
+                    Span<std::byte> workspace,
+                    Span<int32_t> info_out) {
         static LinalgHandle<B> handle;
         handle.setStream(ctx);
         BumpAllocator pool(workspace);
         auto Lwork = potrf_buffer_size<B>(ctx, descrA, uplo) - BumpAllocator::allocation_size<int>(ctx, 1);
         if (descrA.batch_size() == 1) {
             auto potrf_span = pool.allocate<std::byte>(ctx, Lwork);
-            auto info = pool.allocate<int>(ctx, 1);
+            auto info = detail::info_target(ctx, pool, info_out, 1);
             auto status = call_backend<T, BackendLibrary::CUSOLVER, B>(cusolverDnSpotrf, cusolverDnDpotrf, cusolverDnCpotrf, cusolverDnZpotrf,
                 handle, uplo, descrA.rows(), descrA.data_ptr(), descrA.ld(), reinterpret_cast<T*>(potrf_span.data()), Lwork, info.data());
         } else {
-            auto info = pool.allocate<int>(ctx, descrA.batch_size());
+            auto info = detail::info_target(ctx, pool, info_out, descrA.batch_size());
             call_backend<T, BackendLibrary::CUSOLVER, B>(cusolverDnSpotrfBatched, cusolverDnDpotrfBatched, cusolverDnCpotrfBatched, cusolverDnZpotrfBatched,
                 handle, uplo, descrA.rows(), descrA.data_ptrs(ctx).data(), descrA.ld(), info.data(), descrA.batch_size());
         }
@@ -492,7 +493,8 @@ namespace batchlas {
         Queue&, \
         const MatrixView<fp, MatrixFormat::Dense>&, \
         Uplo, \
-        Span<std::byte>);
+        Span<std::byte>, \
+        Span<int32_t>);
     
     #define POTRF_BUFFER_SIZE_INSTANTIATE(fp) \
     template size_t potrf_buffer_size<Backend::CUDA, fp>( \

--- a/src/backends/mkl.cc
+++ b/src/backends/mkl.cc
@@ -26,7 +26,7 @@ namespace batchlas {
                Transpose transB,
                ComputePrecision precision) {
         if (!gemm_batch_dimensions_compatible(A, B, C, transA, transB)) {
-            throw std::runtime_error("GEMM: incompatible matrix dimensions");
+            throw std::invalid_argument("GEMM: incompatible matrix dimensions");
         }
 
         if (gemm_has_heterogeneous_batch(A, B, C)) {
@@ -121,7 +121,7 @@ namespace batchlas {
         auto stride_tau = std::min(m, n);
         size_t scratch = geqrf_buffer_size<Back>(ctx, A, tau);
         if (workspace.size() < scratch) {
-            throw std::runtime_error("Insufficient workspace for MKL geqrf");
+            throw std::invalid_argument("Insufficient workspace for MKL geqrf");
         }
         auto* scratch_ptr = reinterpret_cast<T*>(workspace.data());
         oneapi::mkl::lapack::geqrf_batch(

--- a/src/backends/netlib_lapack.cc
+++ b/src/backends/netlib_lapack.cc
@@ -405,11 +405,11 @@ namespace batchlas{
     Event trsm(Queue& ctx,
         const MatrixView<T, MatrixFormat::Dense>& descrA,
         const MatrixView<T, MatrixFormat::Dense>& descrB,
+        T alpha,
         Side side,
         Uplo uplo,
         Transpose transA,
-        Diag diag,
-        T alpha) {
+        Diag diag) {
         auto A_view = descrA;
         auto B_view = descrB;
         return detail::submit_host_task<T>(ctx, "netlib.trsm", [=] {

--- a/src/backends/netlib_lapack.cc
+++ b/src/backends/netlib_lapack.cc
@@ -944,21 +944,31 @@ namespace batchlas{
     Event potrf(Queue& ctx,
                     const MatrixView<T, MatrixFormat::Dense>& descrA,
                     Uplo uplo,
-                    Span<std::byte> workspace) {
+                    Span<std::byte> workspace,
+                    Span<int32_t> info_out) {
         static_cast<void>(workspace);
         auto A_view = descrA;
+        // LAPACKE reports failure only through its return value, and this loop
+        // used to drop it on the floor (issue #73): an indefinite item came back
+        // looking exactly like a factorised one. There is no pool fallback to
+        // pick here -- unlike the vendor backends netlib needs no status array of
+        // its own -- so an empty span simply means "do not record".
+        auto info = info_out;
+        const bool want_info = info.size() >= static_cast<size_t>(descrA.batch_size());
         return detail::submit_host_task<T>(ctx, "netlib.potrf", [=] {
             if (A_view.batch_size() == 1) {
-                call_backend_nh<T, BackendLibrary::LAPACKE>(
+                auto st = call_backend_nh_r<T, BackendLibrary::LAPACKE>(
                     LAPACKE_spotrf, LAPACKE_dpotrf, LAPACKE_cpotrf, LAPACKE_zpotrf,
                     Layout::ColMajor, uplo,
                     A_view.rows(), A_view.data_ptr(), A_view.ld());
+                if (want_info) info[0] = static_cast<int32_t>(st);
             } else {
                 for (int i = 0; i < A_view.batch_size(); ++i) {
-                    call_backend_nh<T, BackendLibrary::LAPACKE>(
+                    auto st = call_backend_nh_r<T, BackendLibrary::LAPACKE>(
                         LAPACKE_spotrf, LAPACKE_dpotrf, LAPACKE_cpotrf, LAPACKE_zpotrf,
                         Layout::ColMajor, uplo,
                         A_view[i].rows(), A_view[i].data_ptr(), A_view[i].ld());
+                    if (want_info) info[i] = static_cast<int32_t>(st);
                 }
             }
         });
@@ -1201,17 +1211,22 @@ namespace batchlas{
     Event getrf(Queue& ctx,
                 const MatrixView<T, MatrixFormat::Dense>& A,
                 Span<int64_t> pivots,
-                Span<std::byte> workspace) {
+                Span<std::byte> workspace,
+                Span<int32_t> info_out) {
         BumpAllocator pool(workspace);
         auto A_view = A;
         auto piv = pivots;
         const int n = A_view.rows();
         const int batch = A_view.batch_size();
         auto piv_i32 = pool.allocate<int>(ctx, n * batch);
+        // See potrf above: the LAPACKE return was discarded, so a singular item
+        // was indistinguishable from a factorised one (issue #73).
+        auto info = info_out;
+        const bool want_info = info.size() >= static_cast<size_t>(batch);
 
         Event getrf_event = detail::submit_host_task<T>(ctx, "netlib.getrf", [=] {
             for (int i = 0; i < batch; ++i) {
-                call_backend_nh<T, BackendLibrary::LAPACKE>(
+                auto st = call_backend_nh_r<T, BackendLibrary::LAPACKE>(
                     LAPACKE_sgetrf, LAPACKE_dgetrf, LAPACKE_cgetrf, LAPACKE_zgetrf,
                     Layout::ColMajor,
                     n,
@@ -1219,6 +1234,7 @@ namespace batchlas{
                     A_view[i].data_ptr(),
                     A_view.ld(),
                     piv_i32.data() + i * n);
+                if (want_info) info[i] = static_cast<int32_t>(st);
             }
         });
         ctx.enqueue(getrf_event);
@@ -1249,7 +1265,8 @@ namespace batchlas{
                 const MatrixView<T, MatrixFormat::Dense>& A,
                 const MatrixView<T, MatrixFormat::Dense>& C,
                 Span<int64_t> pivots,
-                Span<std::byte> workspace) {
+                Span<std::byte> workspace,
+                Span<int32_t> info_out) {
         BumpAllocator pool(workspace);
         auto A_view = A;
         auto C_view = C;
@@ -1257,6 +1274,10 @@ namespace batchlas{
         const int n = A_view.rows();
         const int batch = A_view.batch_size();
         auto piv_i32 = pool.allocate<int>(ctx, n * batch);
+        // See potrf above: the LAPACKE return was discarded, so an item with no
+        // inverse was indistinguishable from one that inverted (issue #73).
+        auto info = info_out;
+        const bool want_info = info.size() >= static_cast<size_t>(batch);
         return detail::submit_host_task<T>(ctx, "netlib.getri", [=] {
             auto piv_in = piv.as_span<int64_t>();
             for (int b = 0; b < batch; ++b) {
@@ -1267,13 +1288,14 @@ namespace batchlas{
                     piv_i32[b * n + i] = static_cast<int>(piv_in[b * n + i]);
                 }
 
-                call_backend_nh<T, BackendLibrary::LAPACKE>(
+                auto st = call_backend_nh_r<T, BackendLibrary::LAPACKE>(
                     LAPACKE_sgetri, LAPACKE_dgetri, LAPACKE_cgetri, LAPACKE_zgetri,
                     Layout::ColMajor,
                     n,
                     Cb.data_ptr(),
                     Cb.ld(),
                     piv_i32.data() + b * n);
+                if (want_info) info[b] = static_cast<int32_t>(st);
             }
         });
     }

--- a/src/backends/rocblas.cc
+++ b/src/backends/rocblas.cc
@@ -24,7 +24,7 @@ namespace batchlas {
                Transpose transB,
                ComputePrecision precision) {
         if (!gemm_batch_dimensions_compatible(A, B, C, transA, transB)) {
-            throw std::runtime_error("GEMM: incompatible matrix dimensions");
+            throw std::invalid_argument("GEMM: incompatible matrix dimensions");
         }
 
         if (gemm_has_heterogeneous_batch(A, B, C)) {
@@ -138,11 +138,11 @@ namespace batchlas {
     Event trsm(Queue& ctx,
                const MatrixView<T,MatrixFormat::Dense>& A,
                const MatrixView<T,MatrixFormat::Dense>& Bmat,
+               T alpha,
                Side side,
                Uplo uplo,
                Transpose transA,
-               Diag diag,
-               T alpha) {
+               Diag diag) {
         static LinalgHandle<B> handle;
         handle.setStream(ctx);
         auto [kB, n] = get_effective_dims(Bmat, Transpose::NoTrans);
@@ -175,17 +175,17 @@ namespace batchlas {
         handle.setStream(ctx);
 
         if (C.rows() != C.cols()) {
-            throw std::runtime_error("SYRK: C must be square");
+            throw std::invalid_argument("SYRK: C must be square");
         }
         if (A.batch_size() != C.batch_size()) {
-            throw std::runtime_error("SYRK: batch size mismatch");
+            throw std::invalid_argument("SYRK: batch size mismatch");
         }
 
         const int n = C.rows();
         const int k = transA == Transpose::NoTrans ? A.cols() : A.rows();
         const int expected_n = transA == Transpose::NoTrans ? A.rows() : A.cols();
         if (expected_n != n || k <= 0) {
-            throw std::runtime_error("SYRK: incompatible matrix dimensions");
+            throw std::invalid_argument("SYRK: incompatible matrix dimensions");
         }
 
         const auto roc_uplo = enum_convert<BackendLibrary::ROCBLAS>(uplo);
@@ -243,10 +243,10 @@ namespace batchlas {
         handle.setStream(ctx);
 
         if (C.rows() != C.cols()) {
-            throw std::runtime_error("SYR2K: C must be square");
+            throw std::invalid_argument("SYR2K: C must be square");
         }
         if (A.batch_size() != Bmat.batch_size() || A.batch_size() != C.batch_size()) {
-            throw std::runtime_error("SYR2K: batch size mismatch");
+            throw std::invalid_argument("SYR2K: batch size mismatch");
         }
 
         const int n = C.rows();
@@ -255,7 +255,7 @@ namespace batchlas {
         const int k = transA == Transpose::NoTrans ? A.cols() : A.rows();
         const int b_k = transA == Transpose::NoTrans ? Bmat.cols() : Bmat.rows();
         if (expected_n != n || expected_b_n != n || b_k != k || k <= 0) {
-            throw std::runtime_error("SYR2K: incompatible matrix dimensions");
+            throw std::invalid_argument("SYR2K: incompatible matrix dimensions");
         }
 
         const auto roc_uplo = enum_convert<BackendLibrary::ROCBLAS>(uplo);
@@ -319,17 +319,17 @@ namespace batchlas {
         handle.setStream(ctx);
 
         if (A.rows() != A.cols()) {
-            throw std::runtime_error("TRMM: A must be square");
+            throw std::invalid_argument("TRMM: A must be square");
         }
         if (A.batch_size() != Bmat.batch_size() || A.batch_size() != C.batch_size()) {
-            throw std::runtime_error("TRMM: batch size mismatch");
+            throw std::invalid_argument("TRMM: batch size mismatch");
         }
 
         const int m = C.rows();
         const int n = C.cols();
         const int expected_dim = side == Side::Left ? m : n;
         if (A.rows() != expected_dim || Bmat.rows() != m || Bmat.cols() != n) {
-            throw std::runtime_error("TRMM: incompatible matrix dimensions");
+            throw std::invalid_argument("TRMM: incompatible matrix dimensions");
         }
 
         const auto roc_side = enum_convert<BackendLibrary::ROCBLAS>(side);
@@ -423,7 +423,7 @@ namespace batchlas {
     #define GEMV_INSTANTIATE(fp) \
     template Event gemv<Backend::ROCM, fp>(Queue&, const MatrixView<fp,MatrixFormat::Dense>&, const VectorView<fp>&, const VectorView<fp>&, fp, fp, Transpose);
     #define TRSM_INSTANTIATE(fp) \
-    template Event trsm<Backend::ROCM, fp>(Queue&, const MatrixView<fp,MatrixFormat::Dense>&, const MatrixView<fp,MatrixFormat::Dense>&, Side, Uplo, Transpose, Diag, fp);
+    template Event trsm<Backend::ROCM, fp>(Queue&, const MatrixView<fp,MatrixFormat::Dense>&, const MatrixView<fp,MatrixFormat::Dense>&, fp, Side, Uplo, Transpose, Diag);
     #define TRMM_INSTANTIATE(fp) \
     template Event trmm<Backend::ROCM, fp>(Queue&, const MatrixView<fp,MatrixFormat::Dense>&, const MatrixView<fp,MatrixFormat::Dense>&, const MatrixView<fp,MatrixFormat::Dense>&, fp, Side, Uplo, Transpose, Diag);
     #define SYRK_INSTANTIATE(fp) \

--- a/src/backends/rocsolver.cc
+++ b/src/backends/rocsolver.cc
@@ -32,11 +32,15 @@ namespace batchlas {
     Event potrf(Queue& ctx,
                 const MatrixView<T, MatrixFormat::Dense>& A,
                 Uplo uplo,
-                Span<std::byte> workspace) {
+                Span<std::byte> workspace,
+                Span<int32_t> info_out) {
         static LinalgHandle<B> handle;
         handle.setStream(ctx);
         BumpAllocator pool(workspace);
-        auto info = pool.allocate<int>(ctx, A.batch_size());
+        // rocSOLVER's info is a per-item device array with LAPACK semantics; it
+        // used to be pool scratch nothing read (issue #73). A caller span, when
+        // supplied, replaces the scratch -- so the workspace size is unchanged.
+        auto info = detail::info_target(ctx, pool, info_out, static_cast<size_t>(A.batch_size()));
         if (A.batch_size() == 1) {
             call_backend<T, BackendLibrary::ROCSOLVER, B>(rocsolver_spotrf, rocsolver_dpotrf, rocsolver_cpotrf, rocsolver_zpotrf,
                 handle, enum_convert<BackendLibrary::ROCSOLVER>(uplo), A.rows(), A.data_ptr(), A.ld(), info.data());
@@ -188,11 +192,13 @@ namespace batchlas {
     Event getrf(Queue& ctx,
                 const MatrixView<T, MatrixFormat::Dense>& A,
                 Span<int64_t> pivots,
-                Span<std::byte> workspace) {
+                Span<std::byte> workspace,
+                Span<int32_t> info_out) {
         static LinalgHandle<B> handle;
         handle.setStream(ctx);
         BumpAllocator pool(workspace);
-        auto info = pool.allocate<int>(ctx, A.batch_size());
+        // See potrf above (issue #73).
+        auto info = detail::info_target(ctx, pool, info_out, static_cast<size_t>(A.batch_size()));
         auto ipiv = pivots.as_span<int>();
         if (A.batch_size() == 1) {
             call_backend<T, BackendLibrary::ROCSOLVER, B>(rocsolver_sgetrf, rocsolver_dgetrf,
@@ -271,11 +277,13 @@ namespace batchlas {
                 const MatrixView<T, MatrixFormat::Dense>& A,
                 const MatrixView<T, MatrixFormat::Dense>& C,
                 Span<int64_t> pivots,
-                Span<std::byte> workspace) {
+                Span<std::byte> workspace,
+                Span<int32_t> info_out) {
         static LinalgHandle<B> handle;
         handle.setStream(ctx);
         BumpAllocator pool(workspace);
-        auto info = pool.allocate<int>(ctx, A.batch_size());
+        // See potrf above (issue #73).
+        auto info = detail::info_target(ctx, pool, info_out, static_cast<size_t>(A.batch_size()));
         auto ipiv = pivots.as_span<int>();
         if (A.data_ptr() != C.data_ptr()) {
             ctx->memcpy(C.data_ptr(), A.data_ptr(), sizeof(T) * static_cast<size_t>(A.stride()) * A.batch_size());
@@ -381,7 +389,7 @@ namespace batchlas {
     template size_t backend::gesvd_vendor_buffer_size<Backend::ROCM, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&, Span<typename base_type<fp>::type>, const MatrixView<fp, MatrixFormat::Dense>&, const MatrixView<fp, MatrixFormat::Dense>&, SvdVectors, SvdVectors);
 
     #define POTRF_INSTANTIATE(fp) \
-    template Event potrf<Backend::ROCM, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&, Uplo, Span<std::byte>);
+    template Event potrf<Backend::ROCM, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&, Uplo, Span<std::byte>, Span<int32_t>);
     #define POTRF_BUFFER_SIZE_INSTANTIATE(fp) \
     template size_t potrf_buffer_size<Backend::ROCM, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&, Uplo);
     #define SYEV_INSTANTIATE(fp) \
@@ -409,7 +417,7 @@ namespace batchlas {
     #define ORGQR_BUFFER_SIZE_INSTANTIATE(fp) \
     template size_t orgqr_buffer_size<Backend::ROCM, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&, Span<fp>);
     #define GETRF_INSTANTIATE(fp) \
-    template Event getrf<Backend::ROCM, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&, Span<int64_t>, Span<std::byte>);
+    template Event getrf<Backend::ROCM, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&, Span<int64_t>, Span<std::byte>, Span<int32_t>);
     #define GETRF_BUFFER_SIZE_INSTANTIATE(fp) \
     template size_t getrf_buffer_size<Backend::ROCM, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&);
     #define GETRS_INSTANTIATE(fp) \
@@ -417,7 +425,7 @@ namespace batchlas {
     #define GETRS_BUFFER_SIZE_INSTANTIATE(fp) \
     template size_t getrs_buffer_size<Backend::ROCM, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&, const MatrixView<fp, MatrixFormat::Dense>&, Transpose);
     #define GETRI_INSTANTIATE(fp) \
-    template Event getri<Backend::ROCM, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&, const MatrixView<fp, MatrixFormat::Dense>&, Span<int64_t>, Span<std::byte>);
+    template Event getri<Backend::ROCM, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&, const MatrixView<fp, MatrixFormat::Dense>&, Span<int64_t>, Span<std::byte>, Span<int32_t>);
     #define GETRI_BUFFER_SIZE_INSTANTIATE(fp) \
     template size_t getri_buffer_size<Backend::ROCM, fp>(Queue&, const MatrixView<fp, MatrixFormat::Dense>&);
 

--- a/src/extensions/bdsdc.cc
+++ b/src/extensions/bdsdc.cc
@@ -143,7 +143,7 @@ BdsdcWorkspace<T> bdsdc_layout(Queue& ctx,
                                               static_cast<int64_t>(N) * static_cast<int64_t>(N), batch);
 
     ws.stedc_ws = pool.allocate<std::byte>(
-        ctx, stedc_workspace_size<B, T>(ctx, static_cast<size_t>(N), nb, JobType::EigenVectors,
+        ctx, stedc_buffer_size<B, T>(ctx, static_cast<size_t>(N), nb, JobType::EigenVectors,
                                         bdsdc_stedc_params<T>()));
     return ws;
 }

--- a/src/extensions/gesvd_blocked.cc
+++ b/src/extensions/gesvd_blocked.cc
@@ -276,7 +276,7 @@ size_t gesvd_solver_workspace_size(Queue& ctx,
     if (mode == GesvdNativeMode::CTA) {
         return steqr_cta_buffer_size<T>(ctx, diag_dummy, offdiag_dummy, evals_dummy, jobz, gesvd_cta_steqr_params<T>());
     }
-    return stedc_workspace_size<B, T>(ctx,
+    return stedc_buffer_size<B, T>(ctx,
                                       static_cast<size_t>(n),
                                       static_cast<size_t>(batch),
                                       JobType::EigenVectors,

--- a/src/extensions/ritz_values.cc
+++ b/src/extensions/ritz_values.cc
@@ -163,7 +163,7 @@ namespace batchlas {
      * @return size_t Required workspace size in bytes
      */
     template <Backend B, typename T, MatrixFormat MFormat>
-    size_t ritz_values_workspace(Queue& ctx,
+    size_t ritz_values_buffer_size(Queue& ctx,
                                  const MatrixView<T, MFormat>& A,
                                  const MatrixView<T, MatrixFormat::Dense>& V,
                                  const VectorView<typename base_type<T>::type>& ritz_vals) {
@@ -190,7 +190,7 @@ namespace batchlas {
     // Explicit template instantiations for common types
     #define RITZ_VALUES_INSTANTIATE(back, fp, fmt) \
         template Event ritz_values<back, BATCHLAS_UNPAREN fp, fmt>(Queue&, const MatrixView<BATCHLAS_UNPAREN fp, fmt>&, const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>&, const VectorView<typename base_type<BATCHLAS_UNPAREN fp>::type>&, Span<std::byte>); \
-        template size_t ritz_values_workspace<back, BATCHLAS_UNPAREN fp, fmt>(Queue&, const MatrixView<BATCHLAS_UNPAREN fp, fmt>&, const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>&, const VectorView<typename base_type<BATCHLAS_UNPAREN fp>::type>&);
+        template size_t ritz_values_buffer_size<back, BATCHLAS_UNPAREN fp, fmt>(Queue&, const MatrixView<BATCHLAS_UNPAREN fp, fmt>&, const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>&, const VectorView<typename base_type<BATCHLAS_UNPAREN fp>::type>&);
 
     #define RITZ_VALUES_INSTANTIATE_FOR_BACKEND_TYPE(back, fp) \
         BATCHLAS_FOR_EACH_MATRIX_FORMAT_2(RITZ_VALUES_INSTANTIATE, back, fp)

--- a/src/extensions/stedc.cc
+++ b/src/extensions/stedc.cc
@@ -954,7 +954,7 @@ Event stedc(Queue& ctx, const VectorView<T>& d, const VectorView<T>& e, const Ve
 }
 
 template <Backend B, typename T>
-size_t stedc_workspace_size(Queue& ctx, size_t n, size_t batch_size, JobType jobz, StedcParams<T> params) {
+size_t stedc_buffer_size(Queue& ctx, size_t n, size_t batch_size, JobType jobz, StedcParams<T> params) {
     if (n <= 0 || batch_size <= 0) {
         return 0;
     }
@@ -1029,7 +1029,7 @@ size_t stedc_internal_workspace_size(Queue& ctx, size_t n, size_t batch_size, Jo
 
 #define STEDC_INSTANTIATE(back, fp) \
 template Event stedc<back, BATCHLAS_UNPAREN fp>(Queue& ctx, const VectorView<BATCHLAS_UNPAREN fp>& d, const VectorView<BATCHLAS_UNPAREN fp>& e, const VectorView<BATCHLAS_UNPAREN fp>& eigenvalues, const Span<std::byte>& ws, JobType jobz, StedcParams<BATCHLAS_UNPAREN fp> params, const MatrixView<BATCHLAS_UNPAREN fp, MatrixFormat::Dense>& eigvects); \
-template size_t stedc_workspace_size<back, BATCHLAS_UNPAREN fp>(Queue& ctx, size_t n, size_t batch_size, JobType jobz, StedcParams<BATCHLAS_UNPAREN fp> params);
+template size_t stedc_buffer_size<back, BATCHLAS_UNPAREN fp>(Queue& ctx, size_t n, size_t batch_size, JobType jobz, StedcParams<BATCHLAS_UNPAREN fp> params);
 
 #define STEDC_INSTANTIATE_FOR_BACKEND(back) \
     BATCHLAS_FOR_EACH_REAL_TYPE_1(STEDC_INSTANTIATE, back)

--- a/src/extensions/syev_blocked.cc
+++ b/src/extensions/syev_blocked.cc
@@ -288,7 +288,7 @@ Event syev_blocked(Queue& ctx,
         // backtransform/store vectors when requested by the public API.
         const JobType internal_jobz = JobType::EigenVectors;
         {
-            auto stedc_ws_bytes = stedc_workspace_size<B, Real>(ctx, static_cast<std::size_t>(n), static_cast<std::size_t>(batch), internal_jobz, stedc_params);
+            auto stedc_ws_bytes = stedc_buffer_size<B, Real>(ctx, static_cast<std::size_t>(n), static_cast<std::size_t>(batch), internal_jobz, stedc_params);
             auto stedc_ws = pool.allocate<std::byte>(ctx, stedc_ws_bytes);
             stedc<B, Real>(ctx, d_view, e_view, evals_view, stedc_ws, internal_jobz, stedc_params, z_view);
         }
@@ -427,7 +427,7 @@ Event syev_blocked(Queue& ctx,
 
         const JobType internal_jobz = JobType::EigenVectors;
         {
-            auto stedc_ws_bytes = stedc_workspace_size<B, T>(ctx, static_cast<std::size_t>(n), static_cast<std::size_t>(batch), internal_jobz, stedc_params);
+            auto stedc_ws_bytes = stedc_buffer_size<B, T>(ctx, static_cast<std::size_t>(n), static_cast<std::size_t>(batch), internal_jobz, stedc_params);
             auto stedc_ws = pool.allocate<std::byte>(ctx, stedc_ws_bytes);
             stedc<B, T>(ctx, d_view, e_view, evals_view, stedc_ws, internal_jobz, stedc_params, z_view);
         }
@@ -544,7 +544,7 @@ size_t syev_blocked_buffer_size(Queue& ctx,
         bytes += sytrd_blocked_buffer_size<B, T>(ctx, a, d_c_dummy, e_c_dummy, tau_c_dummy, uplo, sytrd_block_size);
 
         if (want_vectors) {
-            bytes += stedc_workspace_size<B, Real>(ctx, static_cast<std::size_t>(n), static_cast<std::size_t>(batch), JobType::EigenVectors, stedc_params);
+            bytes += stedc_buffer_size<B, Real>(ctx, static_cast<std::size_t>(n), static_cast<std::size_t>(batch), JobType::EigenVectors, stedc_params);
 
             MatrixView<T, MatrixFormat::Dense> aq_dummy(nullptr, p, p, p, static_cast<int64_t>(p) * static_cast<int64_t>(p), batch);
             MatrixView<T, MatrixFormat::Dense> c_dummy(nullptr, p, n, p, static_cast<int64_t>(p) * static_cast<int64_t>(n), batch);
@@ -588,7 +588,7 @@ size_t syev_blocked_buffer_size(Queue& ctx,
         bytes += sytrd_blocked_buffer_size<B, T>(ctx, a, d_dummy, e_dummy, tau_dummy, uplo, sytrd_block_size);
 
         if (want_vectors) {
-            bytes += stedc_workspace_size<B, T>(ctx, static_cast<std::size_t>(n), static_cast<std::size_t>(batch), JobType::EigenVectors, stedc_params);
+            bytes += stedc_buffer_size<B, T>(ctx, static_cast<std::size_t>(n), static_cast<std::size_t>(batch), JobType::EigenVectors, stedc_params);
 
             MatrixView<T, MatrixFormat::Dense> aq_dummy(nullptr, p, p, p, static_cast<int64_t>(p) * static_cast<int64_t>(p), batch);
             MatrixView<T, MatrixFormat::Dense> c_dummy(nullptr, p, n, p, static_cast<int64_t>(p) * static_cast<int64_t>(n), batch);

--- a/src/extensions/syev_two_stage.cc
+++ b/src/extensions/syev_two_stage.cc
@@ -300,7 +300,7 @@ Event syev_two_stage(Queue& ctx,
 
     {
         BATCHLAS_KERNEL_TRACE_SCOPE("syev_two_stage.stedc_eigvecs");
-        const size_t stedc_ws_bytes = stedc_workspace_size<B, Real>(ctx,
+        const size_t stedc_ws_bytes = stedc_buffer_size<B, Real>(ctx,
                                                                      static_cast<std::size_t>(n),
                                                                      static_cast<std::size_t>(batch),
                                                                      JobType::EigenVectors,
@@ -498,7 +498,7 @@ size_t syev_two_stage_buffer_size(Queue& ctx,
                                            uplo,
                                            kd,
                                            sb2st_block_size);
-    bytes += stedc_workspace_size<B, Real>(ctx,
+    bytes += stedc_buffer_size<B, Real>(ctx,
                                            static_cast<std::size_t>(n),
                                            static_cast<std::size_t>(batch),
                                            want_eigvecs ? JobType::EigenVectors : JobType::NoEigenVectors,

--- a/src/extra/elementwise.cc
+++ b/src/extra/elementwise.cc
@@ -19,6 +19,9 @@ struct ElementwiseBinaryKernel {};
 template <typename T>
 struct AxpbyKernel {};
 
+template <typename T>
+struct TriangularMaskKernel {};
+
 template <typename T, BinaryOp Op>
 inline T apply(const T& a, const T& b) {
     if constexpr (Op == BinaryOp::Add) return a + b;
@@ -112,6 +115,48 @@ Event axpby_into(Queue& ctx,
 }
 
 template <typename T>
+Event triangular_mask_into(Queue& ctx,
+                           const MatrixView<T, MatrixFormat::Dense>& A,
+                           const MatrixView<T, MatrixFormat::Dense>& C,
+                           Uplo uplo,
+                           int64_t k) {
+    check_same_shape(A, C, "linalg::triangular_mask_into");
+
+    const size_t rows = static_cast<size_t>(A.rows());
+    const size_t cols = static_cast<size_t>(A.cols());
+    const size_t total = rows * cols * static_cast<size_t>(A.batch_size());
+    if (total == 0) return ctx.get_event();
+
+    auto [global_size, local_size] =
+        compute_nd_range_sizes(total, ctx.device(), KernelType::ELEMENTWISE);
+
+    // Same reasoning as elementwise_into: kernel views so that a submatrix
+    // (linalg::qr masks a row slice of the factored array) is indexed correctly,
+    // and A may alias C because each work-item touches one element of each.
+    auto Av = A.kernel_view();
+    auto Cv = C.kernel_view();
+    const bool upper = (uplo == Uplo::Upper);
+
+    ctx->parallel_for<TriangularMaskKernel<T>>(
+        sycl::nd_range<1>(global_size, local_size), [=](sycl::nd_item<1> item) {
+            const size_t stride = item.get_global_range(0);
+            for (size_t flat = item.get_global_id(0); flat < total; flat += stride) {
+                const size_t b = flat / (rows * cols);
+                const size_t rem = flat % (rows * cols);
+                const size_t col = rem / rows;
+                const size_t row = rem % rows;
+                // Signed: the diagonal offset is negative below the main
+                // diagonal, and an unsigned difference would wrap there and keep
+                // exactly the elements the mask is meant to drop.
+                const int64_t d = static_cast<int64_t>(col) - static_cast<int64_t>(row);
+                const bool keep = upper ? (d >= k) : (d <= k);
+                Cv(row, col, b) = keep ? Av(row, col, b) : T(0);
+            }
+        });
+    return ctx.get_event();
+}
+
+template <typename T>
 Event scale(Queue& ctx, const MatrixView<T, MatrixFormat::Dense>& A, T alpha) {
     // beta = 0 with B = A, so the second term contributes nothing and A is
     // read and written in place by the same work-item.
@@ -133,7 +178,9 @@ Event scale(Queue& ctx, const MatrixView<T, MatrixFormat::Dense>& A, T alpha) {
                          elementwise_into, BATCHLAS_UNPAREN fp, BinaryOp::Divide)          \
     BATCHLAS_INSTANTIATE(sig::axpby_into<BATCHLAS_UNPAREN fp>, axpby_into,                 \
                          BATCHLAS_UNPAREN fp)                                              \
-    BATCHLAS_INSTANTIATE(sig::scale<BATCHLAS_UNPAREN fp>, scale, BATCHLAS_UNPAREN fp)
+    BATCHLAS_INSTANTIATE(sig::scale<BATCHLAS_UNPAREN fp>, scale, BATCHLAS_UNPAREN fp)         \
+    BATCHLAS_INSTANTIATE(sig::triangular_mask_into<BATCHLAS_UNPAREN fp>,                      \
+                         triangular_mask_into, BATCHLAS_UNPAREN fp)
 
 BATCHLAS_FOR_EACH_SCALAR_TYPE(ELEMENTWISE_INSTANTIATE)
 

--- a/src/linalg-impl.hh
+++ b/src/linalg-impl.hh
@@ -666,6 +666,59 @@ namespace batchlas{
         }
     }
 
+    // Same dispatch, but hands back what the routine returned.
+    //
+    // A sibling rather than a change of return type on call_backend_nh above:
+    // that one is also used for the CBLAS calls (cblas_sgemm and friends), which
+    // return void, and `return void_expr;` is fine but `auto` deduced from four
+    // different branches is not -- one of them being void makes the whole thing
+    // ill-formed the moment a caller tries to use the result. Keeping the two
+    // apart means the void users cannot be broken by a change made for LAPACKE.
+    //
+    // The reason this exists at all: every LAPACKE routine reports failure only
+    // through its return value, and netlib's potrf/getrf/getri discarded it, so
+    // a singular batch item was indistinguishable from a factorised one (issue
+    // #73). See src/backends/netlib_lapack.cc.
+    template <typename T, BackendLibrary BL, typename Fun1, typename Fun2, typename Fun3, typename Fun4, typename... Args>
+    auto call_backend_nh_r(const Fun1& fun1, const Fun2& fun2, const Fun3& fun3, const Fun4& fun4, Args&&... args) {
+        if constexpr (std::is_same_v<T,float>) {
+            return std::apply(fun1, backend_convert<BL>(std::forward<Args>(args)...));
+        } else if constexpr (std::is_same_v<T,double>) {
+            return std::apply(fun2, backend_convert<BL>(std::forward<Args>(args)...));
+        } else if constexpr (std::is_same_v<T,std::complex<float>>) {
+            return std::apply(fun3, backend_convert<BL>(std::forward<Args>(args)...));
+        } else {
+            return std::apply(fun4, backend_convert<BL>(std::forward<Args>(args)...));
+        }
+    }
+
+    namespace detail {
+
+    // Where a factorisation should write its per-item LAPACK status.
+    //
+    // Every backend already allocates this array because the vendor call demands
+    // somewhere to write; before issue #73 it was pool scratch that nobody read.
+    // Now the caller may supply it: their span is USM, so the vendor writes it in
+    // place and there is no copy back.
+    //
+    // An empty (or too-short) caller span falls back to the pool, which is what
+    // preserves today's behaviour exactly for the ~all call sites that pass
+    // nothing. Note the direction: supplying a span only ever *removes* a pool
+    // draw, never adds one, so *_buffer_size stays correct in both modes -- a
+    // workspace sized without `info` is never too small for a call made with it.
+    //
+    // Short spans are silently ignored here rather than rejected; the public
+    // deducing overloads reject them up front (detail::require_info_span in
+    // blas/options.hh), and this layer is the library's own inner-loop spelling,
+    // which must not pay a throw path per call.
+    inline Span<int32_t> info_target(Queue& ctx, BumpAllocator& pool,
+                                     Span<int32_t> info_out, size_t count) {
+        if (info_out.size() >= count) return info_out;
+        return pool.allocate<int32_t>(ctx, count);
+    }
+
+    }  // namespace detail
+
 
     // Variadic template for converting multiple enums
 /*     template <Backend B, typename... Args>

--- a/src/matrix.cc
+++ b/src/matrix.cc
@@ -477,6 +477,17 @@ Matrix<T, NewMType> Matrix<T, MType>::convert_to(const float_t<T>& zero_threshol
         // 2. Create row offsets using exclusive scan within each batch
         Matrix<T, MatrixFormat::CSR> result(rows, cols, NonZeros{max_nnz}, batch_size);
 
+        // The scan below writes offsets 1..rows of each batch item and never element 0,
+        // and the CSR allocating constructor reaches the buffer through
+        // UnifiedVector::resize, which does not zero. So row_offsets()[b * (rows + 1)]
+        // was left uninitialised for every item, and anything reading an item's non-zero
+        // count as offsets[end] - offsets[start] read garbage. The CSR Random path writes
+        // that element explicitly; this path did not. Zeroing the whole array also makes
+        // the value/index padding above each item's own count deterministic: max_nnz is
+        // the batch MAXIMUM, so on a heterogeneous batch every smaller item has slots the
+        // population kernel never touches.
+        std::fill(result.row_offsets().begin(), result.row_offsets().end(), 0);
+
         // Initialize batch offset counters
         UnifiedVector<int> batch_offsets(batch_size + 1, 0);
         
@@ -1825,10 +1836,54 @@ template <typename U, MatrixFormat M>
     requires DenseMatrixFormat<M>
 MatrixView<T, MType>::MatrixView(T* data, int rows, int cols, int ld,
                   int stride, int batch_size, T** data_ptrs) :
-                data_(data, (stride > 0 ? stride : 
+                data_(data, (stride > 0 ? stride :
                             ld > 0 ? ld * cols : rows * cols) * batch_size),
                 rows_(rows), cols_(cols), batch_size_(batch_size),
-                ld_(ld > 0 ? ld : rows), stride_(stride > 0 ? stride : ld > 0 ? ld * cols : rows * cols), data_ptrs_(data_ptrs, (data_ptrs ? batch_size : 0)) {}
+                ld_(ld > 0 ? ld : rows), stride_(stride > 0 ? stride : ld > 0 ? ld * cols : rows * cols), data_ptrs_(data_ptrs, (data_ptrs ? batch_size : 0)) {
+    // This constructor performed no validation at all -- it was an init list with an
+    // empty body -- while the allocating Matrix constructor above has checked the same
+    // invariant for a while. That asymmetry is what makes the argument-order trap silent:
+    // Matrix takes (rows, cols, batch_size, ld, stride) but MatrixView takes
+    // (data, rows, cols, ld, stride, batch_size), so a caller who learned the order from
+    // `Matrix A(n, n, batch)` writes `MatrixView<float> V(p, n, n, batch)` and gets
+    // ld = batch, stride = batch * n, batch_size = 1 -- a view over a wrongly strided
+    // buffer, with no throw and plausible-looking numbers. `ld_ < rows` catches exactly
+    // that whenever batch < n, and the message names the intended spelling.
+    //
+    // What this deliberately does NOT check:
+    //   * a null `data` pointer, or rows == 0 / cols == 0. Roughly 37 in-repo sites build
+    //     `MatrixView<T, Dense>(nullptr, ...)` as a shape-only stand-in for a workspace
+    //     query, several of them with the shape (nullptr, 0, 0, 1, 1, batch).
+    //   * stride_ >= ld_ * cols, which the Matrix constructor does check. Two live call
+    //     sites violate it -- src/extensions/ortho.cc's transposed CGS view
+    //     `(A.data_ptr(), i, m, m, A.stride(), batch)`, where A is k x m with k <= m so
+    //     A.stride() is k*m against an ld*cols of m*m, and syevx_lobpcg's workspace-sizing
+    //     dummy `(p, 3*bv, 3*bv, 3*bv, 3*bv*bv, batch)`. Both look like real bugs in those
+    //     files, but a throw here would take out ortho and syevx_lobpcg_buffer_size, and
+    //     the check adds nothing against the trap this constructor is being hardened
+    //     against: for `V(p, n, n, batch)` the resolved stride equals ld * cols exactly.
+    const std::string prefix = "MatrixView(data, rows, cols, ld, stride, batch_size): ";
+    if (rows < 0 || cols < 0) {
+        throw std::invalid_argument(prefix + "invalid matrix dimensions " +
+                                    std::to_string(rows) + "x" + std::to_string(cols));
+    }
+    if (batch_size < 0) {
+        throw std::invalid_argument(prefix + "invalid batch size " + std::to_string(batch_size));
+    }
+    if (ld < 0) {
+        throw std::invalid_argument(prefix + "invalid leading dimension " + std::to_string(ld));
+    }
+    if (stride < 0) {
+        throw std::invalid_argument(prefix + "invalid stride " + std::to_string(stride));
+    }
+    if (ld_ < rows) {
+        throw std::invalid_argument(prefix + "leading dimension " + std::to_string(ld_) +
+                                    " is smaller than the row count " + std::to_string(rows) +
+                                    " (did you mean MatrixView(data, rows, cols, /*ld=*/" +
+                                    std::to_string(rows) + ", /*stride=*/0, /*batch_size=*/" +
+                                    std::to_string(ld_) + ")?)");
+    }
+}
 
 
 //----------------------------------------------------------------------
@@ -1933,7 +1988,9 @@ T& MatrixView<T, MType>::at(int row, int col, int batch) {
     if (row < 0 || row >= batch_rows || col < 0 || col >= batch_cols) {
         throw std::out_of_range("Matrix indices out of range");
     }
-    return data_[batch * stride_ + col * ld_ + row];
+    // The batch term in int64_t: batch * stride_ in int wraps at batch sizes this
+    // library targets (a 512x512 float item has stride 262144, so it wraps at b = 8192).
+    return data_[static_cast<int64_t>(batch) * stride_ + col * ld_ + row];
 }
 
 template <typename T, MatrixFormat MType>
@@ -1948,7 +2005,9 @@ const T& MatrixView<T, MType>::at(int row, int col, int batch) const {
     if (row < 0 || row >= batch_rows || col < 0 || col >= batch_cols) {
         throw std::out_of_range("Matrix indices out of range");
     }
-    return data_[batch * stride_ + col * ld_ + row];
+    // The batch term in int64_t: batch * stride_ in int wraps at batch sizes this
+    // library targets (a 512x512 float item has stride 262144, so it wraps at b = 8192).
+    return data_[static_cast<int64_t>(batch) * stride_ + col * ld_ + row];
 }
 
 // Create a view of a single batch item
@@ -1959,17 +2018,19 @@ MatrixView<T, MType> MatrixView<T, MType>::batch_item(int batch_index) const {
     }
     
     if constexpr (MType == MatrixFormat::Dense) {
-        // Calculate offset to the start of the batch
-        size_t offset = batch_index * stride_;
-        
+        // Calculate offset to the start of the batch. In int64_t, not int: the product is
+        // being widened to size_t anyway, and computing it in int wraps before the widening
+        // at batch sizes this library targets.
+        int64_t offset = static_cast<int64_t>(batch_index) * stride_;
+
         // Create a new view with batch_size = 1
         return MatrixView<T, MType>(
             data_.data() + offset,
             rows(batch_index), cols(batch_index), ld_);
     } else if constexpr (MType == MatrixFormat::CSR) {
-        // Calculate offsets to the start of the batch
-        size_t val_offset = batch_index * matrix_stride_;
-        size_t row_offset = batch_index * offset_stride_;
+        // Calculate offsets to the start of the batch (int64_t for the same reason).
+        int64_t val_offset = static_cast<int64_t>(batch_index) * matrix_stride_;
+        int64_t row_offset = static_cast<int64_t>(batch_index) * offset_stride_;
         
         // Create a new view with batch_size = 1, keeping the parent's strides so the
         // spans cover the slots this item actually owns.

--- a/src/sort.hh
+++ b/src/sort.hh
@@ -460,7 +460,7 @@ Event sort(Queue& ctx, const VectorView<T>& eigs, const MatrixView<T, MatrixForm
     // Ensure contiguous unit-inc views for argsort
     VectorView<T> eigs_unit = eigs;
     if (eigs.inc() != 1) {
-        auto tmp = Vector<T>(eigs.size(), eigs.batch_size(), eigs.size(), 1);
+        auto tmp = Vector<T>(eigs.size(), eigs.batch_size(), Stride{eigs.size()}, Inc{1});
         VectorView<T>::copy(ctx, tmp, eigs);
         eigs_unit = VectorView<T>(tmp);
     }

--- a/tests/gemm_tests.cc
+++ b/tests/gemm_tests.cc
@@ -462,7 +462,7 @@ TYPED_TEST(GemmTest, HeterogeneousBatchedGemmUsesPerItemActiveDimensions) {
         gemm(*(this->ctx), Ab, Bb, Cb, {.alpha = ScalarType(1), .beta = ScalarType(0)});
     }
 
-    gemm_heterogeneous(*(this->ctx), A.view(), B.view(), C.view(), ScalarType(1), ScalarType(0),
+    gemm(*(this->ctx), A.view(), B.view(), C.view(), ScalarType(1), ScalarType(0),
                                     Transpose::NoTrans, Transpose::NoTrans, ComputePrecision::Default);
 
     this->ctx->wait();
@@ -563,7 +563,7 @@ TYPED_TEST(GemmTest, HeterogeneousBatchedGemmZeroInnerDimensionScalesCByBeta) {
         gemm(*(this->ctx), Ab, Bb, Cb, {.alpha = alpha, .beta = beta});
     }
 
-    gemm_heterogeneous(*(this->ctx), A.view(), B.view(), C.view(), alpha, beta,
+    gemm(*(this->ctx), A.view(), B.view(), C.view(), alpha, beta,
                                     Transpose::NoTrans, Transpose::NoTrans, ComputePrecision::Default);
 
     this->ctx->wait();
@@ -642,13 +642,13 @@ TYPED_TEST(GemmTest, HeterogeneousBatchedGemmForcedCuBLASDxVariant) {
     {
         ScopedEnvVar force_variant("BATCHLAS_GEMM_VARIANT", "cublasdx");
         ScopedEnvVar force_kernel("BATCHLAS_GEMM_CUBLASDX_KERNEL", "cublasdx_nn");
-        gemm_heterogeneous(*(this->ctx), A.view(), B.view(), C.view(), ScalarType(1), ScalarType(1),
+        gemm(*(this->ctx), A.view(), B.view(), C.view(), ScalarType(1), ScalarType(1),
                                         Transpose::NoTrans, Transpose::NoTrans, ComputePrecision::Default);
     }
 
     {
         ScopedEnvVar vendor_variant("BATCHLAS_GEMM_VARIANT", "vendor");
-        gemm_heterogeneous(*(this->ctx), A.view(), B.view(), C_ref.view(), ScalarType(1), ScalarType(1),
+        gemm(*(this->ctx), A.view(), B.view(), C_ref.view(), ScalarType(1), ScalarType(1),
                                         Transpose::NoTrans, Transpose::NoTrans, ComputePrecision::Default);
     }
 

--- a/tests/linalg_layer_tests.cc
+++ b/tests/linalg_layer_tests.cc
@@ -331,7 +331,58 @@ Matrix<float, MatrixFormat::Dense> spd(int n, int batch) {
     linalg::subtract_into(ctx, A, B, C);
     linalg::multiply_into(ctx, A, B, C);
     linalg::divide_into(ctx, A, B, C);
+
+    // "The linalg convenience layer" -- the rest of the layer
+    [[maybe_unused]] auto svd_result = linalg::svd(ctx, A);
+    [[maybe_unused]] auto lu_result = linalg::lu(ctx, A);
+    [[maybe_unused]] auto inverse = linalg::inv(ctx, A);
+    [[maybe_unused]] auto transposed = linalg::transpose(ctx, A);
+    [[maybe_unused]] auto norms = linalg::norm(ctx, A);
+    [[maybe_unused]] auto conds = linalg::cond(ctx, A);
+    [[maybe_unused]] auto upper = linalg::triu(ctx, A);
+    [[maybe_unused]] auto strict_lower = linalg::tril(ctx, A, -1);
+    linalg::matmul(ctx, A, B, {.alpha = 2.0f});
 }
+
+// What the layer must NOT accept. Each of these is spelled as a concept rather
+// than a bare `!requires(...)` in the static_assert: a requires-expression only
+// swallows errors that come from template substitution, so an ill-formed call
+// written with concrete types in a non-template context is a hard error and the
+// guard would fail to compile instead of passing.
+template <typename T>
+concept MatmulOptionsHasBeta = requires(linalg::MatmulOptions<T> o) { o.beta; };
+
+template <typename T>
+concept HasLinalgTranspose = requires(Queue& ctx, const MatrixView<T, MatrixFormat::Dense>& A) {
+    linalg::transpose(ctx, A);
+};
+
+template <typename T>
+concept HasLinalgCond = requires(Queue& ctx, const MatrixView<T, MatrixFormat::Dense>& A) {
+    linalg::cond(ctx, A);
+};
+
+template <typename T>
+concept MatmulTakesOptionList = requires(Queue& ctx, const MatrixView<T, MatrixFormat::Dense>& A) {
+    linalg::matmul(ctx, A, A, {.alpha = T(2)});
+};
+
+// matmul allocates its result, so beta has no meaning: it used to be spellable
+// through GemmOptions and silently discarded.
+static_assert(!MatmulOptionsHasBeta<float>,
+              "MatmulOptions must not carry a beta: matmul allocates its result");
+static_assert(MatmulTakesOptionList<float>,
+              "matmul must still accept a designated-initialiser option list");
+
+// transpose and cond are constrained to real scalars because the entry points
+// behind them are instantiated for real scalars only. Without the constraint
+// these calls would compile and fail at link time.
+static_assert(HasLinalgTranspose<float> && HasLinalgTranspose<double>);
+static_assert(!HasLinalgTranspose<std::complex<float>>,
+              "complex transpose must be rejected: transpose_impl does not conjugate");
+static_assert(HasLinalgCond<float> && HasLinalgCond<double>);
+static_assert(!HasLinalgCond<std::complex<float>>,
+              "complex cond must be rejected: there is no complex instantiation behind it");
 
 }  // namespace
 
@@ -442,6 +493,10 @@ TEST(LinalgLayer, ValueReturningWrappersLeaveInputsAlone) {
     auto L = linalg::cholesky(q, A.view());
     auto w = linalg::eigvalsh(q, A.view());
     auto e = linalg::eigh(q, A.view());
+    auto s = linalg::svd(q, A.view());
+    auto f = linalg::lu(q, A.view());
+    auto Ai = linalg::inv(q, A.view());
+    auto up = linalg::triu(q, A.view());
     q.wait();
 
     size_t k = 0;
@@ -530,4 +585,204 @@ TEST(LinalgLayer, RepeatedCallsDoNotGrowTheArena) {
         q.wait();
     }
     EXPECT_EQ(q.workspace_capacity(), settled);
+}
+
+// alpha is matmul's only scalar knob now that beta is gone, and nothing else
+// exercises it.
+TEST(LinalgLayer, MatmulAlphaScalesTheProduct) {
+    Queue q;
+    const int n = 4, batch = 2;
+    auto A = from_fn(n, n, batch, [](int i, int j, int b) { return float(1 + i + 2 * j + b); });
+    auto B = from_fn(n, n, batch, [](int i, int j, int) { return float(j - i + 3); });
+
+    auto plain = linalg::matmul(q, A.view(), B.view());
+    auto scaled_product = linalg::matmul(q, A.view(), B.view(), {.alpha = 2.0f});
+    auto transposed = linalg::matmul(q, A.view(), B.view(), {.transA = Transpose::Trans});
+    q.wait();
+
+    for (int b = 0; b < batch; ++b)
+        for (int j = 0; j < n; ++j)
+            for (int i = 0; i < n; ++i) {
+                ASSERT_NEAR(at(scaled_product.view(), i, j, b),
+                            2.0f * at(plain.view(), i, j, b), 1e-3f)
+                    << "alpha at (" << i << "," << j << ") batch " << b;
+                float acc = 0.0f;
+                for (int k = 0; k < n; ++k) acc += at(A.view(), k, i, b) * at(B.view(), k, j, b);
+                ASSERT_NEAR(at(transposed.view(), i, j, b), acc, 1e-3f)
+                    << "transA at (" << i << "," << j << ") batch " << b;
+            }
+}
+
+// triu/tril mask an existing matrix; fill_triangular generates one. The k
+// offsets follow NumPy, and the negative-k case is the one an unsigned diagonal
+// difference would get wrong.
+TEST(LinalgLayer, TriuTrilMaskAnExistingMatrix) {
+    Queue q;
+    const int rows = 5, cols = 7, batch = 2;  // rectangular, so row/col are not interchangeable
+    auto A = from_fn(rows, cols, batch,
+                     [](int i, int j, int b) { return float(1 + i + 10 * j + 100 * b); });
+
+    auto u0 = linalg::triu(q, A.view());
+    auto u2 = linalg::triu(q, A.view(), 2);
+    auto l0 = linalg::tril(q, A.view());
+    auto lm1 = linalg::tril(q, A.view(), -1);
+    q.wait();
+
+    for (int b = 0; b < batch; ++b)
+        for (int j = 0; j < cols; ++j)
+            for (int i = 0; i < rows; ++i) {
+                const float a = at(A.view(), i, j, b);
+                const int d = j - i;
+                ASSERT_FLOAT_EQ(at(u0.view(), i, j, b), d >= 0 ? a : 0.0f) << "triu " << i << "," << j;
+                ASSERT_FLOAT_EQ(at(u2.view(), i, j, b), d >= 2 ? a : 0.0f) << "triu2 " << i << "," << j;
+                ASSERT_FLOAT_EQ(at(l0.view(), i, j, b), d <= 0 ? a : 0.0f) << "tril " << i << "," << j;
+                ASSERT_FLOAT_EQ(at(lm1.view(), i, j, b), d <= -1 ? a : 0.0f) << "tril-1 " << i << "," << j;
+            }
+
+    // Aliasing: the documented in-place spelling.
+    linalg::triangular_mask_into<float>(q, A.view(), A.view(), Uplo::Upper, 0);
+    q.wait();
+    for (int b = 0; b < batch; ++b)
+        for (int j = 0; j < cols; ++j)
+            for (int i = 0; i < rows; ++i)
+                ASSERT_FLOAT_EQ(at(A.view(), i, j, b), at(u0.view(), i, j, b))
+                    << "in place " << i << "," << j;
+}
+
+TEST(LinalgLayer, TriangularMaskRejectsMismatchedShapes) {
+    Queue q;
+    auto A = from_fn(4, 4, 1, [](int, int, int) { return 1.0f; });
+    auto C = from_fn(4, 5, 1, [](int, int, int) { return 1.0f; });
+    EXPECT_THROW(linalg::triangular_mask_into<float>(q, A.view(), C.view(), Uplo::Upper, 0),
+                 std::invalid_argument);
+}
+
+TEST(LinalgLayer, InvReproducesTheIdentity) {
+    Queue q;
+    const int n = 8, batch = 2;
+    auto A = spd(n, batch);
+    auto Ai = linalg::inv(q, A.view());
+    q.wait();
+    auto I = linalg::matmul(q, A.view(), Ai.view());
+    q.wait();
+
+    for (int b = 0; b < batch; ++b)
+        for (int j = 0; j < n; ++j)
+            for (int i = 0; i < n; ++i)
+                ASSERT_NEAR(at(I.view(), i, j, b), i == j ? 1.0f : 0.0f, 1e-3f)
+                    << "A A^-1 at (" << i << "," << j << ") batch " << b;
+}
+
+TEST(LinalgLayer, TransposeSwapsExtentsAndElements) {
+    Queue q;
+    const int rows = 3, cols = 5, batch = 2;
+    auto A = from_fn(rows, cols, batch,
+                     [](int i, int j, int b) { return float(1 + i + 7 * j + 50 * b); });
+    auto At = linalg::transpose(q, A.view());
+    q.wait();
+
+    ASSERT_EQ(At.view().rows(), cols);
+    ASSERT_EQ(At.view().cols(), rows);
+    for (int b = 0; b < batch; ++b)
+        for (int j = 0; j < cols; ++j)
+            for (int i = 0; i < rows; ++i)
+                ASSERT_FLOAT_EQ(at(At.view(), j, i, b), at(A.view(), i, j, b));
+}
+
+// norm returns one value per batch item. Unlike the rest of the layer it has
+// already waited by the time it returns.
+TEST(LinalgLayer, NormMatchesTheHostFrobeniusNorm) {
+    Queue q;
+    const int rows = 4, cols = 3, batch = 3;
+    auto A = from_fn(rows, cols, batch, [](int i, int j, int b) { return float(i - 2 * j + b); });
+    auto n = linalg::norm(q, A.view());
+
+    ASSERT_EQ(n.size(), size_t(batch));
+    for (int b = 0; b < batch; ++b) {
+        double acc = 0.0;
+        for (int j = 0; j < cols; ++j)
+            for (int i = 0; i < rows; ++i) {
+                const double v = at(A.view(), i, j, b);
+                acc += v * v;
+            }
+        ASSERT_NEAR(n[b], float(std::sqrt(acc)), 1e-3f) << "batch " << b;
+    }
+}
+
+// cond on a diagonal matrix has a closed form: the Frobenius condition number is
+// ||A||_F ||A^-1||_F, and both factors are exact for a diagonal.
+TEST(LinalgLayer, CondMatchesTheDiagonalReference) {
+    Queue q;
+    const int n = 4, batch = 2;
+    const float d[n] = {1.0f, 2.0f, 4.0f, 8.0f};
+    auto A = from_fn(n, n, batch, [&](int i, int j, int) { return i == j ? d[i] : 0.0f; });
+    auto k = linalg::cond(q, A.view());
+
+    double a2 = 0.0, ai2 = 0.0;
+    for (int i = 0; i < n; ++i) {
+        a2 += double(d[i]) * d[i];
+        ai2 += 1.0 / (double(d[i]) * d[i]);
+    }
+    const float expected = float(std::sqrt(a2) * std::sqrt(ai2));
+    ASSERT_EQ(k.size(), size_t(batch));
+    for (int b = 0; b < batch; ++b) ASSERT_NEAR(k[b], expected, 1e-2f) << "batch " << b;
+}
+
+// The factors and the pivots are checked together, by solving with them: the
+// pivot convention (base, and whether the entries are interchanges or a
+// permutation) is a backend detail this layer does not promise.
+TEST(LinalgLayer, LuFactorsAndPivotsSolveTheSystem) {
+    Queue q;
+    const int n = 8, nrhs = 2, batch = 2;
+    auto A = spd(n, batch);
+    auto B = from_fn(n, nrhs, batch, [](int i, int j, int b) { return float(1 + i - j + b); });
+
+    auto f = linalg::lu(q, A.view());
+    ASSERT_EQ(f.pivots.size(), size_t(n) * size_t(batch));
+
+    Matrix<float, MatrixFormat::Dense> X(n, nrhs, batch);
+    MatrixView<float, MatrixFormat::Dense>::copy(q, X.view(), B.view());
+    getrs(q, f.factors.view(), X.view(), f.pivots.to_span());
+    q.wait();
+
+    auto AX = linalg::matmul(q, A.view(), X.view());
+    q.wait();
+    for (int b = 0; b < batch; ++b)
+        for (int j = 0; j < nrhs; ++j)
+            for (int i = 0; i < n; ++i)
+                ASSERT_NEAR(at(AX.view(), i, j, b), at(B.view(), i, j, b), 1e-2f)
+                    << "A X != B at (" << i << "," << j << ") batch " << b;
+}
+
+// U diag(S) Vh == A, on a square well-conditioned input.
+TEST(LinalgLayer, SvdReconstructsInput) {
+    Queue q;
+    const int n = 6, batch = 2;
+    auto A = spd(n, batch);
+
+    auto s = linalg::svd(q, A.view());
+    q.wait();
+
+    ASSERT_EQ(s.U.view().rows(), n);
+    ASSERT_EQ(s.U.view().cols(), n);
+    ASSERT_EQ(s.Vh.view().rows(), n);
+    ASSERT_EQ(s.Vh.view().cols(), n);
+    ASSERT_EQ(s.values.size(), size_t(n) * size_t(batch));
+
+    for (int b = 0; b < batch; ++b)
+        for (int j = 0; j < n; ++j)
+            for (int i = 0; i < n; ++i) {
+                float acc = 0.0f;
+                for (int k = 0; k < n; ++k)
+                    acc += at(s.U.view(), i, k, b) * s.values[b * n + k] *
+                           at(s.Vh.view(), k, j, b);
+                ASSERT_NEAR(acc, at(A.view(), i, j, b), 1e-2f)
+                    << "U S Vh != A at (" << i << "," << j << ") batch " << b;
+            }
+}
+
+TEST(LinalgLayer, SvdRejectsTheVectorlessJob) {
+    Queue q;
+    auto A = spd(4, 1);
+    EXPECT_THROW(linalg::svd(q, A.view(), SvdVectors::None), std::invalid_argument);
 }

--- a/tests/linalg_layer_tests.cc
+++ b/tests/linalg_layer_tests.cc
@@ -114,8 +114,9 @@ Matrix<float, MatrixFormat::Dense> spd(int n, int batch) {
         Vector<float> x(n, /*batch_size=*/batch), y(m, batch);
         gemv(ctx, A, x.view(), y.view(), {.alpha = 1.0f});
 
-        // The inc/stride argument orders are opposite, and the document says so.
-        [[maybe_unused]] Vector<float> v(n, /*batch_size=*/batch, /*stride=*/n, /*inc=*/1);
+        // The inc/stride argument orders are opposite. Vector now names both with tag
+        // types, so the two spellings can no longer be transliterated into each other.
+        [[maybe_unused]] Vector<float> v(n, /*batch_size=*/batch, Stride{n}, Inc{1});
         [[maybe_unused]] VectorView<float> vv(x.view().data_ptr(), n, /*batch_size=*/batch,
                                               /*inc=*/1, /*stride=*/n);
         [[maybe_unused]] auto vz = Vector<float>::zeros(n, batch);

--- a/tests/matrix_tests.cc
+++ b/tests/matrix_tests.cc
@@ -514,6 +514,99 @@ static_assert(!std::is_convertible_v<NonZeros, int>, "NonZeros must not decay to
 static_assert(std::is_trivially_copyable_v<NonZeros>);
 static_assert(NonZeros{7}.value == 7);
 
+// The layout tags get the same treatment. If either of these ever decays back to int the
+// Vector/VectorView inc-stride swap becomes writable again, silently.
+static_assert(!std::is_convertible_v<int, Inc>, "Inc must be explicit");
+static_assert(!std::is_convertible_v<Inc, int>, "Inc must not decay to int");
+static_assert(!std::is_convertible_v<int, Stride>, "Stride must be explicit");
+static_assert(!std::is_convertible_v<Stride, int>, "Stride must not decay to int");
+static_assert(!std::is_convertible_v<int, Ld>, "Ld must be explicit");
+static_assert(!std::is_convertible_v<Ld, int>, "Ld must not decay to int");
+static_assert(!std::is_convertible_v<int, BatchSize>, "BatchSize must be explicit");
+static_assert(!std::is_convertible_v<BatchSize, int>, "BatchSize must not decay to int");
+static_assert(Stride{7}.value == 7 && Inc{3}.value == 3);
+
+// Vector's four-argument spelling now names stride and inc; the bare-int order it used to
+// accept -- the one that transliterates into VectorView's opposite order -- is deleted.
+static_assert(!std::is_constructible_v<Vector<float>, int, int, int, int>,
+              "Vector(size, batch, stride, inc) with bare ints must not compile");
+static_assert(std::is_constructible_v<Vector<float>, int, int, Stride, Inc>,
+              "Vector(size, batch, Stride, Inc) must compile");
+static_assert(std::is_constructible_v<Vector<float>, int, int>,
+              "the two-argument Vector(size, batch) spelling must keep working");
+// VectorView keeps its positional constructors (138 correct call sites) and gains tagged
+// ones alongside them.
+static_assert(std::is_constructible_v<VectorView<float>, float*, int, int, int, int>,
+              "VectorView's positional constructor must keep working");
+static_assert(std::is_constructible_v<VectorView<float>, float*, int, int, Inc, Stride>,
+              "VectorView must accept the tagged spelling");
+
+TEST(VectorLayoutTagTest, TaggedArgumentsLandInTheRightFields) {
+    constexpr int size = 5, batch = 3, stride = 7, inc = 2;
+    // stride and inc deliberately distinct and non-default, so a swap changes an
+    // observable number rather than landing on an equal one.
+    Vector<float> v(size, batch, Stride{stride}, Inc{inc});
+    EXPECT_EQ(v.size(), size);
+    EXPECT_EQ(v.batch_size(), batch);
+    EXPECT_EQ(v.stride(), stride);
+    EXPECT_EQ(v.inc(), inc);
+
+    // The view spelled with the tags means the same layout, even though its positional
+    // order is the reverse of Vector's.
+    VectorView<float> view(v.data_ptr(), size, batch, Inc{inc}, Stride{stride});
+    EXPECT_EQ(view.stride(), stride);
+    EXPECT_EQ(view.inc(), inc);
+
+    auto z = Vector<float>::zeros(size, batch, Stride{stride}, Inc{inc});
+    EXPECT_EQ(z.stride(), stride);
+    EXPECT_EQ(z.inc(), inc);
+    EXPECT_EQ(Vector<float>::zeros(size, batch).stride(), size);
+    EXPECT_EQ(Vector<float>::zeros(size, batch).inc(), 1);
+}
+
+TEST(MatrixViewTrapTest, LeadingDimensionSmallerThanRowsThrows) {
+    // The trap this guards: MatrixView takes (data, rows, cols, ld, stride, batch_size)
+    // while Matrix takes (rows, cols, batch_size, ld, stride), so a caller who learned the
+    // order from Matrix writes the batch count into ld. It used to be accepted silently.
+    constexpr int n = 8, batch = 2;
+    std::vector<float> buffer(static_cast<size_t>(n) * n * batch, 0.0f);
+    EXPECT_THROW((MatrixView<float, MatrixFormat::Dense>(buffer.data(), n, n, batch)),
+                 std::invalid_argument);
+    // The spelling the error message names must be accepted.
+    EXPECT_NO_THROW((MatrixView<float, MatrixFormat::Dense>(buffer.data(), n, n, n, 0, batch)));
+    // And the innocent shorthands must stay innocent: a shape-only stand-in for a
+    // workspace query, and the three-argument spelling.
+    EXPECT_NO_THROW((MatrixView<float, MatrixFormat::Dense>(nullptr, 0, 0, 1, 1, batch)));
+    EXPECT_NO_THROW((MatrixView<float, MatrixFormat::Dense>(buffer.data(), n, n)));
+}
+
+TEST(MatrixCSRTest, ConvertToSeparatesPerItemCountFromCapacity) {
+    // A heterogeneous batch is the normal result of a dense -> CSR conversion, and the
+    // conversion sizes the whole batch by its largest item. nnz() is that capacity;
+    // nnz(b) is what item b actually stored.
+    constexpr int n = 4, batch = 2;
+    Matrix<float, MatrixFormat::Dense> dense(n, n, batch);
+    std::fill(dense.data().begin(), dense.data().end(), 0.0f);
+
+    // Item 0: three non-zeros. Item 1: six.
+    dense(0, 0, 0) = 1.0f; dense(1, 2, 0) = 2.0f; dense(3, 3, 0) = 3.0f;
+    for (int i = 0; i < 3; ++i) { dense(i, i, 1) = 1.0f; dense(i, i + 1, 1) = 2.0f; }
+    constexpr int nnz0 = 3, nnz1 = 6;
+
+    auto csr = dense.convert_to<MatrixFormat::CSR>();
+    EXPECT_EQ(csr.nnz(), std::max(nnz0, nnz1));      // capacity, the batch maximum
+    EXPECT_EQ(csr.nnz_capacity(), std::max(nnz0, nnz1));
+    EXPECT_EQ(csr.nnz(0), nnz0);                     // what item 0 actually stored
+    EXPECT_EQ(csr.nnz(1), nnz1);
+
+    // Regression guard: the scan writes offsets 1..rows of each item and never element 0,
+    // and the allocation does not zero, so this used to be uninitialised memory -- which
+    // is exactly what nnz(b) subtracts.
+    for (int b = 0; b < batch; ++b) {
+        EXPECT_EQ(csr.row_offsets()[static_cast<size_t>(b) * csr.offset_stride()], 0);
+    }
+}
+
 TEST(MatrixCSRTest, NonZerosSpellingAllocatesAndRoundTrips) {
     // rows/cols/nnz/batch deliberately all distinct, so a swapped argument would
     // change an observable number rather than land on an equal one.

--- a/tests/options_api_tests.cc
+++ b/tests/options_api_tests.cc
@@ -444,6 +444,154 @@ static_assert(!std::is_convertible_v<Uplo, detail::EmptyBracesAreAmbiguous>,
               "Uplo must not convert to the trap type, or the positional "
               "spelling would become ambiguous too");
 
+// ---------------------------------------------------------------------------
+// Per-item factorisation status (issue #73).
+//
+// potrf, getrf and getri all had somewhere to put LAPACK's `info` -- every
+// backend allocated the array the vendor call demands -- and every backend then
+// dropped it. A batch containing one rank-deficient item returned an ordinary
+// Event, no throw and no flag, so the caller could not tell "the batch
+// factorised" from "item 1 is garbage and everything downstream of it is noise".
+// There was no workaround at the public API.
+//
+// The batches below are deliberately mixed: item 0 is well-conditioned and item
+// 1 is not, so the test fails both if status is never reported (bad item reads
+// 0) and if it is reported indiscriminately (good item reads non-zero). The
+// `info` buffers start at a sentinel rather than 0, because 0 is the success
+// value -- a buffer the backend never touched would otherwise look like "all
+// items factorised", which is exactly the bug.
+//
+// Values are asserted only as zero / non-zero. LAPACK, cuSOLVER, cuBLAS and
+// rocSOLVER agree on the sign convention but not always on which index they
+// name first, and the API's contract is the zero/non-zero distinction.
+// ---------------------------------------------------------------------------
+namespace {
+
+// Item 0: diagonally dominant, so Cholesky succeeds. Item 1: the negative of
+// it, so the very first leading minor is not positive definite.
+Matrix<float, MatrixFormat::Dense> spd_then_negative_definite(int n) {
+    Matrix<float, MatrixFormat::Dense> m(n, n, 2);
+    auto v = m.view();
+    for (int b = 0; b < 2; ++b) {
+        const float sign = (b == 0) ? 1.0f : -1.0f;
+        for (int j = 0; j < n; ++j)
+            for (int i = 0; i < n; ++i)
+                v.data_ptr()[b * v.stride() + j * v.ld() + i] =
+                    sign * ((i == j) ? float(n + 2) : 0.25f);
+    }
+    return m;
+}
+
+// Item 0: a well-conditioned diagonal. Item 1: all zeros, so the first pivot is
+// exactly zero and U is singular.
+Matrix<float, MatrixFormat::Dense> nonsingular_then_singular(int n) {
+    Matrix<float, MatrixFormat::Dense> m(n, n, 2);
+    auto v = m.view();
+    for (int b = 0; b < 2; ++b)
+        for (int j = 0; j < n; ++j)
+            for (int i = 0; i < n; ++i)
+                v.data_ptr()[b * v.stride() + j * v.ld() + i] =
+                    (b == 1) ? 0.0f : ((i == j) ? float(i + 2) : 0.5f);
+    return m;
+}
+
+constexpr int32_t kNeverWritten = -12345;
+
+}  // namespace
+
+TEST(OptionsApi, FactorisationsReportPerItemStatus) {
+    Queue q;
+    constexpr int n = 8;
+    constexpr int batch = 2;
+
+    {   // potrf: item 1 is not positive definite
+        auto A = spd_then_negative_definite(n);
+        UnifiedVector<int32_t> info(batch, kNeverWritten);
+        potrf(q, A.view(), {.uplo = Uplo::Lower, .info = info.to_span()});
+        q.wait();
+        EXPECT_EQ(info[0], 0) << "potrf reported failure on a positive definite item";
+        EXPECT_NE(info[0], kNeverWritten) << "potrf never wrote info at all";
+        EXPECT_GT(info[1], 0) << "potrf did not report the indefinite item";
+    }
+
+    {   // getrf: item 1 is singular
+        auto A = nonsingular_then_singular(n);
+        UnifiedVector<int64_t> pivots(static_cast<size_t>(n) * batch);
+        UnifiedVector<int32_t> info(batch, kNeverWritten);
+        getrf(q, A.view(), pivots.to_span(), info.to_span());
+        q.wait();
+        EXPECT_EQ(info[0], 0) << "getrf reported failure on a nonsingular item";
+        EXPECT_NE(info[0], kNeverWritten) << "getrf never wrote info at all";
+        EXPECT_GT(info[1], 0) << "getrf did not report the singular item";
+    }
+
+    {   // getri: same batch, inverted from its own LU
+        auto A = nonsingular_then_singular(n);
+        Matrix<float, MatrixFormat::Dense> Ainv(n, n, batch);
+        UnifiedVector<int64_t> pivots(static_cast<size_t>(n) * batch);
+        UnifiedVector<int32_t> info(batch, kNeverWritten);
+        getrf(q, A.view(), pivots.to_span());
+        getri(q, A.view(), Ainv.view(), pivots.to_span(), info.to_span());
+        q.wait();
+        EXPECT_EQ(info[0], 0) << "getri reported failure on an invertible item";
+        EXPECT_NE(info[0], kNeverWritten) << "getri never wrote info at all";
+        EXPECT_GT(info[1], 0) << "getri did not report the singular item";
+    }
+}
+
+// The whole change is additive, so the spellings that existed before must still
+// compile and still run. If `info` had been made a required parameter -- or a
+// defaulted one on a signature the sig:: aliases have to restate, which function
+// types cannot carry -- every one of these would have broken instead.
+TEST(OptionsApi, FactorisationsStillWorkWithoutAnInfoSpan) {
+    Queue q;
+    constexpr int n = 8;
+    constexpr int batch = 2;
+
+    auto A = spd(n, batch);
+    potrf(q, A.view(), {.uplo = Uplo::Lower});
+    auto Aw = spd(n, batch);
+    with_backend(q, [&](auto Back) {
+        constexpr Backend Bk = Back.value;
+        auto ws = q.workspace(potrf_buffer_size<Bk, float>(q, Aw.view(), Uplo::Lower));
+        // The four-argument positional spelling: the arity that had to survive.
+        potrf<Bk, float>(q, Aw.view(), Uplo::Lower, ws.span());
+    });
+
+    auto B = nonsingular_then_singular(n);
+    UnifiedVector<int64_t> pivots(static_cast<size_t>(n) * batch);
+    getrf(q, B.view(), pivots.to_span());
+
+    Matrix<float, MatrixFormat::Dense> Binv(n, n, batch);
+    getri(q, B.view(), Binv.view(), pivots.to_span());
+    q.wait();
+    SUCCEED();
+}
+
+// An `info` span shorter than the batch is rejected up front rather than
+// silently ignored. That direction matters more than it looks: a backend handed
+// a short span falls back to its own scratch and writes nothing to the caller's
+// buffer, so the caller would read stale zeros -- "every item factorised" -- on
+// precisely the batch it was trying to diagnose. An EMPTY span stays legal; it
+// is the API's spelling for "do not report".
+TEST(OptionsApi, ShortInfoSpanIsRejected) {
+    Queue q;
+    constexpr int n = 8;
+    constexpr int batch = 4;
+
+    auto A = spd(n, batch);
+    UnifiedVector<int32_t> too_short(batch - 1, 0);
+    EXPECT_THROW(potrf(q, A.view(), {.uplo = Uplo::Lower, .info = too_short.to_span()}),
+                 std::invalid_argument);
+
+    UnifiedVector<int64_t> pivots(static_cast<size_t>(n) * batch);
+    EXPECT_THROW(getrf(q, A.view(), pivots.to_span(), too_short.to_span()),
+                 std::invalid_argument);
+
+    EXPECT_NO_THROW(potrf(q, A.view(), {.uplo = Uplo::Lower, .info = Span<int32_t>{}}));
+    q.wait();
+}
+
 // The USM contract used to be documented and unenforced: handing ordinary host
 // memory to a GPU queue reached the device as a wild address and aborted the
 // process from inside the SYCL runtime during teardown, where no catch block

--- a/tests/options_api_tests.cc
+++ b/tests/options_api_tests.cc
@@ -232,8 +232,8 @@ TEST(OptionsApi, Blas3OptionsMatchPositional) {
         auto Bp = filled(n, batch, 0.6f);
         auto Tri = spd(n, batch);
         trsm(q, Tri.view(), Bo.view(), {.alpha = 1.0f, .diag = Diag::NonUnit});
-        trsm(q, Tri.view(), Bp.view(), Side::Left, Uplo::Lower, Transpose::NoTrans,
-             Diag::NonUnit, 1.0f);
+        trsm(q, Tri.view(), Bp.view(), 1.0f, Side::Left, Uplo::Lower, Transpose::NoTrans,
+             Diag::NonUnit);
         q.wait();
         expect_same(Bo.view(), Bp.view(), n, batch, "trsm");
     }

--- a/tests/ritz_values_tests.cc
+++ b/tests/ritz_values_tests.cc
@@ -69,7 +69,7 @@ TYPED_TEST(RitzValuesTest, DiagonalMatrix) {
     Vector<RealType> ritz_vals(k, batch);
     
     // Compute workspace size and allocate
-    size_t workspace_size = ritz_values_workspace<BackendType, ScalarType, MatrixFormat::Dense>(
+    size_t workspace_size = ritz_values_buffer_size<BackendType, ScalarType, MatrixFormat::Dense>(
         *(this->ctx), A, V, ritz_vals);
     UnifiedVector<std::byte> workspace(workspace_size);
     
@@ -129,7 +129,7 @@ TYPED_TEST(RitzValuesTest, TridiagonalMatrix) {
     Vector<RealType> ritz_vals(k, batch);
     
     // Compute workspace size and allocate
-    size_t workspace_size = ritz_values_workspace<BackendType, ScalarType, MatrixFormat::Dense>(
+    size_t workspace_size = ritz_values_buffer_size<BackendType, ScalarType, MatrixFormat::Dense>(
         *(this->ctx), A, V, ritz_vals);
     UnifiedVector<std::byte> workspace(workspace_size);
     

--- a/tests/stedc_tests.cc
+++ b/tests/stedc_tests.cc
@@ -98,7 +98,7 @@ TYPED_TEST(StedcTest, BatchedMatrices) {
     auto eigvects = Matrix<float_type>::Identity(n, batch);
     StedcParams<float_type> params= {.recursion_threshold = 32};
 
-    UnifiedVector<std::byte> ws(stedc_workspace_size(*this->ctx, n, batch, JobType::EigenVectors, params));
+    UnifiedVector<std::byte> ws(stedc_buffer_size(*this->ctx, n, batch, JobType::EigenVectors, params));
 
     stedc(*this->ctx, a.view(), b.view(), eigvals.view(),
                       ws, JobType::EigenVectors, params, eigvects.view());
@@ -144,7 +144,7 @@ TYPED_TEST(StedcTest, BatchedRandomMatrices) {
     auto eigvects = Matrix<float_type>::Identity(n, batch);
     StedcParams<float_type> params= {.recursion_threshold = 16};
 
-    UnifiedVector<std::byte> ws(stedc_workspace_size(*this->ctx, n, batch, JobType::EigenVectors, params));
+    UnifiedVector<std::byte> ws(stedc_buffer_size(*this->ctx, n, batch, JobType::EigenVectors, params));
 
     Matrix<float_type> reconstructed = Matrix<float_type>::Zeros(n, n, batch);
     reconstructed.view().fill_tridiag(*this->ctx, b, a, b).wait();
@@ -234,8 +234,8 @@ TYPED_TEST(StedcTest, LevelsMatchesRecursive) {
         auto eigvecs_rec = Matrix<float_type>::Identity(n, batch);
         auto eigvecs_lvl = Matrix<float_type>::Identity(n, batch);
 
-        UnifiedVector<std::byte> ws_rec(stedc_workspace_size(*this->ctx, n, batch, JobType::EigenVectors, params_rec));
-        UnifiedVector<std::byte> ws_lvl(stedc_workspace_size(*this->ctx, n, batch, JobType::EigenVectors, params_lvl));
+        UnifiedVector<std::byte> ws_rec(stedc_buffer_size(*this->ctx, n, batch, JobType::EigenVectors, params_rec));
+        UnifiedVector<std::byte> ws_lvl(stedc_buffer_size(*this->ctx, n, batch, JobType::EigenVectors, params_lvl));
 
         stedc(*this->ctx, a_rec.view(), b_rec.view(), eigvals_rec.view(), ws_rec, JobType::EigenVectors, params_rec, eigvecs_rec.view());
         stedc(*this->ctx, a_lvl.view(), b_lvl.view(), eigvals_lvl.view(), ws_lvl, JobType::EigenVectors, params_lvl, eigvecs_lvl.view());
@@ -293,8 +293,8 @@ TYPED_TEST(StedcTest, FusedMergeMatchesBaseline) {
         .enable_rescale = true,
     };
 
-    UnifiedVector<std::byte> ws_base(stedc_workspace_size(*this->ctx, n, batch, JobType::EigenVectors, params_base));
-    UnifiedVector<std::byte> ws_fused(stedc_workspace_size(*this->ctx, n, batch, JobType::EigenVectors, params_fused));
+    UnifiedVector<std::byte> ws_base(stedc_buffer_size(*this->ctx, n, batch, JobType::EigenVectors, params_base));
+    UnifiedVector<std::byte> ws_fused(stedc_buffer_size(*this->ctx, n, batch, JobType::EigenVectors, params_fused));
 
     stedc(*this->ctx, a_base.view(), b_base.view(), eigvals_base.view(), ws_base, JobType::EigenVectors, params_base, eigvecs_base.view());
     stedc(*this->ctx, a_fused.view(), b_fused.view(), eigvals_fused.view(), ws_fused, JobType::EigenVectors, params_fused, eigvecs_fused.view());
@@ -339,7 +339,7 @@ TYPED_TEST(StedcTest, FusedCtaMergeMatchesReference) {
         .secular_threads_per_root = 32,
     };
 
-    UnifiedVector<std::byte> ws_cta(stedc_workspace_size(*this->ctx, n, batch, JobType::EigenVectors, params_cta));
+    UnifiedVector<std::byte> ws_cta(stedc_buffer_size(*this->ctx, n, batch, JobType::EigenVectors, params_cta));
     stedc(*this->ctx, a_cta.view(), b_cta.view(), eigvals_cta.view(), ws_cta, JobType::EigenVectors, params_cta, eigvecs_cta.view());
     this->ctx->wait();
 
@@ -412,7 +412,7 @@ TYPED_TEST(StedcTest, FusedCtaConditionedHeavyDeflation) {
                 .secular_threads_per_root = P,
             };
 
-            UnifiedVector<std::byte> ws(stedc_workspace_size(*this->ctx, n, batch, JobType::EigenVectors, params));
+            UnifiedVector<std::byte> ws(stedc_buffer_size(*this->ctx, n, batch, JobType::EigenVectors, params));
             stedc(*this->ctx, a_cta.view(), b_cta.view(), eigvals.view(), ws, JobType::EigenVectors, params, eigvecs.view());
             this->ctx->wait();
 
@@ -472,7 +472,7 @@ TYPED_TEST(StedcTest, FusedCtaPartitionWidths) {
             .secular_threads_per_root = P,
         };
 
-        UnifiedVector<std::byte> ws_cta(stedc_workspace_size(*this->ctx, n, batch, JobType::EigenVectors, params_cta));
+        UnifiedVector<std::byte> ws_cta(stedc_buffer_size(*this->ctx, n, batch, JobType::EigenVectors, params_cta));
         stedc(*this->ctx, a_cta.view(), b_cta.view(), eigvals_cta.view(), ws_cta, JobType::EigenVectors, params_cta, eigvecs_cta.view());
         this->ctx->wait();
 
@@ -516,7 +516,7 @@ TYPED_TEST(StedcTest, FusedCtaFallsBackToWgWhenRequestedExceedsMaxSubgroup) {
         .secular_threads_per_root = forced_threads_per_root,
     };
 
-    UnifiedVector<std::byte> ws_cta(stedc_workspace_size(*this->ctx, n, batch, JobType::EigenVectors, params_cta));
+    UnifiedVector<std::byte> ws_cta(stedc_buffer_size(*this->ctx, n, batch, JobType::EigenVectors, params_cta));
     stedc(*this->ctx, a_cta.view(), b_cta.view(), eigvals_cta.view(), ws_cta, JobType::EigenVectors, params_cta, eigvecs_cta.view());
     this->ctx->wait();
 


### PR DESCRIPTION
Works through the 21 open `trap:` / `friction:` / `polish:` issues from the API review pass.

**18 closed, 3 partial or declined.** Every change was chosen so a caller who gets it wrong gets a compile error or a throw, never a plausible wrong number.

## Closed

**Traps** — #71 (Vector/VectorView `inc`/`stride` order), #72 (`MatrixView(p,n,n,batch)` silently meaning `ld = batch`), #74 (`int` overflow in element addresses at batch ≥ 8192), #75 (no shape validation on the LAPACK entry points), #76 (CSR `nnz()` meaning capacity), #77 (the `= Queue()` defaults), #73 (per-item factorisation `info`)

**Friction** — #78 (`cond_buffer_size` could not link), #80 (`runtime_error` vs `invalid_argument`), #81 (queue dispatch for `cond`), #82 (`stebz`/`stein` sizing could not deduce `T`), #83 (arena spelling for `gesvd`/`ormqr`/`ortho`), #85 (`*_buffer_size` naming), #86 (`trsm`'s `alpha` position), #88 (`linalg::matmul` discarding `beta`)

**Polish** — #84 (`*Options` vs `*Params`), #89 (stale `Span(T&)` comment), #90 (`gemm_heterogeneous`)

## Partial or declined, with reasons

- **#87** (`linalg::` coverage) — added `svd`, `lu`, `inv`, `transpose`, `norm`, `cond`, `triu`/`tril`. **`qr` is deliberately not shipped**: it was written and returns Q·R off by four orders of magnitude, at an identical value every time, in 2–4 of 4 concurrent runs of the test binary, while passing every serial run. Not freed pages (deterministic), not uninitialised output (zero-filling changes nothing), not scratch lifetime (draining changes nothing). Left out with the evidence and a reproducer recorded where it would go, rather than shipped confidently wrong.
- **#91** (one rule for the 1-D types) — documented the rule and added `stein`'s missing overloads; the signature sweep is declined at 113 call sites, because demoting a `VectorView` to a `Span` drops `inc`/`stride` and so fails with wrong numbers rather than a compile error.
- **#79** (device-resident USM) — declined. It cannot be an inert default: the moment a caller passes it, ~975 host-access sites across 116 files become UB with no compile-time signal.

## Premises that did not survive checking

Several issues asked for something the code contradicts, and are closed by doing the correct thing instead:

- **#71**'s suggested `= delete` cannot compile — both orders are `(Span<T>, int, int, int, int)` — and it proposed changing the 138-call-site side rather than the 6-site side.
- **#83**'s stated blocker is false: an option-struct overload need not mirror the primary's parameter order, and `getrs` already proves it. The fix is purely additive; nothing moves.
- **#84**'s rule is wrong for 4 of 10 structs (`ILUKParams` and `SytrdBandReductionParams` play the `*Options` role; `SteqrParams`/`StedcParams` are not last), so the rename would have moved the inaccuracy into the type names. Documented instead.
- **#73**'s `geqrf` half is refuted: cuBLAS's `geqrfBatched` takes a host scalar, not a per-item array; rocSOLVER's has none; LAPACK's info is never positive. A per-item `geqrf` info would be all zeros by construction.
- **#81**'s dispatch macro would emit *nothing* for the six `random_*_with_log10_cond_metric` generators (`float_t<T>` is a non-deduced context), reading as fixed while being dead code.

## A defect found in this PR's own work

#75's checks landed in `222ce1a` attached only to the backend-deducing overloads. `BATCHLAS_DISPATCH_ON_QUEUE` generates a variadic `NAME(Queue&, Args&&...)`, and for `getrf(ctx, A.view(), pivots)` the `Args&&` binds the prvalue better than `const MA&`, so the variadic won and stepped over every check — an 8×4 `A` sailed through the squareness check meant to reject it. Fixed in the last commit by also attaching the checks where the variadic lands.

## Verification

Full build clean. `ctest` sampled repeatedly: `lanczos_tests` and `steqr_tests` fail every run and `sytrd_blocked_tests` intermittently — the identical failure set, including the same intermittency, that the **untouched main build** produces when sampled the same way. No test regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2iYGKcMmvZCbzXYgJbcGF